### PR TITLE
fix(ops): auth-safe ops-projects + better NEXT parsing

### DIFF
--- a/command-center/src/services/githubIssuesBoardService.js
+++ b/command-center/src/services/githubIssuesBoardService.js
@@ -1,0 +1,60 @@
+import { supabase } from '@/lib/customSupabaseClient';
+
+const requireAccessToken = async () => {
+  const { data, error } = await supabase.auth.getSession();
+  if (error) throw error;
+
+  const accessToken = data?.session?.access_token || null;
+  if (!accessToken) {
+    throw new Error('Not signed in (missing access token). Please refresh and sign in again.');
+  }
+
+  return accessToken;
+};
+
+const invokeAuthed = async (name, body) => {
+  const accessToken = await requireAccessToken();
+  return supabase.functions.invoke(name, {
+    body,
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+};
+
+const extractFunctionsErrorMessage = async (error) => {
+  const message = error?.message ? String(error.message) : '';
+  const context = error?.context;
+  if (!context) return message || 'Edge Function error';
+
+  try {
+    const res = typeof context.clone === 'function' ? context.clone() : context;
+    const data = await res.json();
+    if (data?.error) return String(data.error);
+    if (data?.message) return String(data.message);
+    return JSON.stringify(data);
+  } catch {
+    try {
+      const res = typeof context.clone === 'function' ? context.clone() : context;
+      const text = await res.text();
+      return text || message || 'Edge Function error';
+    } catch {
+      return message || 'Edge Function error';
+    }
+  }
+};
+
+const unwrap = async (result) => {
+  if (result?.error) {
+    const msg = await extractFunctionsErrorMessage(result.error);
+    throw new Error(msg);
+  }
+  if (result?.data?.error) throw new Error(result.data.error);
+  return result?.data || null;
+};
+
+export const githubIssuesBoardService = {
+  async board() {
+    const result = await invokeAuthed('github-issues-board', { action: 'board' });
+    const data = await unwrap(result);
+    return data || { repo: null, track_label: 'track:ops', columns: { backlog: [], active: [], blocked: [], done: [] } };
+  },
+};

--- a/command-center/src/services/opsProjectsService.js
+++ b/command-center/src/services/opsProjectsService.js
@@ -1,0 +1,71 @@
+import { supabase } from '@/lib/customSupabaseClient';
+
+const requireAccessToken = async () => {
+  const { data, error } = await supabase.auth.getSession();
+  if (error) throw error;
+
+  const accessToken = data?.session?.access_token || null;
+  if (!accessToken) {
+    throw new Error('Not signed in (missing access token). Please refresh and sign in again.');
+  }
+
+  return accessToken;
+};
+
+const invokeAuthed = async (name, body) => {
+  const accessToken = await requireAccessToken();
+  return supabase.functions.invoke(name, {
+    body,
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+};
+
+const extractFunctionsErrorMessage = async (error) => {
+  const message = error?.message ? String(error.message) : '';
+  const context = error?.context;
+  if (!context) return message || 'Edge Function error';
+
+  try {
+    const res = typeof context.clone === 'function' ? context.clone() : context;
+    const data = await res.json();
+    if (data?.error) return String(data.error);
+    if (data?.message) return String(data.message);
+    return JSON.stringify(data);
+  } catch {
+    try {
+      const res = typeof context.clone === 'function' ? context.clone() : context;
+      const text = await res.text();
+      return text || message || 'Edge Function error';
+    } catch {
+      return message || 'Edge Function error';
+    }
+  }
+};
+
+const unwrap = async (result) => {
+  if (result?.error) {
+    const msg = await extractFunctionsErrorMessage(result.error);
+    throw new Error(msg);
+  }
+  if (result?.data?.error) throw new Error(result.data.error);
+  return result?.data || null;
+};
+
+export const opsProjectsService = {
+  async list() {
+    const result = await invokeAuthed('ops-projects', { action: 'list' });
+    const data = await unwrap(result);
+    return data?.projects || [];
+  },
+
+  async upsert(project) {
+    const result = await invokeAuthed('ops-projects', { action: 'upsert', project });
+    const data = await unwrap(result);
+    return data?.project || null;
+  },
+
+  async remove(id) {
+    const result = await invokeAuthed('ops-projects', { action: 'delete', id });
+    await unwrap(result);
+  },
+};

--- a/command-center/supabase/functions/github-issues-board/index.ts
+++ b/command-center/supabase/functions/github-issues-board/index.ts
@@ -85,6 +85,43 @@ const typeLabelFromLabels = (labels: string[]): 'build' | 'fix' | 'discovery' | 
   return null;
 };
 
+const looksLikePlaceholder = (value: string): boolean => {
+  const v = value.trim().toLowerCase();
+  if (!v) return true;
+  return (
+    v.includes('single next step') ||
+    v.includes('≤60') ||
+    v.includes('60 min') ||
+    v.includes('e.g.') ||
+    v.includes('example') ||
+    v === '-' ||
+    v === 'tbd'
+  );
+};
+
+const parseSectionValue = (text: string, heading: RegExp): string | null => {
+  const lines = text.split(/\r?\n/);
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+    if (!heading.test(line)) continue;
+
+    for (let j = i + 1; j < lines.length; j += 1) {
+      const candidate = String(lines[j] ?? '').trim();
+      if (!candidate) continue;
+      if (/^#{1,6}\s+/.test(candidate)) break; // next section
+      const cleaned = candidate.replace(/^[-*]\s+/, '').trim();
+      if (!cleaned) continue;
+      if (looksLikePlaceholder(cleaned)) return null;
+      return cleaned;
+    }
+
+    break;
+  }
+
+  return null;
+};
+
 const parseNextAction = (body: string | null | undefined): string | null => {
   const text = String(body ?? '');
   if (!text.trim()) return null;
@@ -93,7 +130,11 @@ const parseNextAction = (body: string | null | undefined): string | null => {
   if (!match?.[1]) return null;
 
   const next = match[1].trim();
-  return next ? next : null;
+  if (looksLikePlaceholder(next)) return null;
+  if (next) return next;
+
+  // Fallback: accept a markdown heading like "## NEXT" and read the first non-empty line below it.
+  return parseSectionValue(text, /^#{2,6}\s*.*\bnext\b.*$/i);
 };
 
 const parseBlockedBy = (body: string | null | undefined): string | null => {
@@ -104,7 +145,10 @@ const parseBlockedBy = (body: string | null | undefined): string | null => {
   if (!match?.[1]) return null;
 
   const blockedBy = match[1].trim();
-  return blockedBy ? blockedBy : null;
+  if (looksLikePlaceholder(blockedBy)) return null;
+  if (blockedBy) return blockedBy;
+
+  return parseSectionValue(text, /^#{2,6}\s*.*\bblocked\s+by\b.*$/i);
 };
 
 const fetchJson = async (url: string, token: string) => {


### PR DESCRIPTION
Fixes two production Ops-tab issues:

1) Local (Legacy) tab toast: Expected 3 parts in JWT; got 1
   - Ensure Edge Function invokes always use the current session access token via explicit Authorization header.

2) GitHub Board build cards showing 'Missing NEXT'
   - Extend NEXT/BLOCKED BY parsing to also accept markdown headings (fallback) while still preferring NEXT: lines.

Validation:
- npm run lint (warnings only)
- npm run test:smoke (passed)