### PR TITLE
feat(ops): build rollups for Ops GitHub board

### DIFF
--- a/command-center/src/pages/crm/settings/GitHubIssuesBoard.jsx
+++ b/command-center/src/pages/crm/settings/GitHubIssuesBoard.jsx
@@ -1,0 +1,370 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { RefreshCw, ExternalLink, AlertTriangle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { githubIssuesBoardService } from '@/services/githubIssuesBoardService';
+import { formatDistanceToNow } from 'date-fns';
+import { useToast } from '@/components/ui/use-toast';
+
+const COLUMN_LABELS = {
+  backlog: 'Backlog',
+  active: 'Active',
+  blocked: 'Blocked',
+  done: 'Done',
+};
+
+const BUILD_STATUS_LABELS = {
+  active: 'Active',
+  blocked: 'Blocked',
+  backlog: 'Backlog',
+  done: 'Done',
+};
+
+const badgeClass = (key) => {
+  switch (key) {
+    case 'active':
+      return 'bg-emerald-50 text-emerald-700 border-emerald-200';
+    case 'blocked':
+      return 'bg-red-50 text-red-700 border-red-200';
+    case 'done':
+      return 'bg-blue-50 text-blue-700 border-blue-200';
+    default:
+      return 'bg-amber-50 text-amber-800 border-amber-200';
+  }
+};
+
+const buildStatusBadgeClass = (key) => {
+  switch (key) {
+    case 'active':
+      return 'bg-emerald-50 text-emerald-700 border-emerald-200';
+    case 'blocked':
+      return 'bg-red-50 text-red-700 border-red-200';
+    case 'done':
+      return 'bg-blue-50 text-blue-700 border-blue-200';
+    default:
+      return 'bg-amber-50 text-amber-800 border-amber-200';
+  }
+};
+
+const IssueCard = ({ issue, columnKey }) => {
+  const updated = issue.updated_at ? formatDistanceToNow(new Date(issue.updated_at), { addSuffix: true }) : null;
+  const missingNext = !issue.next;
+  const missingBlockedBy = columnKey === 'blocked' && !issue.blocked_by;
+
+  return (
+    <div className="rounded border bg-white p-3 space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-xs text-slate-500">#{issue.number}</span>
+            <div className="font-medium text-slate-900 truncate">{issue.title}</div>
+          </div>
+          <div className="mt-1 text-xs text-slate-600">
+            {issue.next ? <><span className="text-slate-400">NEXT:</span> {issue.next}</> : <span className="text-red-700">Missing NEXT:</span>}
+          </div>
+          {columnKey === 'blocked' ? (
+            <div className="mt-1 text-xs text-slate-600">
+              {issue.blocked_by ? (
+                <>
+                  <span className="text-slate-400">BLOCKED BY:</span> {issue.blocked_by}
+                </>
+              ) : (
+                <span className="text-red-700">Missing BLOCKED BY:</span>
+              )}
+            </div>
+          ) : null}
+        </div>
+        <a
+          href={issue.url}
+          target="_blank"
+          rel="noreferrer"
+          className="shrink-0 inline-flex items-center gap-1 text-xs text-blue-700 hover:underline"
+          title="Open in GitHub"
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1">
+        {missingNext ? (
+          <Badge variant="destructive" className="text-[10px]">
+            NEXT?
+          </Badge>
+        ) : null}
+        {missingBlockedBy ? (
+          <Badge variant="destructive" className="text-[10px]">
+            BLOCKED BY?
+          </Badge>
+        ) : null}
+        {(issue.labels || []).slice(0, 6).map((l) => (
+          <Badge key={l} variant="secondary" className="text-[10px]">
+            {l}
+          </Badge>
+        ))}
+        {Array.isArray(issue.labels) && issue.labels.length > 6 ? (
+          <span className="text-[10px] text-slate-400">+{issue.labels.length - 6}</span>
+        ) : null}
+      </div>
+
+      <div className="flex items-center justify-between text-[11px] text-slate-500">
+        <div className="truncate">
+          {(issue.assignees || []).length ? `@${issue.assignees.join(', @')}` : 'Unassigned'}
+        </div>
+        <div>{updated || '-'}</div>
+      </div>
+    </div>
+  );
+};
+
+const GitHubIssuesBoard = () => {
+  const [loading, setLoading] = useState(true);
+  const [repo, setRepo] = useState(null);
+  const [columns, setColumns] = useState({ backlog: [], active: [], blocked: [], done: [] });
+  const [builds, setBuilds] = useState([]);
+  const [loadError, setLoadError] = useState(null);
+  const [trackLabel, setTrackLabel] = useState('track:ops');
+  const { toast } = useToast();
+
+  const refresh = async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const data = await githubIssuesBoardService.board();
+      setRepo(data.repo || null);
+      setColumns(data.columns || { backlog: [], active: [], blocked: [], done: [] });
+      setBuilds(Array.isArray(data.builds) ? data.builds : []);
+      setTrackLabel(data.track_label || 'track:ops');
+    } catch (e) {
+      const message = e?.message || 'Failed to load GitHub board.';
+      setLoadError(message);
+      toast({ variant: 'destructive', title: 'GitHub load failed', description: message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const counts = useMemo(() => {
+    const by = {};
+    for (const k of Object.keys(COLUMN_LABELS)) {
+      by[k] = Array.isArray(columns?.[k]) ? columns[k].length : 0;
+    }
+    return by;
+  }, [columns]);
+
+  const buildGroups = useMemo(() => {
+    const list = Array.isArray(builds) ? builds : [];
+    const active = list.filter((b) => b.status === 'active');
+    const blocked = list.filter((b) => b.status === 'blocked');
+    const backlog = list.filter((b) => b.status === 'backlog');
+    const done = list.filter((b) => b.status === 'done');
+    return { active, blocked, backlog, done, total: list.length };
+  }, [builds]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <h2 className="text-2xl font-bold text-slate-900">GitHub Work Board</h2>
+            {repo ? (
+              <Badge variant="secondary" className="font-mono text-xs">
+                {repo}
+              </Badge>
+            ) : null}
+          </div>
+          <p className="text-slate-500 text-sm">
+            Only issues labeled <span className="font-mono">{trackLabel}</span> appear here. Columns are driven by labels:{' '}
+            <span className="font-mono">status:backlog</span>,{' '}
+            <span className="font-mono">status:active</span>, <span className="font-mono">status:blocked</span>,{' '}
+            and Done = closed issues.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={refresh} disabled={loading}>
+            <RefreshCw className={`mr-2 h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+          {repo ? (
+            <Button asChild>
+              <a href={`https://github.com/${repo}/issues/new/choose`} target="_blank" rel="noreferrer">
+                New Issue
+              </a>
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Setup Checklist</CardTitle>
+          <CardDescription>Do these first (in order). Until then, this board will error.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-slate-700">
+          <div>
+            1) Supabase Edge Runtime running (local) + `github-issues-board` deployed (hosted)
+          </div>
+          <div>
+            2) Set Edge Function secrets: <span className="font-mono">GITHUB_TOKEN</span> (+ optional{' '}
+            <span className="font-mono">GITHUB_REPO</span>)
+          </div>
+          <div>
+            3) Create GitHub label: <span className="font-mono">{trackLabel}</span> (required to appear on the board)
+          </div>
+          <div>
+            4) Create GitHub labels: <span className="font-mono">status:backlog</span>,{' '}
+            <span className="font-mono">status:active</span>, <span className="font-mono">status:blocked</span>,{' '}
+            (optional: <span className="font-mono">status:done</span> is not required if you close issues to mark done)
+          </div>
+          <div>
+            5) Issue body rules: <span className="font-mono">NEXT:</span> is mandatory; blocked issues require{' '}
+            <span className="font-mono">BLOCKED BY:</span>
+          </div>
+          {loadError ? (
+            <div className="mt-3 rounded border border-red-200 bg-red-50 p-3 text-red-800 text-xs">
+              <div className="font-semibold">Current error</div>
+              <div className="mt-1 font-mono break-words">{loadError}</div>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Builds</CardTitle>
+          <CardDescription>
+            Rollups are derived from issue labels prefixed with <span className="font-mono">build:</span>. Completion only counts{' '}
+            <span className="font-mono">type:build</span> and <span className="font-mono">type:fix</span>; Done = closed issues.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {buildGroups.total === 0 ? (
+            <div className="text-sm text-slate-600">
+              No builds found. Add a <span className="font-mono">build:&lt;id&gt;</span> label to issues (and ensure they are labeled{' '}
+              <span className="font-mono">{trackLabel}</span>).
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+              {[...buildGroups.active, ...buildGroups.blocked, ...buildGroups.backlog].slice(0, 12).map((b) => (
+                <div key={b.id} className="rounded border bg-white p-3 space-y-2">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="font-medium text-slate-900 truncate">{b.name}</div>
+                      <div className="mt-1 text-xs text-slate-600 truncate">
+                        {b.next ? (
+                          <>
+                            <span className="text-slate-400">NEXT:</span> {b.next}
+                          </>
+                        ) : (
+                          <span className="text-slate-400">No NEXT found (open issue missing NEXT:)</span>
+                        )}
+                      </div>
+                    </div>
+                    <Badge variant="outline" className={buildStatusBadgeClass(b.status)}>
+                      {BUILD_STATUS_LABELS[b.status] || b.status}
+                    </Badge>
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-slate-600">
+                    <span className="font-mono">{b.id}</span>
+                    <span>Open: {b.counts?.open ?? 0}</span>
+                    <span>Blocked: {b.counts?.blocked ?? 0}</span>
+                    <span>
+                      %: {typeof b.percent_complete === 'number' ? `${b.percent_complete}%` : '-'}
+                    </span>
+                    {repo && b.resume_issue_number ? (
+                      <a
+                        href={`https://github.com/${repo}/issues/${b.resume_issue_number}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-blue-700 hover:underline"
+                      >
+                        Resume #{b.resume_issue_number}
+                      </a>
+                    ) : null}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {buildGroups.done.length ? (
+            <details className="text-sm">
+              <summary className="cursor-pointer text-slate-700">
+                Done builds ({buildGroups.done.length})
+              </summary>
+              <div className="mt-2 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+                {buildGroups.done.slice(0, 12).map((b) => (
+                  <div key={b.id} className="rounded border bg-slate-50 p-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="font-medium text-slate-900 truncate">{b.name}</div>
+                      <Badge variant="outline" className={buildStatusBadgeClass(b.status)}>
+                        {BUILD_STATUS_LABELS[b.status] || b.status}
+                      </Badge>
+                    </div>
+                    <div className="mt-1 text-xs text-slate-600 font-mono truncate">{b.id}</div>
+                  </div>
+                ))}
+              </div>
+            </details>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        {Object.keys(COLUMN_LABELS).map((k) => (
+          <Card key={k} className="bg-slate-50 border-slate-200">
+            <CardContent className="p-4 flex items-center justify-between">
+              <div>
+                <div className="text-xs text-slate-500">{COLUMN_LABELS[k]}</div>
+                <div className="text-2xl font-bold text-slate-900">{counts[k]}</div>
+              </div>
+              <Badge variant="outline" className={badgeClass(k)}>
+                {k}
+              </Badge>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        {Object.keys(COLUMN_LABELS).map((k) => (
+          <Card key={k}>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center justify-between">
+                <span>{COLUMN_LABELS[k]}</span>
+                <Badge variant="outline" className={badgeClass(k)}>
+                  {counts[k]}
+                </Badge>
+              </CardTitle>
+              <CardDescription className="text-xs">
+                {k === 'blocked' ? (
+                  <span className="inline-flex items-center gap-1 text-red-700">
+                    <AlertTriangle className="h-3 w-3" /> Requires explicit reason in issue body.
+                  </span>
+                ) : (
+                  <span>Resume point is parsed from the first <span className="font-mono">NEXT:</span> line.</span>
+                )}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {(columns?.[k] || []).length === 0 ? (
+                <div className="text-sm text-slate-500">No issues.</div>
+              ) : (
+                (columns[k] || []).slice(0, 25).map((issue) => (
+                  <IssueCard key={issue.id} issue={issue} columnKey={k} />
+                ))
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default GitHubIssuesBoard;

--- a/command-center/supabase/functions/github-issues-board/index.ts
+++ b/command-center/supabase/functions/github-issues-board/index.ts
@@ -1,0 +1,393 @@
+import { buildCorsHeaders, readJson } from '../_shared/publicUtils.ts';
+import { getVerifiedClaims } from '../_shared/auth.ts';
+
+type GitHubLabel = { name?: string | null } | string;
+type GitHubIssue = {
+  id: number;
+  number: number;
+  title: string;
+  html_url: string;
+  state: 'open' | 'closed';
+  updated_at?: string;
+  created_at?: string;
+  labels?: GitHubLabel[];
+  body?: string | null;
+  pull_request?: unknown;
+  assignee?: { login?: string | null } | null;
+  assignees?: { login?: string | null }[] | null;
+};
+
+type BoardColumn = 'backlog' | 'active' | 'blocked' | 'done';
+type BuildStatus = 'active' | 'blocked' | 'backlog' | 'done';
+
+const respondJson = (body: Record<string, unknown>, status: number, headers: Record<string, string>) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...headers, 'Content-Type': 'application/json' },
+  });
+
+const asBool = (v: string | null) => v === '1' || v === 'true';
+
+const normalizeLabel = (value: unknown) => String(value ?? '').trim().toLowerCase();
+
+const issueLabels = (issue: GitHubIssue): string[] => {
+  const labels = Array.isArray(issue.labels) ? issue.labels : [];
+  return labels
+    .map((l) => (typeof l === 'string' ? l : l?.name))
+    .filter(Boolean)
+    .map((name) => normalizeLabel(name));
+};
+
+const firstLabelWithPrefix = (labels: string[], prefix: string): string | null => {
+  for (const label of labels) {
+    if (label.startsWith(prefix)) return label;
+  }
+  return null;
+};
+
+const titleFromBuildLabel = (buildLabel: string): string => {
+  const raw = buildLabel.replace(/^build:/, '').trim();
+  if (!raw) return 'Unassigned';
+
+  return raw
+    .split(/[-_]+/g)
+    .filter(Boolean)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(' ');
+};
+
+const columnFromLabels = (labels: string[]): BoardColumn => {
+  const statuses: Record<string, BoardColumn> = {
+    'status:backlog': 'backlog',
+    'status:active': 'active',
+    'status:blocked': 'blocked',
+  };
+
+  for (const label of labels) {
+    if (label in statuses) return statuses[label];
+  }
+
+  return 'backlog';
+};
+
+const statusLabelFromLabels = (labels: string[]): BuildStatus | null => {
+  if (labels.includes('status:active')) return 'active';
+  if (labels.includes('status:blocked')) return 'blocked';
+  if (labels.includes('status:backlog')) return 'backlog';
+  return null;
+};
+
+const typeLabelFromLabels = (labels: string[]): 'build' | 'fix' | 'discovery' | 'audit' | null => {
+  if (labels.includes('type:build')) return 'build';
+  if (labels.includes('type:fix')) return 'fix';
+  if (labels.includes('type:discovery')) return 'discovery';
+  if (labels.includes('type:audit')) return 'audit';
+  return null;
+};
+
+const parseNextAction = (body: string | null | undefined): string | null => {
+  const text = String(body ?? '');
+  if (!text.trim()) return null;
+
+  const match = text.match(/^\s*NEXT:\s*(.+)\s*$/im);
+  if (!match?.[1]) return null;
+
+  const next = match[1].trim();
+  return next ? next : null;
+};
+
+const parseBlockedBy = (body: string | null | undefined): string | null => {
+  const text = String(body ?? '');
+  if (!text.trim()) return null;
+
+  const match = text.match(/^\s*BLOCKED BY:\s*(.+)\s*$/im);
+  if (!match?.[1]) return null;
+
+  const blockedBy = match[1].trim();
+  return blockedBy ? blockedBy : null;
+};
+
+const fetchJson = async (url: string, token: string) => {
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`GitHub API error (${res.status}): ${text || res.statusText}`);
+  }
+
+  const link = res.headers.get('link') || '';
+  const data = (await res.json().catch(() => null)) as unknown;
+  return { data, link };
+};
+
+const parseNextLink = (linkHeader: string): string | null => {
+  const parts = linkHeader.split(',');
+  for (const part of parts) {
+    const m = part.match(/<([^>]+)>\s*;\s*rel="next"/i);
+    if (m?.[1]) return m[1];
+  }
+  return null;
+};
+
+const fetchIssues = async (
+  repo: string,
+  token: string,
+  trackLabel: string,
+  maxIssues = 250,
+): Promise<GitHubIssue[]> => {
+  const base = `https://api.github.com/repos/${repo}/issues`;
+  const labelParam = encodeURIComponent(trackLabel);
+  let url = `${base}?state=all&per_page=100&sort=updated&direction=desc&labels=${labelParam}`;
+
+  const issues: GitHubIssue[] = [];
+  while (url && issues.length < maxIssues) {
+    const { data, link } = await fetchJson(url, token);
+    if (!Array.isArray(data)) break;
+
+    for (const row of data) {
+      if (issues.length >= maxIssues) break;
+      issues.push(row as GitHubIssue);
+    }
+
+    url = parseNextLink(link);
+  }
+
+  return issues;
+};
+
+const isSuperuserFromClaims = (claims: Record<string, unknown>): boolean => {
+  const app = (claims.app_metadata ?? {}) as Record<string, unknown>;
+  const user = (claims.user_metadata ?? {}) as Record<string, unknown>;
+  const role = normalizeLabel(claims.role);
+
+  return (
+    role === 'service_role' ||
+    app?.is_superuser === true ||
+    app?.superuser === true ||
+    user?.is_superuser === true ||
+    user?.superuser === true
+  );
+};
+
+Deno.serve(async (req) => {
+  const origin = req.headers.get('origin');
+  const cors = buildCorsHeaders(origin);
+
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: cors.headers });
+  }
+
+  if (req.method !== 'POST') {
+    return respondJson({ error: 'Method not allowed' }, 405, cors.headers);
+  }
+
+  let claims;
+  try {
+    ({ claims } = await getVerifiedClaims(req));
+  } catch (error) {
+    return respondJson({ error: String(error?.message ?? error) }, 401, cors.headers);
+  }
+
+  const requireSuper = asBool(Deno.env.get('GITHUB_REQUIRE_SUPERUSER'));
+  if (requireSuper && !isSuperuserFromClaims(claims as Record<string, unknown>)) {
+    return respondJson({ error: 'Forbidden' }, 403, cors.headers);
+  }
+
+  const token = (Deno.env.get('GITHUB_TOKEN') ?? '').trim();
+  if (!token) {
+    return respondJson({ error: 'Missing GITHUB_TOKEN secret' }, 500, cors.headers);
+  }
+
+  const repo = (Deno.env.get('GITHUB_REPO') ?? 'faydog127/BHFOS').trim();
+  if (!repo || !repo.includes('/')) {
+    return respondJson({ error: 'Invalid GITHUB_REPO (expected owner/repo)' }, 500, cors.headers);
+  }
+
+  const trackLabel = (Deno.env.get('GITHUB_TRACK_LABEL') ?? 'track:ops').trim() || 'track:ops';
+
+  const body = (await readJson(req)) as Record<string, unknown> | null;
+  const action = String(body?.action ?? 'board').trim().toLowerCase();
+  if (action !== 'board') {
+    return respondJson({ error: 'Unknown action' }, 400, cors.headers);
+  }
+
+  try {
+    const issues = await fetchIssues(repo, token, trackLabel);
+
+    const columns: Record<BoardColumn, unknown[]> = {
+      backlog: [],
+      active: [],
+      blocked: [],
+      done: [],
+    };
+
+    const builds = new Map<
+      string,
+      {
+        id: string;
+        name: string;
+        status: BuildStatus;
+        counts: {
+          total: number;
+          open: number;
+          blocked: number;
+          countable_total: number;
+          countable_closed: number;
+        };
+        next: string | null;
+        resume_issue_number: number | null;
+        updated_at: string | null;
+      }
+    >();
+
+    for (const issue of issues) {
+      if (issue.pull_request) continue; // exclude PRs
+
+      const labels = issueLabels(issue);
+      const column = columnFromLabels(labels);
+      const statusLabel = statusLabelFromLabels(labels);
+      const typeLabel = typeLabelFromLabels(labels);
+      const buildLabel = firstLabelWithPrefix(labels, 'build:') || 'build:unassigned';
+
+      const next = parseNextAction(issue.body);
+      const blockedBy = parseBlockedBy(issue.body);
+
+      const item = {
+        id: issue.id,
+        number: issue.number,
+        title: issue.title,
+        url: issue.html_url,
+        state: issue.state,
+        updated_at: issue.updated_at ?? null,
+        labels,
+        assignees: (issue.assignees || [])
+          .map((a) => normalizeLabel(a?.login))
+          .filter(Boolean),
+        next,
+        blocked_by: blockedBy,
+      };
+
+      // Build rollups (derived from build:* labels on issues)
+      const existing = builds.get(buildLabel) ?? {
+        id: buildLabel,
+        name: titleFromBuildLabel(buildLabel),
+        status: 'backlog' as BuildStatus,
+        counts: {
+          total: 0,
+          open: 0,
+          blocked: 0,
+          countable_total: 0,
+          countable_closed: 0,
+        },
+        next: null as string | null,
+        resume_issue_number: null as number | null,
+        updated_at: null as string | null,
+      };
+
+      existing.counts.total += 1;
+      if (issue.state !== 'closed') {
+        existing.counts.open += 1;
+      }
+
+      if (issue.state !== 'closed' && statusLabel === 'blocked') {
+        existing.counts.blocked += 1;
+      }
+
+      const isCountable = typeLabel === 'build' || typeLabel === 'fix';
+      if (isCountable) {
+        existing.counts.countable_total += 1;
+        if (issue.state === 'closed') {
+          existing.counts.countable_closed += 1;
+        }
+      }
+
+      const updatedAt = issue.updated_at ?? null;
+      const isOpen = issue.state !== 'closed';
+      const isResumeCandidate = isOpen && statusLabel === 'active' && !!next;
+      const isBetterCandidate =
+        isResumeCandidate &&
+        (!existing.updated_at || (updatedAt && updatedAt > existing.updated_at));
+
+      if (isBetterCandidate) {
+        existing.next = next;
+        existing.resume_issue_number = issue.number;
+        existing.updated_at = updatedAt;
+      } else if (!existing.next && isOpen && !!next) {
+        // fallback: first open issue with NEXT
+        existing.next = next;
+        existing.resume_issue_number = issue.number;
+        existing.updated_at = updatedAt;
+      } else if (!existing.updated_at && updatedAt) {
+        existing.updated_at = updatedAt;
+      }
+
+      // Derive build status: active beats blocked beats backlog beats done
+      // - done: no open issues
+      // - active: any open status:active issue
+      // - blocked: no active, but any open status:blocked issue
+      // - backlog: otherwise if any open issues
+      if (existing.counts.open === 0) {
+        existing.status = 'done';
+      } else if (issue.state !== 'closed' && statusLabel === 'active') {
+        existing.status = 'active';
+      } else if (existing.status !== 'active' && issue.state !== 'closed' && statusLabel === 'blocked') {
+        existing.status = 'blocked';
+      } else if (existing.status === 'done') {
+        existing.status = 'backlog';
+      }
+
+      builds.set(buildLabel, existing);
+
+      // Treat closed issues as done regardless of label, but keep label-driven behavior for open issues.
+      if (issue.state === 'closed') {
+        columns.done.push(item);
+      } else {
+        columns[column].push(item);
+      }
+    }
+
+    const buildList = Array.from(builds.values())
+      .map((b) => {
+        const total = b.counts.countable_total;
+        const closed = b.counts.countable_closed;
+        const percent_complete = total > 0 ? Math.round((closed / total) * 100) : null;
+        return { ...b, percent_complete };
+      })
+      .sort((a, b) => {
+        const order: Record<BuildStatus, number> = { active: 0, blocked: 1, backlog: 2, done: 3 };
+        const ao = order[a.status] ?? 99;
+        const bo = order[b.status] ?? 99;
+        if (ao !== bo) return ao - bo;
+        const au = a.updated_at ?? '';
+        const bu = b.updated_at ?? '';
+        return bu.localeCompare(au);
+      });
+
+    return respondJson(
+      {
+        ok: true,
+        repo,
+        track_label: trackLabel,
+        columns,
+        builds: buildList,
+        build_rules: {
+          label_prefix: 'build:',
+          count_toward_percent: ['type:build', 'type:fix'],
+          excluded_from_percent: ['type:discovery', 'type:audit'],
+          done_means: 'closed issue',
+        },
+        meta: { fetched: issues.length, max: 250 },
+      },
+      200,
+      cors.headers,
+    );
+  } catch (error) {
+    return respondJson({ error: String(error?.message ?? error) }, 500, cors.headers);
+  }
+});


### PR DESCRIPTION
Adds build-level rollups derived from uild:* labels to the github-issues-board edge function response, and renders a Builds section above the status columns in the Ops GitHub Board UI.

Contract:
- Builds = uild:<id> labels
- % complete counts only 	ype:build + 	ype:fix; Done = closed

Notes:
- GitHub board still requires GITHUB_TOKEN secret to be configured in Supabase.