### PR TITLE
Manifest-first run contract + strict consistency

### DIFF
--- a/command-center/artifacts/tenants/vent-guys/runs/2026-04-06T04-27-17.2008142Z/manifest.json
+++ b/command-center/artifacts/tenants/vent-guys/runs/2026-04-06T04-27-17.2008142Z/manifest.json
@@ -1,16 +1,16 @@
 {
+  "manifest_version": "2.0",
   "run_id": "2026-04-06T04:27:17.2008142Z",
-  "generated_at": "2026-04-06T04:37:47.5130944Z",
+  "tenant_id": "vent-guys",
+  "artifact_class": "legacy",
+  "created_at": "2026-04-06T04:37:47.5130944Z",
   "source_commit": "3c9785ee279b5d41b3e7755debae71a696d9df04",
-  "artifacts": [
-    {
-      "type": "db_output",
-      "path": "artifacts/runs/2026-04-06T04-27-17.2008142Z/db_output.txt"
-    },
-    {
-      "type": "manifest",
-      "path": "artifacts/runs/2026-04-06T04-27-17.2008142Z/manifest.json"
-    }
-  ],
-  "note": "Manifest is a run-scoped index. Hashing can be added later if/when enforcement is required."
+  "paths": {
+    "judgment_json": null,
+    "raw_doc": null,
+    "review_doc": null,
+    "observed_bundle_root": null,
+    "manifest": "artifacts/tenants/vent-guys/runs/2026-04-06T04-27-17.2008142Z/manifest.json"
+  },
+  "note": "Legacy run (pre-ledger-lock). Not a self-contained observed bundle."
 }

--- a/command-center/artifacts/tenants/vent-guys/runs/2026-04-08T20-59-17.687Z/manifest.json
+++ b/command-center/artifacts/tenants/vent-guys/runs/2026-04-08T20-59-17.687Z/manifest.json
@@ -1,8 +1,17 @@
 {
+  "manifest_version": "2.0",
   "run_id": "2026-04-08T20:59:17.687Z",
+  "tenant_id": "vent-guys",
+  "artifact_class": "legacy_layer2_non_self_contained",
+  "created_at": "2026-04-08T20:59:17.687Z",
   "change_id": "CHANGE-20260408-LAYER2-LEDGER-LOCK",
   "title": "Layer 2 (Orchestrator v2) — observed judgment lock for ledger contention invariants",
   "source_commit": "5862bf696f147cbbe13fb7a301b5cae4927236f5",
-  "observed_bundle_root": ".\\tmp\\orchestrator-v2\\observed\\20260408_150010",
-  "created_at": "2026-04-08T20:59:17.687Z"
+  "paths": {
+    "judgment_json": "artifacts/tenants/vent-guys/runs/2026-04-08T20-59-17.687Z/layer2_observed_judgment.json",
+    "raw_doc": null,
+    "review_doc": null,
+    "observed_bundle_root": ".\\tmp\\orchestrator-v2\\observed\\20260408_150010",
+    "manifest": "artifacts/tenants/vent-guys/runs/2026-04-08T20-59-17.687Z/manifest.json"
+  }
 }

--- a/command-center/artifacts/tenants/vent-guys/runs/2026-04-08T21-00-02.932Z/manifest.json
+++ b/command-center/artifacts/tenants/vent-guys/runs/2026-04-08T21-00-02.932Z/manifest.json
@@ -1,8 +1,17 @@
 {
+  "manifest_version": "2.0",
   "run_id": "2026-04-08T21:00:02.932Z",
+  "tenant_id": "vent-guys",
+  "artifact_class": "legacy_layer2_non_self_contained",
+  "created_at": "2026-04-08T21:00:02.932Z",
   "change_id": "CHANGE-20260408-LAYER2-LEDGER-LOCK",
   "title": "Layer 2 (Orchestrator v2) — observed judgment lock for ledger contention invariants",
   "source_commit": "5862bf696f147cbbe13fb7a301b5cae4927236f5",
-  "observed_bundle_root": ".\\tmp\\orchestrator-v2\\observed\\20260408_150010",
-  "created_at": "2026-04-08T21:00:02.932Z"
+  "paths": {
+    "judgment_json": "artifacts/tenants/vent-guys/runs/2026-04-08T21-00-02.932Z/layer2_observed_judgment.json",
+    "raw_doc": null,
+    "review_doc": null,
+    "observed_bundle_root": ".\\tmp\\orchestrator-v2\\observed\\20260408_150010",
+    "manifest": "artifacts/tenants/vent-guys/runs/2026-04-08T21-00-02.932Z/manifest.json"
+  }
 }

--- a/command-center/artifacts/tenants/vent-guys/runs/2026-04-08T21-00-37.843Z/manifest.json
+++ b/command-center/artifacts/tenants/vent-guys/runs/2026-04-08T21-00-37.843Z/manifest.json
@@ -1,8 +1,17 @@
 {
+  "manifest_version": "2.0",
   "run_id": "2026-04-08T21:00:37.843Z",
+  "tenant_id": "vent-guys",
+  "artifact_class": "legacy_layer2_non_self_contained",
+  "created_at": "2026-04-08T21:00:37.843Z",
   "change_id": "CHANGE-20260408-LAYER2-LEDGER-LOCK",
   "title": "Layer 2 (Orchestrator v2) — observed judgment lock for ledger contention invariants",
   "source_commit": "5862bf696f147cbbe13fb7a301b5cae4927236f5",
-  "observed_bundle_root": ".\\tmp\\orchestrator-v2\\observed\\20260408_150010",
-  "created_at": null
+  "paths": {
+    "judgment_json": "artifacts/tenants/vent-guys/runs/2026-04-08T21-00-37.843Z/layer2_observed_judgment.json",
+    "raw_doc": null,
+    "review_doc": null,
+    "observed_bundle_root": ".\\tmp\\orchestrator-v2\\observed\\20260408_150010",
+    "manifest": "artifacts/tenants/vent-guys/runs/2026-04-08T21-00-37.843Z/manifest.json"
+  }
 }

--- a/command-center/artifacts/tenants/vent-guys/runs/2026-04-08T21-02-02.110Z/layer2_observed_judgment.json
+++ b/command-center/artifacts/tenants/vent-guys/runs/2026-04-08T21-02-02.110Z/layer2_observed_judgment.json
@@ -1,7 +1,7 @@
 {
   "tenant_id": "vent-guys",
   "run_id": "2026-04-08T21:02:02.110Z",
-  "observed_bundle_root": ".\\tmp\\orchestrator-v2\\observed\\20260408_150010",
+  "observed_bundle_root": ".\\artifacts\\tenants\\vent-guys\\runs\\2026-04-08T21-02-02.110Z\\observed_bundle",
   "judgment": {
     "confidence_change": "unavailable_no_prior_run",
     "deployment_risks_still_open": [],

--- a/command-center/artifacts/tenants/vent-guys/runs/2026-04-08T21-02-02.110Z/manifest.json
+++ b/command-center/artifacts/tenants/vent-guys/runs/2026-04-08T21-02-02.110Z/manifest.json
@@ -1,8 +1,19 @@
 {
+  "manifest_version": "2.0",
   "run_id": "2026-04-08T21:02:02.110Z",
+  "tenant_id": "vent-guys",
+  "artifact_class": "ledger_lock_layer2_only",
+  "created_at": "2026-04-08T21:02:02.110Z",
   "change_id": "CHANGE-20260408-LAYER2-LEDGER-LOCK",
   "title": "Layer 2 (Orchestrator v2) — observed judgment lock for ledger contention invariants",
   "source_commit": "5862bf696f147cbbe13fb7a301b5cae4927236f5",
-  "observed_bundle_root": ".\\tmp\\orchestrator-v2\\observed\\20260408_150010",
-  "created_at": null
+  "observed_bundle_root": ".\\artifacts\\tenants\\vent-guys\\runs\\2026-04-08T21-02-02.110Z\\observed_bundle",
+  "source_observed_bundle_root": ".\\tmp\\orchestrator-v2\\observed\\20260408_150010",
+  "paths": {
+    "judgment_json": "artifacts/tenants/vent-guys/runs/2026-04-08T21-02-02.110Z/layer2_observed_judgment.json",
+    "raw_doc": "artifacts/tenants/vent-guys/runs/2026-04-08T21-02-02.110Z/layer3_raw.md",
+    "review_doc": "artifacts/tenants/vent-guys/runs/2026-04-08T21-02-02.110Z/layer3_review.md",
+    "observed_bundle_root": "artifacts/tenants/vent-guys/runs/2026-04-08T21-02-02.110Z/observed_bundle",
+    "manifest": "artifacts/tenants/vent-guys/runs/2026-04-08T21-02-02.110Z/manifest.json"
+  }
 }

--- a/command-center/artifacts/tenants/vent-guys/runs/2026-04-09T03-54-25.639Z/manifest.json
+++ b/command-center/artifacts/tenants/vent-guys/runs/2026-04-09T03-54-25.639Z/manifest.json
@@ -1,9 +1,19 @@
 {
+  "manifest_version": "2.0",
   "run_id": "2026-04-09T03:54:25.639Z",
+  "tenant_id": "vent-guys",
+  "artifact_class": "ledger_lock_full",
+  "created_at": "2026-04-09T03:54:25.639Z",
   "change_id": "CHANGE-20260408-LAYER2-LEDGER-LOCK",
   "title": "Layer 2 (Orchestrator v2) — observed judgment lock for ledger contention invariants",
   "source_commit": "5862bf696f147cbbe13fb7a301b5cae4927236f5",
   "observed_bundle_root": ".\\artifacts\\tenants\\vent-guys\\runs\\2026-04-09T03-54-25.639Z\\observed_bundle",
   "source_observed_bundle_root": ".\\tmp\\orchestrator-v2\\observed\\20260408_150010",
-  "created_at": null
+  "paths": {
+    "judgment_json": "artifacts/tenants/vent-guys/runs/2026-04-09T03-54-25.639Z/layer2_observed_judgment.json",
+    "raw_doc": "docs/reconciliation/lock/layer3/LAYER3_LEDGER_LOCK_JUDGMENT_RAW.md",
+    "review_doc": "docs/reconciliation/lock/layer3/LAYER3_LEDGER_LOCK_REVIEW_v1.md",
+    "observed_bundle_root": "artifacts/tenants/vent-guys/runs/2026-04-09T03-54-25.639Z/observed_bundle",
+    "manifest": "artifacts/tenants/vent-guys/runs/2026-04-09T03-54-25.639Z/manifest.json"
+  }
 }

--- a/command-center/docs/governance/BASELINE.md
+++ b/command-center/docs/governance/BASELINE.md
@@ -28,6 +28,14 @@ Re-run the lock validation lane whenever any of these change:
 - Review gate enforcement or policy: `tools/review-gate.mjs`, `review-policy.json`
 - Any change that touches `domain_tags` `money_state` scope and claims the lock still holds.
 
+## Hardening freeze (governance rule)
+
+Do not keep “tightening the lock” without a triggering signal.
+Allowed triggers for lock/hardening changes:
+- a failing CI/nightly run
+- a real incident/postmortem action item
+- a concrete, logged risk with evidence (run folder + judgment)
+
 ## CI lane (maintained standard)
 
 The lightweight CI lane must run:
@@ -49,4 +57,5 @@ The lightweight CI lane must run:
 ## Notes
 
 - This baseline is **local/CI-grade proof**, not production validation.
+- Layer 3 outputs are **internal governed artifacts** (not external product documents).
 - Do not claim `P0-02: PRODUCTION-VALIDATED` without separate production artifacts.

--- a/command-center/docs/governance/RUN_FOLDER_CONTRACT.md
+++ b/command-center/docs/governance/RUN_FOLDER_CONTRACT.md
@@ -1,0 +1,67 @@
+# Run Folder Contract (Tenant Artifacts)
+
+Purpose: define the **minimum contract** for committed run artifacts under `artifacts/tenants/<tenant_id>/runs/<run_folder>/`.
+
+This contract exists to reduce brittle path assumptions by making `manifest.json` the preferred index.
+
+## Key definitions
+
+- `tenant_id`: tenant slug (e.g. `vent-guys`). Must match the folder name under `artifacts/tenants/`.
+- `run_folder`: filesystem-safe version of `run_id` (e.g. colons replaced with dashes).
+- `artifact_class`: declares what this run folder guarantees it contains.
+
+## Required files (all classes)
+
+- `manifest.json` (preferred index; see below)
+
+## `manifest.json` (preferred index)
+
+Every run manifest must include:
+
+- `tenant_id`
+- `artifact_class`
+- `created_at` (non-null)
+- `paths` object with these keys:
+  - `judgment_json`
+  - `raw_doc`
+  - `review_doc`
+  - `observed_bundle_root`
+  - `manifest`
+
+Tools should resolve canonical paths from `manifest.paths.*` when present.
+
+## Artifact classes
+
+### `ledger_lock_full`
+
+Required (must exist on disk):
+- `paths.judgment_json`
+- `paths.observed_bundle_root`
+- `paths.raw_doc`
+- `paths.review_doc`
+
+Classification:
+- Layer 3 outputs are **internal governed artifacts**, not external product docs.
+
+### `ledger_lock_layer2_only`
+
+Required (must exist on disk):
+- `paths.judgment_json`
+- `paths.observed_bundle_root`
+
+Allowed:
+- `paths.raw_doc` / `paths.review_doc` may be null or point to future outputs.
+
+### `legacy*`
+
+Legacy artifacts may exist for historical reasons.
+They are not baseline SSOT and may be non-self-contained.
+
+## Consistency requirements (when applicable)
+
+When both are present, validators must hard-fail if inconsistent:
+
+- `manifest.run_id` ⇔ `layer2_observed_judgment.json.run_id`
+- `manifest.tenant_id` ⇔ `layer2_observed_judgment.json.tenant_id`
+- `manifest.paths.observed_bundle_root` ⇔ `layer2_observed_judgment.json.observed_bundle_root`
+

--- a/command-center/docs/templates/review-input.schema.json
+++ b/command-center/docs/templates/review-input.schema.json
@@ -6,6 +6,7 @@
   "additionalProperties": true,
   "required": [
     "gate_version",
+    "tenant_id",
     "change_id",
     "pr_id",
     "title",
@@ -29,49 +30,105 @@
     "readiness"
   ],
   "properties": {
-    "gate_version": { "type": "string", "minLength": 1 },
-    "change_id": { "type": "string", "minLength": 1 },
-    "pr_id": { "type": "string", "minLength": 1, "description": "Use \"LOCAL\" when not in a PR." },
-    "title": { "type": "string", "minLength": 1 },
-    "generated_at": { "type": "string", "format": "date-time" },
+    "gate_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tenant_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Tenant slug (e.g. \"vent-guys\")."
+    },
+    "change_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "pr_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Use \"LOCAL\" when not in a PR."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
     "source_commit": {
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{7,40}$",
-      "description": "Git SHA-like hex string."
+      "pattern": "^[0-9a-fA-F]{7,40}$"
     },
-    "run_id": { "type": "string", "format": "date-time" },
+    "run_id": {
+      "type": "string",
+      "format": "date-time"
+    },
     "files_changed": {
       "type": "array",
       "minItems": 1,
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     },
     "scope": {
       "type": "object",
       "additionalProperties": true,
-      "required": ["included"],
+      "required": [
+        "included"
+      ],
       "properties": {
         "included": {
           "type": "array",
           "minItems": 1,
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         },
-        "excluded": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+        "excluded": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
       }
     },
     "domain_tags": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 },
-      "description": "Tags used for critical-domain triggering. The enforced trigger set is in review-policy.json (critical_domains)."
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Trigger set is policy.critical_domains; schema stays permissive to match gate behavior."
     },
-    "summary": { "type": "string", "minLength": 1 },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
     "decider": {
       "type": "object",
       "additionalProperties": true,
-      "required": ["name", "role", "approved_at"],
+      "required": [
+        "name",
+        "role",
+        "approved_at"
+      ],
       "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "role": { "type": "string", "minLength": 1 },
-        "approved_at": { "type": "string", "format": "date-time" }
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "approved_at": {
+          "type": "string",
+          "format": "date-time"
+        }
       }
     },
     "risk_acceptances": {
@@ -79,13 +136,37 @@
       "items": {
         "type": "object",
         "additionalProperties": true,
-        "required": ["expires_at"],
+        "required": [
+          "expires_at"
+        ],
         "properties": {
-          "owner": { "type": "string" },
-          "reason": { "type": "string" },
-          "probability": { "type": "string", "enum": ["LOW", "MEDIUM", "HIGH"] },
-          "blast_radius": { "type": "string", "enum": ["LOW", "MEDIUM", "HIGH", "CATASTROPHIC"] },
-          "expires_at": { "type": "string", "format": "date-time" }
+          "owner": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "probability": {
+            "type": "string",
+            "enum": [
+              "LOW",
+              "MEDIUM",
+              "HIGH"
+            ]
+          },
+          "blast_radius": {
+            "type": "string",
+            "enum": [
+              "LOW",
+              "MEDIUM",
+              "HIGH",
+              "CATASTROPHIC"
+            ]
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       }
     },
@@ -94,44 +175,125 @@
       "items": {
         "type": "object",
         "additionalProperties": true,
-        "required": ["category", "scenario", "expected_behavior", "verification_method", "evidence_required"],
+        "required": [
+          "category",
+          "scenario",
+          "expected_behavior",
+          "verification_method",
+          "evidence_required"
+        ],
         "properties": {
-          "category": { "type": "string", "minLength": 1 },
-          "scenario": { "type": "string", "minLength": 1 },
-          "expected_behavior": { "type": "string", "minLength": 1 },
-          "verification_method": { "type": "string", "minLength": 1 },
-          "evidence_required": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+          "category": {
+            "type": "string",
+            "minLength": 1
+          },
+          "scenario": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expected_behavior": {
+            "type": "string",
+            "minLength": 1
+          },
+          "verification_method": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_required": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
         }
       }
     },
     "concurrency_model": {
       "type": "object",
       "additionalProperties": true,
-      "required": ["model", "guarantees", "non_guarantees"],
+      "required": [
+        "model",
+        "guarantees",
+        "non_guarantees"
+      ],
       "properties": {
-        "model": { "type": "string", "enum": ["dedupe_based", "lock_based"] },
-        "guarantees": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
-        "non_guarantees": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
-        "lock_strategy": { "type": "string" }
+        "model": {
+          "type": "string",
+          "enum": [
+            "dedupe_based",
+            "lock_based"
+          ]
+        },
+        "guarantees": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "non_guarantees": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "lock_strategy": {
+          "type": "string"
+        }
       }
     },
     "ops_impact": {
       "type": "object",
       "additionalProperties": true,
-      "required": ["alert_dedupe_identity", "max_open_alerts_per_entity", "task_dedupe_rule"],
+      "required": [
+        "alert_dedupe_identity",
+        "max_open_alerts_per_entity",
+        "task_dedupe_rule"
+      ],
       "properties": {
-        "alert_dedupe_identity": { "type": "string", "minLength": 1 },
-        "max_open_alerts_per_entity": { "type": "string", "minLength": 1 },
-        "task_dedupe_rule": { "type": "string", "minLength": 1 }
+        "alert_dedupe_identity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "max_open_alerts_per_entity": {
+          "type": "string",
+          "minLength": 1
+        },
+        "task_dedupe_rule": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "trigger_evidence": {
       "type": "object",
       "additionalProperties": true,
-      "required": ["derived_domain_tags", "derivation_inputs"],
+      "required": [
+        "derived_domain_tags",
+        "derivation_inputs"
+      ],
       "properties": {
-        "derived_domain_tags": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
-        "derivation_inputs": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+        "derived_domain_tags": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "derivation_inputs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
       }
     },
     "artifacts": {
@@ -140,28 +302,83 @@
       "items": {
         "type": "object",
         "additionalProperties": true,
-        "required": ["type", "label", "proof_of", "path"],
+        "required": [
+          "type",
+          "label",
+          "proof_of",
+          "path"
+        ],
         "properties": {
-          "type": { "type": "string" },
-          "label": { "type": "string", "minLength": 1 },
-          "proof_of": { "type": "string", "minLength": 1 },
-          "path": { "type": "string", "minLength": 1 },
-          "sha256": { "type": "string" },
-          "snippet": { "type": "string" },
-          "created_at": { "type": "string", "format": "date-time" },
-          "notes": { "type": "string" }
+          "type": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "proof_of": {
+            "type": "string",
+            "minLength": 1
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sha256": {
+            "type": "string"
+          },
+          "snippet": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "notes": {
+            "type": "string"
+          }
         }
       }
     },
     "coverage_report": {
       "type": "object",
       "additionalProperties": true,
-      "required": ["files_analyzed", "discovery_inputs", "excluded_scope", "uncertainty_boundaries"],
+      "required": [
+        "files_analyzed",
+        "discovery_inputs",
+        "excluded_scope",
+        "uncertainty_boundaries"
+      ],
       "properties": {
-        "files_analyzed": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
-        "discovery_inputs": { "type": "array", "items": { "type": "string", "minLength": 1 } },
-        "excluded_scope": { "type": "array", "items": { "type": "string", "minLength": 1 } },
-        "uncertainty_boundaries": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+        "files_analyzed": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "discovery_inputs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "excluded_scope": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "uncertainty_boundaries": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
       }
     },
     "findings": {
@@ -182,33 +399,92 @@
           "closure_evidence_required"
         ],
         "properties": {
-          "id": { "type": "string", "minLength": 1 },
-          "title": { "type": "string", "minLength": 1 },
-          "severity": { "type": "string", "minLength": 1 },
-          "business_impact": { "type": "string", "minLength": 1 },
-          "rule_violated": { "type": "string", "minLength": 1 },
-          "proof": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
-          "recommended_action": { "type": "string", "minLength": 1 },
-          "verification_method": { "type": "string", "minLength": 1 },
-          "closure_evidence_required": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "severity": {
+            "type": "string",
+            "minLength": 1
+          },
+          "business_impact": {
+            "type": "string",
+            "minLength": 1
+          },
+          "rule_violated": {
+            "type": "string",
+            "minLength": 1
+          },
+          "proof": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "recommended_action": {
+            "type": "string",
+            "minLength": 1
+          },
+          "verification_method": {
+            "type": "string",
+            "minLength": 1
+          },
+          "closure_evidence_required": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
         }
       }
     },
     "verification": {
       "type": "object",
       "additionalProperties": true,
-      "description": "Critical-domain required keys are enforced by review:gate from review-policy.json. This schema stays permissive to avoid drift."
+      "description": "Critical-domain required keys are enforced by review:gate from policy.critical_change_requirements."
     },
     "readiness": {
       "type": "object",
       "additionalProperties": true,
-      "required": ["status", "labels"],
+      "required": [
+        "status",
+        "labels"
+      ],
       "properties": {
-        "status": { "type": "string", "enum": ["NOT_READY", "CONDITIONALLY_READY", "READY"] },
-        "labels": { "type": "array", "items": { "type": "string", "enum": ["P0-02: LOCAL_PROVEN", "P0-02: PRODUCTION-VALIDATED"] } },
-        "production_artifacts": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+        "status": {
+          "type": "string",
+          "enum": [
+            "NOT_READY",
+            "CONDITIONALLY_READY",
+            "READY"
+          ]
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "P0-02: LOCAL_PROVEN",
+              "P0-02: PRODUCTION-VALIDATED"
+            ]
+          }
+        },
+        "production_artifacts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
       }
     }
   }
 }
-

--- a/command-center/docs/templates/review-input.template.json
+++ b/command-center/docs/templates/review-input.template.json
@@ -1,15 +1,20 @@
 {
   "$schema": "./review-input.schema.json",
   "gate_version": "v1",
+  "tenant_id": "vent-guys",
   "change_id": "CHANGE-REPLACE-ME",
   "pr_id": "LOCAL",
   "title": "REPLACE ME",
-  "generated_at": "2026-04-06T00:00:00.000Z",
+  "generated_at": "2026-04-10T00:43:06.406Z",
   "source_commit": "0000000",
-  "run_id": "2026-04-06T00:00:00.000Z",
-  "files_changed": ["REPLACE/ME.ts"],
+  "run_id": "2026-04-10T00:43:06.419Z",
+  "files_changed": [
+    "REPLACE/ME.ts"
+  ],
   "scope": {
-    "included": ["REPLACE/ME.ts"],
+    "included": [
+      "REPLACE/ME.ts"
+    ],
     "excluded": []
   },
   "domain_tags": [],
@@ -17,22 +22,29 @@
   "decider": {
     "name": "REPLACE ME",
     "role": "REPLACE ME",
-    "approved_at": "2026-04-06T00:00:00.000Z"
+    "approved_at": "2026-04-10T00:43:06.419Z"
   },
   "risk_acceptances": [],
   "scenarios": [
     {
-      "category": "bad_data",
+      "category": "concurrency",
       "scenario": "REPLACE ME",
       "expected_behavior": "REPLACE ME",
       "verification_method": "REPLACE ME",
-      "evidence_required": ["artifacts:log", "artifacts:test_result"]
+      "evidence_required": [
+        "artifacts:log",
+        "artifacts:test_result"
+      ]
     }
   ],
   "concurrency_model": {
     "model": "dedupe_based",
-    "guarantees": ["REPLACE ME"],
-    "non_guarantees": ["REPLACE ME"]
+    "guarantees": [
+      "REPLACE ME"
+    ],
+    "non_guarantees": [
+      "REPLACE ME"
+    ]
   },
   "ops_impact": {
     "alert_dedupe_identity": "REPLACE ME",
@@ -40,8 +52,12 @@
     "task_dedupe_rule": "REPLACE ME"
   },
   "trigger_evidence": {
-    "derived_domain_tags": ["REPLACE ME"],
-    "derivation_inputs": ["git diff --name-only <base>...HEAD"]
+    "derived_domain_tags": [
+      "REPLACE ME"
+    ],
+    "derivation_inputs": [
+      "git diff --name-only <base>...HEAD"
+    ]
   },
   "artifacts": [
     {
@@ -49,14 +65,20 @@
       "label": "REPLACE ME",
       "proof_of": "REPLACE ME",
       "path": "artifacts/tenants/REPLACE_TENANT/runs/REPLACE_ME/stdout.log",
-      "created_at": "2026-04-06T00:00:00.000Z"
+      "created_at": "2026-04-10T00:43:06.419Z"
     }
   ],
   "coverage_report": {
-    "files_analyzed": ["REPLACE/ME.ts"],
-    "discovery_inputs": ["rg -n \"REPLACE\" src"],
+    "files_analyzed": [
+      "REPLACE/ME.ts"
+    ],
+    "discovery_inputs": [
+      "rg -n \"REPLACE\" src"
+    ],
     "excluded_scope": [],
-    "uncertainty_boundaries": ["REPLACE ME"]
+    "uncertainty_boundaries": [
+      "REPLACE ME"
+    ]
   },
   "findings": [
     {
@@ -65,10 +87,14 @@
       "severity": "MEDIUM",
       "business_impact": "REPLACE ME",
       "rule_violated": "REPLACE ME",
-      "proof": ["path:line snippet OR artifact path"],
+      "proof": [
+        "path:line snippet OR artifact path"
+      ],
       "recommended_action": "REPLACE ME",
       "verification_method": "REPLACE ME",
-      "closure_evidence_required": ["REPLACE ME"]
+      "closure_evidence_required": [
+        "REPLACE ME"
+      ]
     }
   ],
   "verification": {},

--- a/command-center/tmp/orchestrator-v2/eval/validate_tenant_scope.mjs
+++ b/command-center/tmp/orchestrator-v2/eval/validate_tenant_scope.mjs
@@ -1,37 +1,108 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
+import path from 'node:path';
 
-const norm = (p) => String(p || '').replaceAll('\\', '/');
-const fail = (msg) => {
-  console.error(`TENANT SCOPE: FAILED\n\n${msg}\n`);
-  process.exit(1);
+const normPath = (p) => String(p || '').replaceAll('\\', '/');
+const normalizeContractLike = (p) => {
+  let s = normPath(p).trim();
+  while (s.startsWith('./')) s = s.slice(2);
+  return s;
+};
+const resolveRepoPath = (p) => path.resolve(process.cwd(), normalizeContractLike(p));
+
+const existsFile = (p) => {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
 };
 
-const inputPath = process.argv[2];
-if (!inputPath) {
-  fail('Usage: node tmp/orchestrator-v2/eval/validate_tenant_scope.mjs <layer2_observed_judgment.json>');
-}
+export const findSiblingManifestForJson = (jsonPath) => {
+  if (!jsonPath) return null;
+  const candidate = path.join(path.dirname(jsonPath), 'manifest.json');
+  return existsFile(candidate) ? candidate : null;
+};
 
-if (!fs.existsSync(inputPath)) fail(`Missing JSON: ${inputPath}`);
-const src = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+export const loadJson = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
 
-const tenantId = String(src?.tenant_id || '').trim();
-if (!tenantId || !/^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$/.test(tenantId)) {
-  fail('Invalid or missing tenant_id in layer2_observed_judgment.json');
-}
+export const assertManifestJudgmentConsistency = ({ manifestPath, manifest, judgmentPath, judgment }) => {
+  const ctx = normPath(manifestPath || '(manifest)');
 
-const pathTenant = norm(inputPath).match(/(?:^|\/)artifacts\/tenants\/([^/]+)\/runs\//)?.[1] || null;
-if (pathTenant && pathTenant !== tenantId) {
-  fail(`tenant_id mismatch vs path: json=${tenantId} path=${pathTenant}`);
-}
+  const mRun = manifest?.run_id;
+  const mTenant = manifest?.tenant_id;
+  const mObserved = manifest?.paths?.observed_bundle_root;
 
-const observedRoot = String(src?.observed_bundle_root || '').trim();
-if (observedRoot) {
-  const observedTenant = norm(observedRoot).match(/(?:^|\/)artifacts\/tenants\/([^/]+)\/runs\//)?.[1] || null;
-  if (observedTenant && observedTenant !== tenantId) {
-    fail(`tenant_id mismatch vs observed_bundle_root: json=${tenantId} observed_bundle_root=${observedTenant}`);
+  const jRun = judgment?.run_id;
+  const jTenant = judgment?.tenant_id;
+  const jObserved = judgment?.observed_bundle_root;
+
+  if (mRun && jRun && mRun !== jRun) throw new Error(`Tenant scope mismatch: run_id (manifest=${mRun} judgment=${jRun}) in ${ctx}`);
+  if (mTenant && jTenant && mTenant !== jTenant) {
+    throw new Error(`Tenant scope mismatch: tenant_id (manifest=${mTenant} judgment=${jTenant}) in ${ctx}`);
   }
+  if (mObserved && jObserved) {
+    const a = normalizeContractLike(mObserved);
+    const b = normalizeContractLike(jObserved);
+    if (a && b && a !== b) {
+      throw new Error(`Tenant scope mismatch: observed_bundle_root (manifest.paths vs judgment) in ${ctx}`);
+    }
+  }
+
+  // If manifest points at a canonical judgment path, ensure it matches the file being validated.
+  const mJudgment = manifest?.paths?.judgment_json;
+  if (mJudgment && judgmentPath) {
+    const a = normalizeContractLike(mJudgment);
+    const b = normalizeContractLike(normPath(path.relative(process.cwd(), judgmentPath)));
+    if (a && b && a !== b) {
+      throw new Error(`Tenant scope mismatch: paths.judgment_json does not match provided judgment path in ${ctx}`);
+    }
+  }
+};
+
+const parseArgs = (argv) => {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--manifest') args.manifest = argv[++i];
+    else if (a === '--json' || a === '--judgment') args.judgment = argv[++i];
+    else if (a === '--help') args.help = true;
+    else if (!a.startsWith('-') && !args.judgment) args.judgment = a; // backwards-compat positional arg
+  }
+  return args;
+};
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help || !args.judgment) {
+  console.error(
+    'Usage:\n' +
+      '  node tmp/orchestrator-v2/eval/validate_tenant_scope.mjs --json <layer2_observed_judgment.json> [--manifest <manifest.json>]\n'
+  );
+  process.exit(2);
 }
 
-console.log('TENANT SCOPE: PASSED');
+try {
+  const judgmentPathAbs = resolveRepoPath(args.judgment);
+  if (!existsFile(judgmentPathAbs)) throw new Error(`Missing judgment JSON: ${args.judgment}`);
+  const judgment = loadJson(judgmentPathAbs);
 
+  const manifestPathAbs = args.manifest ? resolveRepoPath(args.manifest) : findSiblingManifestForJson(judgmentPathAbs);
+  if (!manifestPathAbs) {
+    // No manifest = no consistency check (legacy allowed).
+    process.exit(0);
+  }
+  if (!existsFile(manifestPathAbs)) throw new Error(`Missing manifest.json: ${manifestPathAbs}`);
+  const manifest = loadJson(manifestPathAbs);
+
+  assertManifestJudgmentConsistency({
+    manifestPath: manifestPathAbs,
+    manifest,
+    judgmentPath: judgmentPathAbs,
+    judgment,
+  });
+
+  process.exit(0);
+} catch (e) {
+  console.error(`TENANT SCOPE: FAILED\n\n${e?.message || String(e)}\n`);
+  process.exit(1);
+}

--- a/command-center/tmp/orchestrator-v2/layer3/render_layer3_raw.mjs
+++ b/command-center/tmp/orchestrator-v2/layer3/render_layer3_raw.mjs
@@ -1,6 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { renderLayer3Raw } from './_render_lib.mjs';
+import {
+  assertManifestJudgmentConsistency,
+  findSiblingManifestForJson,
+  loadJson,
+} from '../eval/validate_tenant_scope.mjs';
 
 const [inputPath, outputPath] = process.argv.slice(2);
 if (!inputPath || !outputPath) {
@@ -10,8 +15,24 @@ if (!inputPath || !outputPath) {
 
 const readJson = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
 const ensureDir = (p) => fs.mkdirSync(path.dirname(p), { recursive: true });
+const resolveRepoPath = (p) => path.resolve(process.cwd(), String(p || '').replaceAll('\\', '/').replace(/^\.\//, ''));
 
 const observedJudgmentJson = readJson(inputPath);
+const siblingManifest = findSiblingManifestForJson(resolveRepoPath(inputPath));
+if (siblingManifest) {
+  try {
+    const manifest = loadJson(siblingManifest);
+    assertManifestJudgmentConsistency({
+      manifestPath: siblingManifest,
+      manifest,
+      judgmentPath: resolveRepoPath(inputPath),
+      judgment: observedJudgmentJson,
+    });
+  } catch (e) {
+    console.error(`LAYER3 RAW RENDER: FAILED\n\n${e?.message || String(e)}\n`);
+    process.exit(1);
+  }
+}
 const out = renderLayer3Raw({ inputPath, observedJudgmentJson });
 
 ensureDir(outputPath);

--- a/command-center/tmp/orchestrator-v2/layer3/render_layer3_review.mjs
+++ b/command-center/tmp/orchestrator-v2/layer3/render_layer3_review.mjs
@@ -2,6 +2,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { renderLayer3ReviewV1 } from './_review_lib.mjs';
+import {
+  assertManifestJudgmentConsistency,
+  findSiblingManifestForJson,
+  loadJson,
+} from '../eval/validate_tenant_scope.mjs';
 
 const parseArgs = (argv) => {
   const args = {};
@@ -27,8 +32,45 @@ if (args.help || !args.json || !args.out) {
 
 const readJson = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
 const ensureDir = (p) => fs.mkdirSync(path.dirname(p), { recursive: true });
+const resolveRepoPath = (p) => path.resolve(process.cwd(), String(p || '').replaceAll('\\', '/').replace(/^\.\//, ''));
+const existsFile = (p) => {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+};
+const existsDir = (p) => {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+};
 
 const src = readJson(args.json);
+
+// Manifest-first resolution (when present): reduce path coupling and enforce run-folder consistency.
+let manifest = null;
+const siblingManifest = findSiblingManifestForJson(resolveRepoPath(args.json));
+if (siblingManifest) {
+  try {
+    manifest = loadJson(siblingManifest);
+    assertManifestJudgmentConsistency({
+      manifestPath: siblingManifest,
+      manifest,
+      judgmentPath: resolveRepoPath(args.json),
+      judgment: src,
+    });
+  } catch (e) {
+    console.error(`LAYER3 REVIEW RENDER: FAILED\n\n${e?.message || String(e)}\n`);
+    process.exit(1);
+  }
+}
+
+const manifestPaths = manifest?.paths || {};
+const manifestRawDoc = typeof manifestPaths.raw_doc === 'string' ? manifestPaths.raw_doc : null;
+const manifestEvidence = typeof manifestPaths.observed_bundle_root === 'string' ? manifestPaths.observed_bundle_root : null;
 
 const deriveSiblingRaw = (reviewOutPath) => {
   if (!reviewOutPath) return null;
@@ -41,9 +83,14 @@ const deriveSiblingRaw = (reviewOutPath) => {
 // For baseline/governance docs, or when no sibling exists, fall back to the locked baseline raw contract doc.
 const rawDocPath =
   args.raw ||
+  (manifestRawDoc && existsFile(resolveRepoPath(manifestRawDoc)) ? manifestRawDoc : null) ||
   deriveSiblingRaw(args.out) ||
   './docs/reconciliation/lock/layer3/LAYER3_LEDGER_LOCK_JUDGMENT_RAW.md';
-const evidencePath = args.evidence || src?.observed_bundle_root || './artifacts/tenants/vent-guys/runs/2026-04-09T03-54-25.639Z/observed_bundle/';
+const evidencePath =
+  args.evidence ||
+  (manifestEvidence && existsDir(resolveRepoPath(manifestEvidence)) ? manifestEvidence : null) ||
+  src?.observed_bundle_root ||
+  './artifacts/tenants/vent-guys/runs/2026-04-09T03-54-25.639Z/observed_bundle/';
 
 const out = renderLayer3ReviewV1({
   inputJsonPath: args.json,

--- a/command-center/tmp/orchestrator-v2/layer3/validate_layer3_output.mjs
+++ b/command-center/tmp/orchestrator-v2/layer3/validate_layer3_output.mjs
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
+import path from 'node:path';
 import { normalizeNewlines, renderLayer3Raw } from './_render_lib.mjs';
+import {
+  assertManifestJudgmentConsistency,
+  findSiblingManifestForJson,
+  loadJson,
+} from '../eval/validate_tenant_scope.mjs';
 
 const parseArgs = (argv) => {
   const args = { mode: 'exact' };
@@ -60,6 +66,25 @@ if (args.mode === 'structural') {
 }
 
 const observedJudgmentJson = JSON.parse(fs.readFileSync(args.json, 'utf8'));
+
+// Manifest-first consistency check (when present) so the raw contract doc never drifts from the run index.
+const resolveRepoPath = (p) => path.resolve(process.cwd(), String(p || '').replaceAll('\\', '/').replace(/^\.\//, ''));
+const siblingManifest = findSiblingManifestForJson(resolveRepoPath(args.json));
+if (siblingManifest) {
+  try {
+    const manifest = loadJson(siblingManifest);
+    assertManifestJudgmentConsistency({
+      manifestPath: siblingManifest,
+      manifest,
+      judgmentPath: resolveRepoPath(args.json),
+      judgment: observedJudgmentJson,
+    });
+  } catch (e) {
+    console.error(`LAYER3 VALIDATION: FAILED\n\n${e?.message || String(e)}`);
+    process.exit(1);
+  }
+}
+
 const expected = renderLayer3Raw({ inputPath: args.json, observedJudgmentJson });
 const actual = docText;
 

--- a/command-center/tmp/orchestrator-v2/layer3/validate_layer3_review_output.mjs
+++ b/command-center/tmp/orchestrator-v2/layer3/validate_layer3_review_output.mjs
@@ -2,6 +2,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { normalizeNewlines, renderLayer3ReviewV1 } from './_review_lib.mjs';
+import {
+  assertManifestJudgmentConsistency,
+  findSiblingManifestForJson,
+  loadJson,
+} from '../eval/validate_tenant_scope.mjs';
 
 const parseArgs = (argv) => {
   const args = { mode: 'exact' };
@@ -27,6 +32,21 @@ if (args.help || !args.doc) {
 }
 
 const doc = normalizeNewlines(fs.readFileSync(args.doc, 'utf8'));
+const resolveRepoPath = (p) => path.resolve(process.cwd(), String(p || '').replaceAll('\\', '/').replace(/^\.\//, ''));
+const existsFile = (p) => {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+};
+const existsDir = (p) => {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+};
 
 const requiredHeadings = [
   '# Ledger Lock — Review Summary',
@@ -71,8 +91,31 @@ if (args.mode !== 'exact' || !args.json) {
 }
 
 const observedJudgmentJson = JSON.parse(fs.readFileSync(args.json, 'utf8'));
+
+// Manifest-first: if the judgment JSON lives inside a run folder with a manifest, prefer it and enforce consistency.
+let manifest = null;
+const siblingManifest = findSiblingManifestForJson(resolveRepoPath(args.json));
+if (siblingManifest) {
+  try {
+    manifest = loadJson(siblingManifest);
+    assertManifestJudgmentConsistency({
+      manifestPath: siblingManifest,
+      manifest,
+      judgmentPath: resolveRepoPath(args.json),
+      judgment: observedJudgmentJson,
+    });
+  } catch (e) {
+    console.error(`LAYER3 REVIEW VALIDATION: FAILED\n\n${e?.message || String(e)}`);
+    process.exit(1);
+  }
+}
+
+const manifestPaths = manifest?.paths || {};
+const manifestEvidence = typeof manifestPaths.observed_bundle_root === 'string' ? manifestPaths.observed_bundle_root : null;
 const preferredEvidenceBundlePath =
-  observedJudgmentJson?.observed_bundle_root || './artifacts/tenants/vent-guys/runs/2026-04-09T03-54-25.639Z/observed_bundle/';
+  (manifestEvidence && existsDir(resolveRepoPath(manifestEvidence)) ? manifestEvidence : null) ||
+  observedJudgmentJson?.observed_bundle_root ||
+  './artifacts/tenants/vent-guys/runs/2026-04-09T03-54-25.639Z/observed_bundle/';
 
 const deriveSiblingRaw = (reviewDocPath) => {
   if (!reviewDocPath) return null;
@@ -80,8 +123,10 @@ const deriveSiblingRaw = (reviewDocPath) => {
   return fs.existsSync(candidate) ? candidate : null;
 };
 
+const manifestRawDoc = typeof manifestPaths.raw_doc === 'string' ? manifestPaths.raw_doc : null;
 const rawDocPath =
   args.raw ||
+  (manifestRawDoc && existsFile(resolveRepoPath(manifestRawDoc)) ? manifestRawDoc : null) ||
   deriveSiblingRaw(args.doc) ||
   './docs/reconciliation/lock/layer3/LAYER3_LEDGER_LOCK_JUDGMENT_RAW.md';
 

--- a/command-center/tmp/orchestrator-v2/runner/generate_layer2_review_input.ps1
+++ b/command-center/tmp/orchestrator-v2/runner/generate_layer2_review_input.ps1
@@ -50,8 +50,9 @@ RequirePath (Join-Path $ObservedBundleRoot "layer2_eval_env_control\\judgment.js
 RequirePath (Join-Path $ObservedBundleRoot "layer2_eval_invariant_control\\judgment.json") "Observed invariant-control judgment.json"
 
 $runId = IsoUtcNow
-$generatedAt = $null
+$createdAt = $runId
 $approvedAt = $null
+$artifactClass = "ledger_lock_layer2_only"
 
 $sourceCommit = (& git rev-parse HEAD).Trim()
 if (-not $sourceCommit) { throw "Unable to determine git HEAD sha" }
@@ -59,6 +60,7 @@ if (-not $sourceCommit) { throw "Unable to determine git HEAD sha" }
 $runFolder = SanitizeRunFolder $runId
 $runArtifactsDir = Join-Path ".\\artifacts\\tenants\\$TenantId\\runs" $runFolder
 EnsureDir $runArtifactsDir
+$runArtifactsDirRel = "artifacts/tenants/$TenantId/runs/$runFolder"
 
 $manifestPath = Join-Path $runArtifactsDir "manifest.json"
 $dbOutputPath = Join-Path $runArtifactsDir "db_output.txt"
@@ -69,14 +71,26 @@ $observedJudgment = Get-Content -Raw (Join-Path $ObservedBundleRoot "layer2_eval
 
 $bundleCopyRoot = Join-Path $runArtifactsDir "observed_bundle"
 
+$paths = [ordered]@{
+  judgment_json = "$runArtifactsDirRel/layer2_observed_judgment.json"
+  raw_doc = "$runArtifactsDirRel/layer3_raw.md"
+  review_doc = "$runArtifactsDirRel/layer3_review.md"
+  observed_bundle_root = "$runArtifactsDirRel/observed_bundle"
+  manifest = "$runArtifactsDirRel/manifest.json"
+}
+
 $manifest = [ordered]@{
+  manifest_version = "2.0"
   run_id = $runId
+  tenant_id = $TenantId
+  artifact_class = $artifactClass
+  created_at = $createdAt
   change_id = $ChangeId
   title = $Title
   source_commit = $sourceCommit
   observed_bundle_root = $bundleCopyRoot
   source_observed_bundle_root = $ObservedBundleRoot
-  created_at = $generatedAt
+  paths = $paths
 }
 WriteJson $manifestPath $manifest
 
@@ -162,7 +176,7 @@ foreach ($rel in $toCopy) {
   Copy-Item -Force $src $dst
 }
 
-# Use a post-write timestamp so artifact mtimes are not after generated_at.
+# Use a post-write timestamp for governance files that are regenerated (review-input.json).
 $generatedAt = IsoUtcNow
 $approvedAt = $generatedAt
 

--- a/command-center/tools/generate-review-templates.mjs
+++ b/command-center/tools/generate-review-templates.mjs
@@ -28,6 +28,7 @@ const schema = {
   required: Array.isArray(policy.required_top_level_fields) ? policy.required_top_level_fields : [],
   properties: {
     gate_version: { type: 'string', minLength: 1 },
+    tenant_id: { type: 'string', minLength: 1, description: 'Tenant slug (e.g. "vent-guys").' },
     change_id: { type: 'string', minLength: 1 },
     pr_id: { type: 'string', minLength: 1, description: 'Use "LOCAL" when not in a PR.' },
     title: { type: 'string', minLength: 1 },
@@ -191,6 +192,7 @@ const schema = {
 const template = {
   $schema: './review-input.schema.json',
   gate_version: 'v1',
+  tenant_id: 'vent-guys',
   change_id: 'CHANGE-REPLACE-ME',
   pr_id: 'LOCAL',
   title: 'REPLACE ME',

--- a/command-center/tools/validate-tenant-artifacts.mjs
+++ b/command-center/tools/validate-tenant-artifacts.mjs
@@ -16,6 +16,14 @@ const ok = () => {
   console.log('TENANT ARTIFACTS: PASSED');
 };
 
+const normPath = (p) => String(p || '').replaceAll('\\', '/');
+const normalizeContractLike = (p) => {
+  let s = normPath(p).trim();
+  while (s.startsWith('./')) s = s.slice(2);
+  return s;
+};
+const resolveRepoPath = (p) => path.resolve(process.cwd(), normalizeContractLike(p));
+
 const isDir = (p) => {
   try {
     return fs.statSync(p).isDirectory();
@@ -62,6 +70,141 @@ const walk = (dir) => {
 };
 
 walk(root);
+
+const safeJsonParse = (p) => {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch (e) {
+    bad.push(`Invalid JSON: ${normPath(path.relative(process.cwd(), p))}`);
+    return null;
+  }
+};
+
+const requireString = (label, v, relContext) => {
+  if (typeof v !== 'string' || v.trim().length === 0) {
+    bad.push(`Missing/invalid ${label} in ${relContext}`);
+    return false;
+  }
+  return true;
+};
+
+const requirePathsShape = (paths, relContext) => {
+  if (!paths || typeof paths !== 'object') {
+    bad.push(`Missing paths object in ${relContext}`);
+    return false;
+  }
+  const keys = ['judgment_json', 'raw_doc', 'review_doc', 'observed_bundle_root', 'manifest'];
+  for (const k of keys) {
+    if (!(k in paths)) bad.push(`Missing paths.${k} in ${relContext}`);
+  }
+  return keys.every((k) => k in paths);
+};
+
+const existsFile = (p) => {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+};
+
+const existsDir = (p) => {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+};
+
+const validateManifestConsistency = (tenantIdFromPath, runDirAbs) => {
+  const manifestAbs = path.join(runDirAbs, 'manifest.json');
+  const relCtx = normPath(path.relative(process.cwd(), manifestAbs));
+
+  if (!existsFile(manifestAbs)) {
+    bad.push(`Missing manifest.json: ${normPath(path.relative(process.cwd(), runDirAbs))}`);
+    return;
+  }
+
+  const manifest = safeJsonParse(manifestAbs);
+  if (!manifest) return;
+
+  const tenantOk = requireString('tenant_id', manifest.tenant_id, relCtx);
+  if (tenantOk && manifest.tenant_id !== tenantIdFromPath) {
+    bad.push(`tenant_id mismatch (path=${tenantIdFromPath} manifest=${manifest.tenant_id}): ${relCtx}`);
+  }
+
+  requireString('artifact_class', manifest.artifact_class, relCtx);
+  requireString('created_at', manifest.created_at, relCtx);
+
+  const pathsOk = requirePathsShape(manifest.paths, relCtx);
+  if (!pathsOk) return;
+
+  const expectedManifestRel = normPath(
+    path.relative(process.cwd(), manifestAbs).replaceAll('\\', '/')
+  );
+  const manifestRelFromManifest = normPath(manifest.paths.manifest);
+  if (manifestRelFromManifest && normalizeContractLike(manifestRelFromManifest) !== expectedManifestRel) {
+    bad.push(`paths.manifest mismatch: ${relCtx}`);
+  }
+
+  const artifactClass = manifest.artifact_class;
+  const strict = artifactClass === 'ledger_lock_full' || artifactClass === 'ledger_lock_layer2_only';
+
+  const judgmentRel = manifest.paths.judgment_json;
+  const observedRel = manifest.paths.observed_bundle_root;
+  const rawRel = manifest.paths.raw_doc;
+  const reviewRel = manifest.paths.review_doc;
+
+  const judgmentAbs = judgmentRel ? resolveRepoPath(judgmentRel) : null;
+  const observedAbs = observedRel ? resolveRepoPath(observedRel) : null;
+  const rawAbs = rawRel ? resolveRepoPath(rawRel) : null;
+  const reviewAbs = reviewRel ? resolveRepoPath(reviewRel) : null;
+
+  if (strict) {
+    if (!judgmentAbs || !existsFile(judgmentAbs)) bad.push(`Missing paths.judgment_json file: ${relCtx}`);
+    if (!observedAbs || !existsDir(observedAbs)) bad.push(`Missing paths.observed_bundle_root dir: ${relCtx}`);
+    if (artifactClass === 'ledger_lock_full') {
+      if (!rawAbs || !existsFile(rawAbs)) bad.push(`Missing paths.raw_doc file: ${relCtx}`);
+      if (!reviewAbs || !existsFile(reviewAbs)) bad.push(`Missing paths.review_doc file: ${relCtx}`);
+    }
+  }
+
+  if (judgmentAbs && existsFile(judgmentAbs)) {
+    const judgment = safeJsonParse(judgmentAbs);
+    if (!judgment) return;
+
+    if (manifest.run_id && judgment.run_id && manifest.run_id !== judgment.run_id) {
+      bad.push(`run_id mismatch (manifest=${manifest.run_id} judgment=${judgment.run_id}): ${relCtx}`);
+    }
+    if (manifest.tenant_id && judgment.tenant_id && manifest.tenant_id !== judgment.tenant_id) {
+      bad.push(`tenant_id mismatch (manifest=${manifest.tenant_id} judgment=${judgment.tenant_id}): ${relCtx}`);
+    }
+
+    if (strict && observedRel && judgment.observed_bundle_root) {
+      const a = normalizeContractLike(observedRel);
+      const b = normalizeContractLike(judgment.observed_bundle_root);
+      if (a && b && a !== b) {
+        bad.push(`observed_bundle_root mismatch (manifest.paths vs judgment): ${relCtx}`);
+      }
+    }
+  }
+};
+
+// Manifest-first consistency checks (path coupling reducer).
+// - For strict artifact classes, enforce existence + consistency.
+// - For legacy artifacts, only require a readable manifest (extensions/size are already enforced above).
+if (isDir(root)) {
+  for (const tenantEnt of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!tenantEnt.isDirectory()) continue;
+    const tenantId = tenantEnt.name;
+    const runsDir = path.join(root, tenantId, 'runs');
+    if (!existsDir(runsDir)) continue;
+    for (const runEnt of fs.readdirSync(runsDir, { withFileTypes: true })) {
+      if (!runEnt.isDirectory()) continue;
+      validateManifestConsistency(tenantId, path.join(runsDir, runEnt.name));
+    }
+  }
+}
 
 if (bad.length) {
   fail(bad.slice(0, 50).join('\n') + (bad.length > 50 ? `\n...and ${bad.length - 50} more` : ''));


### PR DESCRIPTION
**Summary**
This PR reduces path-coupling by making committed run folders manifest-first, adds strict manifest↔judgment consistency rails, and documents the committed run-folder contract.

**What changed**

* `manifest_version: 2.0` with `tenant_id`, `artifact_class`, `created_at`, and canonical `paths`
* fail-hard consistency checks across manifest, judgment, and Layer 3 render/validate flow
* added `docs/governance/RUN_FOLDER_CONTRACT.md`
* review-input template/schema regenerated to include required top-level field `tenant_id` (fixes `validate-review-governance`)

**Why**
This keeps Layer 3 reusable without expanding path-based brittleness as new artifact types are added.

**Non-goals**
No new CI lanes, no document redesign, no estimate logic, no broader multi-tenant expansion.

**Validation**
`validate-tenant-artifacts`, `validate-review-governance`, and `ci_layer3_validate` pass locally (CI should match).

Note: the extra fix for `review-policy.json` and template regeneration is not scope creep; it makes the governance contract internally consistent.