### PR TITLE
chore: add GitHub issue + PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/audit.md
+++ b/.github/ISSUE_TEMPLATE/audit.md
@@ -1,7 +1,7 @@
 ---
 name: "🗺️ Audit / Mapping"
 about: "Map existing features to requirements"
-title: "[AUDIT] - <System Name>"
+title: "[AUDIT] - System name"
 labels: "type:audit, status:backlog"
 assignees: ''
 ---
@@ -10,16 +10,19 @@ assignees: ''
 - Requirement: RQ-### or TBD
 - Reason for audit:
 
+## 🧱 BUILD (required)
+- build:<id> (e.g., build:legacy-quarantine)
+
 ## 📍 TARGET SYSTEM
 - System: (e.g., Command Center / CRM)
 
 ## 📦 MINIMAL MAPPING LOG
 | Feature Name | File Location | Requirement |
-|-------------|-------------|------------|
-| Example     | /path/file  | RQ-012     |
-|             |             |            |
+|-------------|---------------|-------------|
+| Example     | /path/file    | RQ-012      |
+|             |               |             |
 
-## 🚧 STATUS
+## 🚧 STATUS (choose exactly one)
 - [ ] status:backlog
 - [ ] status:active
 - [ ] status:blocked
@@ -27,15 +30,15 @@ assignees: ''
 ## 🧩 OPS TRACKING
 - [ ] Add `track:ops` label if this should appear on Ops board
 
-## ⛔ BLOCKED BY (only if blocked)
-- 
+## ⛔ BLOCKED BY (required only if status:blocked)
+-
 
 ## 🛑 STOP CHECK
 - [ ] Any violations found? → create FIX issue immediately
 
-## 💾 SESSION STATE (before ending session)
+## 💾 SESSION STATE (required before ending session)
 **PROGRESS:**
-- 
+-
 
 **NEXT:**
 -

--- a/.github/ISSUE_TEMPLATE/build.md
+++ b/.github/ISSUE_TEMPLATE/build.md
@@ -1,7 +1,7 @@
 ---
 name: "🔷 Build / Execution"
 about: "Implement a feature tied to a requirement"
-title: "[BUILD] - <Short Description>"
+title: "[BUILD] - Short description"
 labels: "type:build, status:backlog"
 assignees: ''
 ---
@@ -9,18 +9,21 @@ assignees: ''
 ## 📐 WHY
 - Requirement: RQ-### or TBD
 
+## 🧱 BUILD (required)
+- build:<id> (e.g., build:lead-state-authority)
+
 ## 📋 SCOPE
 - item
 - item
 
-## ▶️ NEXT
+## ▶️ NEXT (required)
 (single next step, ≤60 min)
 
 ## ✅ DONE WHEN
 - artifact
 - artifact
 
-## 🚧 STATUS
+## 🚧 STATUS (choose exactly one)
 - [ ] status:backlog
 - [ ] status:active
 - [ ] status:blocked
@@ -34,12 +37,12 @@ assignees: ''
 - [ ] Persistence/state verified
 - [ ] UI work now allowed
 
-## ⛔ BLOCKED BY (only if blocked)
-- 
+## ⛔ BLOCKED BY (required only if status:blocked)
+-
 
-## 💾 SESSION STATE (before ending session)
+## 💾 SESSION STATE (required before ending session)
 **PROGRESS:**
-- 
+-
 
 **NEXT:**
 -

--- a/.github/ISSUE_TEMPLATE/discovery.md
+++ b/.github/ISSUE_TEMPLATE/discovery.md
@@ -1,7 +1,7 @@
 ---
 name: "🔍 Discovery / Spike"
 about: "Investigate to define requirements or approach"
-title: "[DISCOVERY] - <System/Feature>"
+title: "[DISCOVERY] - System or feature"
 labels: "type:discovery, status:backlog"
 assignees: ''
 ---
@@ -12,6 +12,9 @@ assignees: ''
 ## 📐 WHY
 - Requirement: RQ-### or TBD
 
+## 🧱 BUILD (required)
+- build:<id> (e.g., build:quote-flow)
+
 ## ⏱️ TIMEBOX
 - Limit: (e.g., 2 sessions max)
 
@@ -19,7 +22,7 @@ assignees: ''
 - [ ] New Requirement (RQ-###)
 - [ ] OR documented technical approach
 
-## 🚧 STATUS
+## 🚧 STATUS (choose exactly one)
 - [ ] status:backlog
 - [ ] status:active
 - [ ] status:blocked
@@ -27,12 +30,12 @@ assignees: ''
 ## 🧩 OPS TRACKING
 - [ ] Add `track:ops` label if this should appear on Ops board
 
-## ⛔ BLOCKED BY (only if blocked)
-- 
+## ⛔ BLOCKED BY (required only if status:blocked)
+-
 
-## 💾 SESSION STATE (before ending session)
+## 💾 SESSION STATE (required before ending session)
 **PROGRESS:**
-- 
+-
 
 **NEXT:**
 -

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,12 @@
 Closes #<issue-number>
 Requirement: RQ-### or TBD
 
+## 🏷️ LABELS (confirm)
+- [ ] Issue includes exactly one `status:*`
+- [ ] Issue includes exactly one `type:*`
+- [ ] Issue includes exactly one `build:*`
+- [ ] If Ops-tracked, issue includes `track:ops`
+
 ## 🛡️ PRE-MERGE CHECKLIST
 - [ ] No duplicate or conflicting logic introduced
 - [ ] No non-canonical state/status values introduced


### PR DESCRIPTION
Adds standardized issue templates (build/discovery/audit) and a PR template.

Contract:
- Requires PROGRESS + NEXT
- Requires build:<id> field
- Uses type:* and status:* labels; Ops-tracked work uses track:ops

Validation:
- Templates only