### PR TITLE
Estimate v1: sample contract + raw/review renderers

### DIFF
--- a/command-center/docs/governance/ESTIMATE_RENDERER_CONTRACT.md
+++ b/command-center/docs/governance/ESTIMATE_RENDERER_CONTRACT.md
@@ -1,0 +1,88 @@
+# Estimate v1 — Renderer Contract (Raw + Review)
+
+Purpose: define what **must** be true for Estimate v1 artifacts so renderers remain deterministic and do not become policy engines.
+
+This contract is intentionally narrow (v1).
+
+## 1) Source of truth (SSOT)
+
+SSOT is the **estimate judgment JSON** (e.g. `tmp/orchestrator-v2/estimate/estimate_judgment.sample.json`).
+
+Renderers:
+- must not infer missing business meaning
+- must only format and present SSOT fields
+
+Validators:
+- must fail hard when invariants are violated
+- must reject unknown policy values
+
+## 2) Status enum (locked)
+
+`status` must be one of:
+- `draft`
+- `issued`
+- `approved`
+- `expired`
+- `superseded`
+
+## 3) Recommendation semantics (no inference)
+
+`options.*.recommended` is authored upstream. The renderer must treat it as:
+
+> “the default proposed option selected by upstream business/judgment logic”
+
+It is **not** automatically:
+- best value
+- cheapest
+- safest
+
+If the business wants “recommended means safest” (or similar), that meaning must be authored upstream and reflected in plain-language `recommendation.reason`.
+
+## 4) Option commercial requirements (no bare nulls)
+
+Every shown option must have exactly one viable commercial representation:
+- `pricing` **or**
+- `estimated_total` **or**
+- `price_range`
+
+`is_fully_quoted` governs how the renderer should communicate certainty:
+- `true` ⇒ `pricing` must be present (subtotal/tax/total)
+- `false` ⇒ option may use `estimated_total` or `price_range`
+
+Additional v1 restriction:
+- a **recommended** option must not be `price_range`-only.
+
+Selected option rule (v1):
+- selected option must include `line_items[]` and full `pricing` (subtotal/tax/total).
+
+## 5) Boundary inheritance (explicit + enumerable)
+
+`boundary_inheritance_policy` must be present and one of the enumerated values.
+
+For v1, allowed:
+- `render_universal_plus_selected_option`
+
+Meaning:
+- render universal “not included”
+- plus selected option `scope_boundaries` (“included” + “not included”)
+
+Unknown values must be rejected by validators (fail hard).
+
+## 6) Evidence traceability (minimum viable)
+
+`evidence_refs[]` must be structured objects, not strings.
+
+Minimum for at least one evidence ref:
+- `type` (e.g. `crm_quote_pdf`)
+- `id` (e.g. quote number)
+- `uri` (path/locator)
+
+This is a traceability **minimum**, not a claim-binding system. Do not imply individual claims are proven unless the data model explicitly binds them.
+
+## 7) Versioning discipline (v1)
+
+The estimate JSON must carry a `schema_version` that starts with:
+- `estimate_judgment_v1.`
+
+Breaking changes require a new major version and must not silently change renderer behavior.
+

--- a/command-center/tmp/orchestrator-v2/estimate/_estimate_lib.mjs
+++ b/command-center/tmp/orchestrator-v2/estimate/_estimate_lib.mjs
@@ -56,6 +56,12 @@ export const requireOneOf = (obj, keys, label) => {
 export const assertEstimateInvariants = (estimate) => {
   requireObject(estimate, 'root');
 
+  // Versioning discipline: keep this tight for v1.
+  requireString(estimate.schema_version, 'schema_version');
+  if (!String(estimate.schema_version).startsWith('estimate_judgment_v1.')) {
+    throw new Error(`Estimate v1: unsupported schema_version=${asString(estimate.schema_version)}`);
+  }
+
   const statusAllowed = ['draft', 'issued', 'approved', 'expired', 'superseded'];
   requireEnum(estimate.status, statusAllowed, 'status');
 
@@ -82,6 +88,51 @@ export const assertEstimateInvariants = (estimate) => {
     throw new Error(`Estimate v1: selected_option_key not found in options: ${selectedOptionKey}`);
   }
 
+  // Recommendation semantics are authored upstream; renderer must never infer.
+  // (Documented in ESTIMATE_RENDERER_CONTRACT.md; enforced here only structurally.)
+
+  for (const k of Object.keys(options)) {
+    const opt = options[k] || {};
+    requireString(opt.label, `options.${k}.label`);
+    requireString(opt.name, `options.${k}.name`);
+    if (typeof opt.recommended !== 'boolean') throw new Error(`Estimate v1: options.${k}.recommended must be boolean`);
+    if (typeof opt.is_fully_quoted !== 'boolean') throw new Error(`Estimate v1: options.${k}.is_fully_quoted must be boolean`);
+
+    // Commercial representation (v1 rule): no bare null.
+    const commercialKey = requireOneOf(opt, ['pricing', 'estimated_total', 'price_range'], `options.${k} commercial`);
+
+    // If an option is marked recommended, it must not be a range-only placeholder in v1.
+    if (opt.recommended && commercialKey === 'price_range') {
+      throw new Error(`Estimate v1: recommended option ${k} must not use price_range only`);
+    }
+
+    // All shown options should list line items (even if not fully quoted).
+    if (!Array.isArray(opt.line_items) || opt.line_items.length === 0) {
+      throw new Error(`Estimate v1: options.${k}.line_items[] must be non-empty`);
+    }
+    for (const li of opt.line_items) {
+      if (typeof li !== 'object' || !li) throw new Error(`Estimate v1: options.${k}.line_items[] must be objects`);
+      requireString(li.line_id, `options.${k}.line_items.line_id`);
+      requireString(li.name, `options.${k}.line_items.name`);
+      if (typeof li.taxable !== 'boolean') throw new Error(`Estimate v1: options.${k}.line_items.taxable must be boolean`);
+      if (typeof li.quantity !== 'number') throw new Error(`Estimate v1: options.${k}.line_items.quantity must be number`);
+      if (typeof li.unit_price_cents !== 'number') throw new Error(`Estimate v1: options.${k}.line_items.unit_price_cents must be number`);
+      if (typeof li.amount_cents !== 'number') throw new Error(`Estimate v1: options.${k}.line_items.amount_cents must be number`);
+    }
+
+    // Fully quoted implies fully structured pricing.
+    if (opt.is_fully_quoted) {
+      if (!opt.pricing || typeof opt.pricing !== 'object') {
+        throw new Error(`Estimate v1: options.${k} is_fully_quoted=true requires pricing`);
+      }
+      for (const pk of ['subtotal_cents', 'tax_total_cents', 'total_cents']) {
+        if (typeof opt.pricing[pk] !== 'number') {
+          throw new Error(`Estimate v1: options.${k}.pricing missing numeric ${pk}`);
+        }
+      }
+    }
+  }
+
   const selected = options[selectedOptionKey] || {};
   if (!Array.isArray(selected.line_items) || selected.line_items.length === 0) {
     throw new Error('Estimate v1: selected option must include line_items[]');
@@ -96,17 +147,30 @@ export const assertEstimateInvariants = (estimate) => {
   }
 
   const boundaryPolicy = requireString(estimate.boundary_inheritance_policy, 'boundary_inheritance_policy');
-  if (boundaryPolicy !== 'render_universal_plus_selected_option') {
+  const allowedBoundaryPolicies = ['render_universal_plus_selected_option'];
+  if (!allowedBoundaryPolicies.includes(boundaryPolicy)) {
     throw new Error(
-      `Estimate v1: unsupported boundary_inheritance_policy=${boundaryPolicy} (expected render_universal_plus_selected_option)`
+      `Estimate v1: unsupported boundary_inheritance_policy=${boundaryPolicy} (allowed: ${allowedBoundaryPolicies.join(', ')})`
     );
   }
 
   // Evidence lineage: require at least one structured ref with a traceable uri.
   const refs = Array.isArray(estimate.evidence_refs) ? estimate.evidence_refs : [];
   if (!refs.length) throw new Error('Estimate v1: evidence_refs[] must be non-empty');
-  const traceable = refs.some((r) => r && typeof r === 'object' && typeof r.uri === 'string' && r.uri.trim().length > 0);
+  const traceable = refs.some(
+    (r) =>
+      r &&
+      typeof r === 'object' &&
+      typeof r.type === 'string' &&
+      r.type.trim().length > 0 &&
+      typeof r.id === 'string' &&
+      r.id.trim().length > 0 &&
+      typeof r.uri === 'string' &&
+      r.uri.trim().length > 0
+  );
   if (!traceable) throw new Error('Estimate v1: evidence_refs[] must include at least one ref with a non-empty uri');
+
+  requireString(estimate?.approval_terms?.terms_reference, 'approval_terms.terms_reference');
 
   // Small tenant safety check: if the input path encodes a tenant, it must match JSON.
   // (Many estimate artifacts will live outside artifacts/tenants; this is best-effort.)
@@ -118,4 +182,3 @@ export const formatMoneyUsd = (cents) => {
   const dollars = cents / 100;
   return dollars.toLocaleString('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2 });
 };
-

--- a/command-center/tmp/orchestrator-v2/estimate/_estimate_lib.mjs
+++ b/command-center/tmp/orchestrator-v2/estimate/_estimate_lib.mjs
@@ -1,0 +1,121 @@
+export const normalizeNewlines = (text) => String(text || '').replace(/\r\n/g, '\n');
+
+export const asString = (value) => {
+  if (value === undefined) return 'UNKNOWN';
+  if (value === null) return 'null';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+export const mdInline = (value) => `\`${asString(value)}\``;
+
+const collapseSlashes = (s) => String(s || '').replace(/([^:])\/{2,}/g, '$1/');
+const normPath = (p) => collapseSlashes(asString(p).replaceAll('\\', '/'));
+
+export const canonicalRel = (p) => {
+  const s = normPath(p);
+  if (!s) return s;
+  if (/^[a-zA-Z]:\//.test(s) || s.startsWith('/')) return s;
+  if (s.startsWith('./') || s.startsWith('../')) return s;
+  return `./${s}`;
+};
+
+export const extractTenantFromPath = (p) => {
+  const s = normPath(p);
+  const m = s.match(/(?:^|\/)artifacts\/tenants\/([^/]+)\/runs\//);
+  return m ? m[1] : null;
+};
+
+export const requireObject = (obj, label) => {
+  if (!obj || typeof obj !== 'object') throw new Error(`Estimate v1: missing required object: ${label}`);
+  return obj;
+};
+
+export const requireString = (value, label) => {
+  if (typeof value !== 'string' || value.trim().length === 0) throw new Error(`Estimate v1: missing required string: ${label}`);
+  return value;
+};
+
+export const requireEnum = (value, allowed, label) => {
+  if (!allowed.includes(value)) {
+    throw new Error(`Estimate v1: invalid ${label} (${asString(value)}). Allowed: ${allowed.join(', ')}`);
+  }
+  return value;
+};
+
+export const requireOneOf = (obj, keys, label) => {
+  for (const k of keys) if (obj && Object.prototype.hasOwnProperty.call(obj, k) && obj[k] !== null) return k;
+  throw new Error(`Estimate v1: missing required ${label}; expected one of: ${keys.join(', ')}`);
+};
+
+export const assertEstimateInvariants = (estimate) => {
+  requireObject(estimate, 'root');
+
+  const statusAllowed = ['draft', 'issued', 'approved', 'expired', 'superseded'];
+  requireEnum(estimate.status, statusAllowed, 'status');
+
+  const tenantId = requireString(estimate.tenant_id, 'tenant_id');
+  const options = requireObject(estimate.options, 'options');
+
+  const recommendedKeys = Object.keys(options).filter((k) => options[k]?.recommended === true);
+  if (recommendedKeys.length !== 1) {
+    throw new Error(`Estimate v1: expected exactly one recommended option; got ${recommendedKeys.length}`);
+  }
+
+  const recommendedOptionKey = requireString(
+    estimate?.recommendation?.recommended_option_key,
+    'recommendation.recommended_option_key'
+  );
+  if (recommendedOptionKey !== recommendedKeys[0]) {
+    throw new Error(
+      `Estimate v1: recommended option mismatch (recommended flag=${recommendedKeys[0]} recommendation.recommended_option_key=${recommendedOptionKey})`
+    );
+  }
+
+  const selectedOptionKey = requireString(estimate?.selection?.selected_option_key, 'selection.selected_option_key');
+  if (!Object.prototype.hasOwnProperty.call(options, selectedOptionKey)) {
+    throw new Error(`Estimate v1: selected_option_key not found in options: ${selectedOptionKey}`);
+  }
+
+  const selected = options[selectedOptionKey] || {};
+  if (!Array.isArray(selected.line_items) || selected.line_items.length === 0) {
+    throw new Error('Estimate v1: selected option must include line_items[]');
+  }
+  if (!selected.pricing || typeof selected.pricing !== 'object') {
+    throw new Error('Estimate v1: selected option must include pricing (not only price_range)');
+  }
+  for (const k of ['subtotal_cents', 'tax_total_cents', 'total_cents']) {
+    if (typeof selected.pricing[k] !== 'number') {
+      throw new Error(`Estimate v1: selected option pricing missing numeric ${k}`);
+    }
+  }
+
+  const boundaryPolicy = requireString(estimate.boundary_inheritance_policy, 'boundary_inheritance_policy');
+  if (boundaryPolicy !== 'render_universal_plus_selected_option') {
+    throw new Error(
+      `Estimate v1: unsupported boundary_inheritance_policy=${boundaryPolicy} (expected render_universal_plus_selected_option)`
+    );
+  }
+
+  // Evidence lineage: require at least one structured ref with a traceable uri.
+  const refs = Array.isArray(estimate.evidence_refs) ? estimate.evidence_refs : [];
+  if (!refs.length) throw new Error('Estimate v1: evidence_refs[] must be non-empty');
+  const traceable = refs.some((r) => r && typeof r === 'object' && typeof r.uri === 'string' && r.uri.trim().length > 0);
+  if (!traceable) throw new Error('Estimate v1: evidence_refs[] must include at least one ref with a non-empty uri');
+
+  // Small tenant safety check: if the input path encodes a tenant, it must match JSON.
+  // (Many estimate artifacts will live outside artifacts/tenants; this is best-effort.)
+  return { tenantId };
+};
+
+export const formatMoneyUsd = (cents) => {
+  if (typeof cents !== 'number' || !Number.isFinite(cents)) return 'UNKNOWN';
+  const dollars = cents / 100;
+  return dollars.toLocaleString('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2 });
+};
+

--- a/command-center/tmp/orchestrator-v2/estimate/_render_estimate_raw_lib.mjs
+++ b/command-center/tmp/orchestrator-v2/estimate/_render_estimate_raw_lib.mjs
@@ -1,0 +1,179 @@
+import {
+  asString,
+  assertEstimateInvariants,
+  canonicalRel,
+  mdInline,
+  normalizeNewlines,
+  formatMoneyUsd,
+} from './_estimate_lib.mjs';
+
+const renderEvidenceRefs = (refs) => {
+  const lines = [];
+  lines.push('## Evidence Refs');
+  const arr = Array.isArray(refs) ? refs : [];
+  for (const r of arr) {
+    lines.push(`- type: ${mdInline(r?.type)} id: ${mdInline(r?.id)} uri: ${mdInline(r?.uri)}`);
+  }
+  if (!arr.length) lines.push('- (none)');
+  lines.push('');
+  return lines;
+};
+
+const renderListBlock = (heading, items) => {
+  const lines = [];
+  lines.push(`## ${heading}`);
+  const arr = Array.isArray(items) ? items : [];
+  for (const x of arr) lines.push(`- ${asString(x)}`);
+  if (!arr.length) lines.push('- (none)');
+  lines.push('');
+  return lines;
+};
+
+const renderOptionPricingSummary = (opt) => {
+  if (opt?.pricing) {
+    return `pricing_total=${asString(opt.pricing.total_cents)} (${formatMoneyUsd(opt.pricing.total_cents)})`;
+  }
+  if (opt?.estimated_total) {
+    return `estimated_total=${asString(opt.estimated_total.total_cents)} (${formatMoneyUsd(opt.estimated_total.total_cents)})`;
+  }
+  if (opt?.price_range) {
+    return `price_range=${asString(opt.price_range.min_total_cents)}..${asString(opt.price_range.max_total_cents)} (${formatMoneyUsd(
+      opt.price_range.min_total_cents
+    )}–${formatMoneyUsd(opt.price_range.max_total_cents)})`;
+  }
+  return 'pricing=UNKNOWN';
+};
+
+const renderLineItems = (items) => {
+  const lines = [];
+  const arr = Array.isArray(items) ? items : [];
+  for (const li of arr) {
+    lines.push(
+      `- ${asString(li.line_id)}: ${asString(li.name)} qty=${asString(li.quantity)} unit=${asString(li.unit)} unit_price_cents=${asString(
+        li.unit_price_cents
+      )} amount_cents=${asString(li.amount_cents)} taxable=${asString(li.taxable)}`
+    );
+    if (li?.notes) lines.push(`  - notes: ${asString(li.notes)}`);
+  }
+  if (!arr.length) lines.push('- (none)');
+  return lines;
+};
+
+const renderBoundaries = (b) => {
+  const lines = [];
+  lines.push('### Scope Boundaries');
+  const inc = Array.isArray(b?.included) ? b.included : [];
+  const notInc = Array.isArray(b?.not_included) ? b.not_included : [];
+  lines.push('- included:');
+  for (const x of inc) lines.push(`  - ${asString(x)}`);
+  if (!inc.length) lines.push('  - (none)');
+  lines.push('- not_included:');
+  for (const x of notInc) lines.push(`  - ${asString(x)}`);
+  if (!notInc.length) lines.push('  - (none)');
+  return lines;
+};
+
+export const renderEstimateRawV1 = ({ inputJsonPath, estimateJson }) => {
+  const src = estimateJson || {};
+  assertEstimateInvariants(src);
+
+  const options = src.options || {};
+  const desired = ['good', 'better', 'best'];
+  const optionKeys = [
+    ...desired.filter((k) => Object.prototype.hasOwnProperty.call(options, k)),
+    ...Object.keys(options).filter((k) => !desired.includes(k)).sort(),
+  ];
+
+  const lines = [];
+  lines.push('# Estimate v1 (Raw) — Judgment Contract');
+  lines.push('');
+  lines.push('Contract: `estimate_raw_v1`');
+  lines.push('');
+  lines.push(`Input: \`${canonicalRel(inputJsonPath)}\``);
+  lines.push('');
+
+  lines.push('## Snapshot');
+  lines.push(`- tenant_id: ${mdInline(src.tenant_id)}`);
+  lines.push(`- estimate_record_id: ${mdInline(src.estimate_record_id)}`);
+  lines.push(`- estimate_number: ${mdInline(src.estimate_number)}`);
+  lines.push(`- job_id: ${mdInline(src.job_id)}`);
+  lines.push(`- status: ${mdInline(src.status)}`);
+  lines.push(`- issue_date: ${mdInline(src.issue_date)}`);
+  lines.push(`- valid_through_date: ${mdInline(src.valid_through_date)}`);
+  lines.push(`- timezone: ${mdInline(src.timezone)}`);
+  lines.push(`- currency_code: ${mdInline(src.currency_code)}`);
+  lines.push(`- version_label: ${mdInline(src.version_label)}`);
+  lines.push(`- terms_reference: ${mdInline(src?.approval_terms?.terms_reference)}`);
+  lines.push(`- boundary_inheritance_policy: ${mdInline(src.boundary_inheritance_policy)}`);
+  lines.push(`- recommended_option_key: ${mdInline(src?.recommendation?.recommended_option_key)}`);
+  lines.push(`- selected_option_key: ${mdInline(src?.selection?.selected_option_key)}`);
+  lines.push('');
+
+  lines.push(...renderEvidenceRefs(src.evidence_refs));
+
+  lines.push('## Situation Summary');
+  lines.push(`- headline: ${mdInline(src?.situation_summary?.headline)}`);
+  lines.push('- observations:');
+  for (const o of src?.situation_summary?.observations || []) lines.push(`  - ${asString(o)}`);
+  if (!(src?.situation_summary?.observations || []).length) lines.push('  - (none)');
+  lines.push('- notes:');
+  for (const n of src?.situation_summary?.notes || []) lines.push(`  - ${asString(n)}`);
+  if (!(src?.situation_summary?.notes || []).length) lines.push('  - (none)');
+  lines.push('');
+
+  lines.push('## Risk & Impact');
+  lines.push(`- risk_level: ${mdInline(src?.risk_impact?.risk_level)}`);
+  lines.push('- customer_facing_impacts:');
+  for (const x of src?.risk_impact?.customer_facing_impacts || []) lines.push(`  - ${asString(x)}`);
+  if (!(src?.risk_impact?.customer_facing_impacts || []).length) lines.push('  - (none)');
+  lines.push('- what_if_ignored:');
+  for (const x of src?.risk_impact?.what_if_ignored || []) lines.push(`  - ${asString(x)}`);
+  if (!(src?.risk_impact?.what_if_ignored || []).length) lines.push('  - (none)');
+  lines.push('');
+
+  lines.push('## Recommendation');
+  lines.push(`- recommended_option_key: ${mdInline(src?.recommendation?.recommended_option_key)}`);
+  lines.push(`- reason: ${mdInline(src?.recommendation?.reason)}`);
+  lines.push('');
+
+  lines.push('## Options');
+  for (const k of optionKeys) {
+    const opt = options[k] || {};
+    lines.push(`### Option: ${asString(k)}`);
+    lines.push(`- label: ${mdInline(opt.label)}`);
+    lines.push(`- name: ${mdInline(opt.name)}`);
+    lines.push(`- recommended: ${mdInline(opt.recommended)}`);
+    lines.push(`- is_fully_quoted: ${mdInline(opt.is_fully_quoted)}`);
+    lines.push(`- commercial: ${mdInline(renderOptionPricingSummary(opt))}`);
+    lines.push('- line_items:');
+    for (const liLine of renderLineItems(opt.line_items)) lines.push(`  ${liLine}`);
+
+    if (opt?.pricing) {
+      lines.push('- pricing:');
+      lines.push(`  - subtotal_cents: ${mdInline(opt.pricing.subtotal_cents)}`);
+      lines.push(`  - tax_total_cents: ${mdInline(opt.pricing.tax_total_cents)}`);
+      lines.push(`  - total_cents: ${mdInline(opt.pricing.total_cents)}`);
+    } else if (opt?.estimated_total) {
+      lines.push('- estimated_total:');
+      lines.push(`  - total_cents: ${mdInline(opt.estimated_total.total_cents)}`);
+      if (opt.estimated_total?.notes) lines.push(`  - notes: ${mdInline(opt.estimated_total.notes)}`);
+    } else if (opt?.price_range) {
+      lines.push('- price_range:');
+      lines.push(`  - min_total_cents: ${mdInline(opt.price_range.min_total_cents)}`);
+      lines.push(`  - max_total_cents: ${mdInline(opt.price_range.max_total_cents)}`);
+      if (opt.price_range?.notes) lines.push(`  - notes: ${mdInline(opt.price_range.notes)}`);
+    }
+
+    for (const bLine of renderBoundaries(opt.scope_boundaries || {})) lines.push(bLine);
+    lines.push('');
+  }
+
+  lines.push(...renderListBlock('Universal Boundaries — Not Included', src?.universal_boundaries?.not_included));
+
+  lines.push('## Approval Terms');
+  lines.push(`- terms_reference: ${mdInline(src?.approval_terms?.terms_reference)}`);
+  lines.push(`- approval_copy: ${mdInline(src?.approval_terms?.approval_copy)}`);
+  lines.push('');
+
+  return normalizeNewlines(lines.join('\n') + '\n');
+};

--- a/command-center/tmp/orchestrator-v2/estimate/_render_estimate_review_lib.mjs
+++ b/command-center/tmp/orchestrator-v2/estimate/_render_estimate_review_lib.mjs
@@ -1,0 +1,140 @@
+import {
+  asString,
+  assertEstimateInvariants,
+  canonicalRel,
+  mdInline,
+  normalizeNewlines,
+  formatMoneyUsd,
+} from './_estimate_lib.mjs';
+
+const moneyLine = (label, cents) => `${label}: ${formatMoneyUsd(cents)} (${asString(cents)}¢)`;
+
+const optionTotalText = (opt) => {
+  if (opt?.pricing?.total_cents !== undefined) return formatMoneyUsd(opt.pricing.total_cents);
+  if (opt?.estimated_total?.total_cents !== undefined) return formatMoneyUsd(opt.estimated_total.total_cents);
+  if (opt?.price_range) {
+    return `${formatMoneyUsd(opt.price_range.min_total_cents)}–${formatMoneyUsd(opt.price_range.max_total_cents)}`;
+  }
+  return 'TBD';
+};
+
+export const renderEstimateReviewV1 = ({
+  inputJsonPath,
+  reviewDocPath,
+  rawDocPath,
+  estimateJson,
+}) => {
+  const src = estimateJson || {};
+  assertEstimateInvariants(src);
+
+  const options = src.options || {};
+  const recommendedKey = src?.recommendation?.recommended_option_key;
+  const selectedKey = src?.selection?.selected_option_key;
+  const selected = options[selectedKey] || {};
+  const recommended = options[recommendedKey] || {};
+
+  const lines = [];
+  lines.push('# Estimate — Review Summary');
+  lines.push('');
+  lines.push('Contract: `estimate_review_v1`');
+  lines.push('Audience: internal/client-facing (human-optimized)');
+  lines.push('SSOT: Estimate raw contract doc + estimate judgment JSON (no extra interpretation).');
+  lines.push('');
+
+  lines.push('## Inputs');
+  lines.push(`- Estimate judgment JSON: ${mdInline(canonicalRel(inputJsonPath))}`);
+  lines.push(`- Estimate raw contract doc: ${mdInline(canonicalRel(rawDocPath))}`);
+  lines.push('');
+
+  lines.push('## Snapshot');
+  lines.push(`- tenant_id: ${mdInline(src.tenant_id)}`);
+  lines.push(`- estimate_number: ${mdInline(src.estimate_number)}`);
+  lines.push(`- job_id: ${mdInline(src.job_id)}`);
+  lines.push(`- status: ${mdInline(src.status)}`);
+  lines.push(`- issue_date: ${mdInline(src.issue_date)}`);
+  lines.push(`- valid_through_date: ${mdInline(src.valid_through_date)}`);
+  lines.push(`- version: ${mdInline(src.version_label)}`);
+  lines.push(`- terms_reference: ${mdInline(src?.approval_terms?.terms_reference)}`);
+  lines.push('');
+
+  lines.push('## Situation');
+  lines.push(asString(src?.situation_summary?.headline));
+  lines.push('');
+
+  lines.push('## Recommendation');
+  lines.push(`Recommended option: ${mdInline(recommendedKey)} — ${asString(recommended?.name)} (${optionTotalText(recommended)})`);
+  lines.push(asString(src?.recommendation?.reason));
+  lines.push('');
+
+  lines.push('## Options');
+  for (const k of Object.keys(options)) {
+    const opt = options[k] || {};
+    const tags = [];
+    if (opt.recommended) tags.push('recommended');
+    if (k === selectedKey) tags.push('selected');
+    const tagText = tags.length ? ` [${tags.join(', ')}]` : '';
+    lines.push(`- ${asString(opt.label)} (${k})${tagText}: ${asString(opt.name)} — ${optionTotalText(opt)}${opt.is_fully_quoted ? '' : ' (not fully quoted)'}`);
+  }
+  lines.push('');
+
+  lines.push('## Selected Scope (What You Are Approving)');
+  for (const li of selected.line_items || []) {
+    lines.push(`- ${asString(li.name)} x${asString(li.quantity)}: ${formatMoneyUsd(li.amount_cents)}`);
+  }
+  lines.push('');
+
+  lines.push('## Investment');
+  if (selected.pricing) {
+    lines.push(`- ${moneyLine('Subtotal', selected.pricing.subtotal_cents)}`);
+    lines.push(`- ${moneyLine('Tax', selected.pricing.tax_total_cents)}`);
+    lines.push(`- ${moneyLine('Total', selected.pricing.total_cents)}`);
+  } else if (selected.price_range) {
+    lines.push(`- Total (range): ${optionTotalText(selected)}`);
+  } else if (selected.estimated_total) {
+    lines.push(`- Total (estimate): ${optionTotalText(selected)}`);
+  }
+  lines.push('');
+
+  lines.push('## Scope Boundaries (How to Read This)');
+  lines.push(`Boundary policy: ${mdInline(src.boundary_inheritance_policy)}`);
+  lines.push('Renderer behavior: show universal not-included + selected option boundaries (included + not included).');
+  lines.push('');
+
+  lines.push('## Not Included (Universal)');
+  for (const x of src?.universal_boundaries?.not_included || []) lines.push(`- ${asString(x)}`);
+  if (!(src?.universal_boundaries?.not_included || []).length) lines.push('- (none)');
+  lines.push('');
+
+  lines.push('## Included / Not Included (Selected Option)');
+  const sb = selected.scope_boundaries || {};
+  lines.push('- Included:');
+  for (const x of sb.included || []) lines.push(`  - ${asString(x)}`);
+  if (!(sb.included || []).length) lines.push('  - (none)');
+  lines.push('- Not Included:');
+  for (const x of sb.not_included || []) lines.push(`  - ${asString(x)}`);
+  if (!(sb.not_included || []).length) lines.push('  - (none)');
+  lines.push('');
+
+  lines.push('## Approval Terms');
+  lines.push(asString(src?.approval_terms?.approval_copy));
+  lines.push('');
+
+  lines.push('## Evidence');
+  for (const r of src.evidence_refs || []) {
+    lines.push(`- ${asString(r.type)} ${asString(r.id)}: ${asString(r.uri)}`);
+  }
+  if (!(src.evidence_refs || []).length) lines.push('- (none)');
+  lines.push('');
+
+  lines.push('## Re-render');
+  lines.push(`- Raw: \`node tmp/orchestrator-v2/estimate/render_estimate_raw.mjs ${canonicalRel(inputJsonPath)} ${canonicalRel(rawDocPath)}\``);
+  lines.push(
+    `- Review: \`node tmp/orchestrator-v2/estimate/render_estimate_review.mjs --json ${canonicalRel(
+      inputJsonPath
+    )} --out ${canonicalRel(reviewDocPath)} --raw ${canonicalRel(rawDocPath)}\``
+  );
+  lines.push('');
+
+  return normalizeNewlines(lines.join('\n') + '\n');
+};
+

--- a/command-center/tmp/orchestrator-v2/estimate/estimate_judgment.sample.json
+++ b/command-center/tmp/orchestrator-v2/estimate/estimate_judgment.sample.json
@@ -1,0 +1,211 @@
+{
+  "schema_version": "estimate_judgment_v1.0",
+  "tenant_id": "vent-guys",
+
+  "estimate_record_id": "ESTREC-SAMPLE-2026-04-09-001",
+  "estimate_number": "20261094",
+  "job_id": "PENDING-687115",
+
+  "status": "draft",
+  "issue_date": "2026-04-09",
+  "valid_through_date": "2026-04-15",
+  "timezone": "America/New_York",
+  "currency_code": "USD",
+  "version_label": "v1",
+
+  "prepared_for": {
+    "name": "ERRON FAYSON",
+    "email": "info@vent-guys.com",
+    "phone": "3217478194",
+    "property_label": "ERRON FAYSON Property"
+  },
+
+  "service_location": {
+    "location_name": "ERRON FAYSON Property",
+    "address_line_1": null,
+    "address_line_2": null,
+    "city": null,
+    "state": null,
+    "postal_code": null,
+    "country_code": "US"
+  },
+
+  "evidence_refs": [
+    {
+      "type": "crm_quote_pdf",
+      "id": "20261094",
+      "uri": "./source/The Vent Guys CRM_test001.pdf"
+    }
+  ],
+
+  "situation_summary": {
+    "headline": "Listing-ready HVAC refresh with targeted return-side improvements",
+    "observations": [
+      "This quote is intended to support a listing-ready refresh and return-side airflow improvements."
+    ],
+    "notes": [
+      "Insert technician evaluation notes/photos here if available. Keep language descriptive (no over-claiming)."
+    ]
+  },
+
+  "risk_impact": {
+    "risk_level": "moderate",
+    "customer_facing_impacts": [
+      "Comfort and perceived air quality can impact walkthrough confidence.",
+      "Skipping the refresh may leave avoidable dust/odor sensitivity for occupants or buyers."
+    ],
+    "what_if_ignored": [
+      "The system may remain functional but not presentation-optimized."
+    ]
+  },
+
+  "recommendation": {
+    "recommended_option_key": "better",
+    "reason": "Best balance of presentation, comfort, and time-to-schedule without expanding into custom system-wide balancing."
+  },
+
+  "approval_terms": {
+    "terms_reference": "standard_estimate_terms_v1",
+    "approval_copy": "Approve this estimate to lock scope, pricing, and scheduling. Any scope changes after approval require a formal change order tied to this estimate version."
+  },
+
+  "boundary_inheritance_policy": "render_universal_plus_selected_option",
+
+  "universal_boundaries": {
+    "not_included": [
+      "Dryer appliance repair or replacement",
+      "Hidden damage, code upgrades, or material replacement not listed",
+      "Access conditions that materially change labor or equipment requirements"
+    ]
+  },
+
+  "options": {
+    "good": {
+      "label": "GOOD",
+      "name": "Realtor Refresh (baseline)",
+      "recommended": false,
+      "is_fully_quoted": true,
+      "line_items": [
+        {
+          "line_id": "LI-GOOD-001",
+          "name": "Package: Realtor Refresh",
+          "quantity": 1,
+          "unit": "ea",
+          "unit_price_cents": 59900,
+          "amount_cents": 59900,
+          "taxable": false
+        }
+      ],
+      "pricing": {
+        "subtotal_cents": 59900,
+        "tax_total_cents": 0,
+        "total_cents": 59900
+      },
+      "scope_boundaries": {
+        "included": [
+          "Package: Realtor Refresh",
+          "Arrival-ready documentation and service coordination"
+        ],
+        "not_included": [
+          "Additional return adjustments (unless added by change order)",
+          "Dryer appliance repair or replacement",
+          "Hidden damage, code upgrades, or material replacement not listed",
+          "Access conditions that materially change labor or equipment requirements"
+        ]
+      }
+    },
+
+    "better": {
+      "label": "BETTER",
+      "name": "Realtor Refresh + Additional Returns (recommended)",
+      "recommended": true,
+      "is_fully_quoted": true,
+      "line_items": [
+        {
+          "line_id": "LI-BETTER-001",
+          "name": "Package: Realtor Refresh",
+          "quantity": 1,
+          "unit": "ea",
+          "unit_price_cents": 59900,
+          "amount_cents": 59900,
+          "taxable": false
+        },
+        {
+          "line_id": "LI-BETTER-002",
+          "name": "Additional Return (Each)",
+          "quantity": 5,
+          "unit": "ea",
+          "unit_price_cents": 4500,
+          "amount_cents": 22500,
+          "taxable": false
+        }
+      ],
+      "pricing": {
+        "subtotal_cents": 82400,
+        "tax_total_cents": 0,
+        "total_cents": 82400
+      },
+      "scope_boundaries": {
+        "included": [
+          "Package: Realtor Refresh",
+          "Additional Return (Each) x5",
+          "Arrival-ready documentation and service coordination"
+        ],
+        "not_included": [
+          "Dryer appliance repair or replacement",
+          "Hidden damage, code upgrades, or material replacement not listed",
+          "Access conditions that materially change labor or equipment requirements"
+        ]
+      }
+    },
+
+    "best": {
+      "label": "BEST",
+      "name": "Full Return Optimization (custom scope)",
+      "recommended": false,
+      "is_fully_quoted": false,
+      "line_items": [
+        {
+          "line_id": "LI-BEST-001",
+          "name": "Package: Realtor Refresh",
+          "quantity": 1,
+          "unit": "ea",
+          "unit_price_cents": 59900,
+          "amount_cents": 59900,
+          "taxable": false
+        },
+        {
+          "line_id": "LI-BEST-002",
+          "name": "Additional Return Adjustments (beyond initial 5)",
+          "quantity": 1,
+          "unit": "lot",
+          "unit_price_cents": 0,
+          "amount_cents": 0,
+          "taxable": false,
+          "notes": "Final quantity/scope priced after confirmation."
+        }
+      ],
+      "price_range": {
+        "min_total_cents": 82400,
+        "max_total_cents": 129900,
+        "notes": "Best option is a scoped optimization. Range is a placeholder for v1 sample; final price is issued after confirmed scope."
+      },
+      "scope_boundaries": {
+        "included": [
+          "Package: Realtor Refresh",
+          "Expanded return-side optimization (scoped after confirmation)",
+          "Arrival-ready documentation and service coordination"
+        ],
+        "not_included": [
+          "Dryer appliance repair or replacement",
+          "Hidden damage, code upgrades, or material replacement not listed",
+          "Access conditions that materially change labor or equipment requirements"
+        ]
+      }
+    }
+  },
+
+  "selection": {
+    "selected_option_key": "better"
+  }
+}

--- a/command-center/tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.missing_evidence_uri.json
+++ b/command-center/tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.missing_evidence_uri.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "estimate_judgment_v1.0",
+  "tenant_id": "vent-guys",
+  "estimate_record_id": "ESTREC-BAD-EVIDENCE",
+  "estimate_number": "BAD-0005",
+  "job_id": "JOB-BAD-0005",
+  "status": "draft",
+  "issue_date": "2026-04-09",
+  "valid_through_date": "2026-04-15",
+  "timezone": "America/New_York",
+  "currency_code": "USD",
+  "version_label": "v1",
+  "evidence_refs": [
+    { "type": "crm_quote_pdf", "id": "BAD-0005", "uri": "" }
+  ],
+  "situation_summary": { "headline": "Bad fixture", "observations": [], "notes": [] },
+  "risk_impact": { "risk_level": "low", "customer_facing_impacts": [], "what_if_ignored": [] },
+  "recommendation": { "recommended_option_key": "better", "reason": "Bad fixture." },
+  "approval_terms": { "terms_reference": "standard_estimate_terms_v1", "approval_copy": "Bad fixture." },
+  "boundary_inheritance_policy": "render_universal_plus_selected_option",
+  "universal_boundaries": { "not_included": [] },
+  "options": {
+    "better": {
+      "label": "BETTER",
+      "name": "Better",
+      "recommended": true,
+      "is_fully_quoted": true,
+      "line_items": [
+        { "line_id": "LI-2", "name": "Y", "quantity": 1, "unit": "ea", "unit_price_cents": 200, "amount_cents": 200, "taxable": false }
+      ],
+      "pricing": { "subtotal_cents": 200, "tax_total_cents": 0, "total_cents": 200 },
+      "scope_boundaries": { "included": [], "not_included": [] }
+    }
+  },
+  "selection": { "selected_option_key": "better" }
+}
+

--- a/command-center/tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.multiple_recommended.json
+++ b/command-center/tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.multiple_recommended.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "estimate_judgment_v1.0",
+  "tenant_id": "vent-guys",
+  "estimate_record_id": "ESTREC-BAD-MULTI-REC",
+  "estimate_number": "BAD-0001",
+  "job_id": "JOB-BAD-0001",
+  "status": "draft",
+  "issue_date": "2026-04-09",
+  "valid_through_date": "2026-04-15",
+  "timezone": "America/New_York",
+  "currency_code": "USD",
+  "version_label": "v1",
+  "evidence_refs": [
+    { "type": "crm_quote_pdf", "id": "BAD-0001", "uri": "./source/BAD.pdf" }
+  ],
+  "situation_summary": { "headline": "Bad fixture", "observations": [], "notes": [] },
+  "risk_impact": { "risk_level": "low", "customer_facing_impacts": [], "what_if_ignored": [] },
+  "recommendation": { "recommended_option_key": "better", "reason": "Bad fixture." },
+  "approval_terms": { "terms_reference": "standard_estimate_terms_v1", "approval_copy": "Bad fixture." },
+  "boundary_inheritance_policy": "render_universal_plus_selected_option",
+  "universal_boundaries": { "not_included": [] },
+  "options": {
+    "good": {
+      "label": "GOOD",
+      "name": "Good",
+      "recommended": true,
+      "is_fully_quoted": true,
+      "line_items": [
+        { "line_id": "LI-1", "name": "X", "quantity": 1, "unit": "ea", "unit_price_cents": 100, "amount_cents": 100, "taxable": false }
+      ],
+      "pricing": { "subtotal_cents": 100, "tax_total_cents": 0, "total_cents": 100 },
+      "scope_boundaries": { "included": [], "not_included": [] }
+    },
+    "better": {
+      "label": "BETTER",
+      "name": "Better",
+      "recommended": true,
+      "is_fully_quoted": true,
+      "line_items": [
+        { "line_id": "LI-2", "name": "Y", "quantity": 1, "unit": "ea", "unit_price_cents": 200, "amount_cents": 200, "taxable": false }
+      ],
+      "pricing": { "subtotal_cents": 200, "tax_total_cents": 0, "total_cents": 200 },
+      "scope_boundaries": { "included": [], "not_included": [] }
+    }
+  },
+  "selection": { "selected_option_key": "better" }
+}
+

--- a/command-center/tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.recommended_key_mismatch.json
+++ b/command-center/tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.recommended_key_mismatch.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "estimate_judgment_v1.0",
+  "tenant_id": "vent-guys",
+  "estimate_record_id": "ESTREC-BAD-REC-MISMATCH",
+  "estimate_number": "BAD-0002",
+  "job_id": "JOB-BAD-0002",
+  "status": "draft",
+  "issue_date": "2026-04-09",
+  "valid_through_date": "2026-04-15",
+  "timezone": "America/New_York",
+  "currency_code": "USD",
+  "version_label": "v1",
+  "evidence_refs": [
+    { "type": "crm_quote_pdf", "id": "BAD-0002", "uri": "./source/BAD.pdf" }
+  ],
+  "situation_summary": { "headline": "Bad fixture", "observations": [], "notes": [] },
+  "risk_impact": { "risk_level": "low", "customer_facing_impacts": [], "what_if_ignored": [] },
+  "recommendation": { "recommended_option_key": "good", "reason": "Bad fixture." },
+  "approval_terms": { "terms_reference": "standard_estimate_terms_v1", "approval_copy": "Bad fixture." },
+  "boundary_inheritance_policy": "render_universal_plus_selected_option",
+  "universal_boundaries": { "not_included": [] },
+  "options": {
+    "good": {
+      "label": "GOOD",
+      "name": "Good",
+      "recommended": false,
+      "is_fully_quoted": true,
+      "line_items": [
+        { "line_id": "LI-1", "name": "X", "quantity": 1, "unit": "ea", "unit_price_cents": 100, "amount_cents": 100, "taxable": false }
+      ],
+      "pricing": { "subtotal_cents": 100, "tax_total_cents": 0, "total_cents": 100 },
+      "scope_boundaries": { "included": [], "not_included": [] }
+    },
+    "better": {
+      "label": "BETTER",
+      "name": "Better",
+      "recommended": true,
+      "is_fully_quoted": true,
+      "line_items": [
+        { "line_id": "LI-2", "name": "Y", "quantity": 1, "unit": "ea", "unit_price_cents": 200, "amount_cents": 200, "taxable": false }
+      ],
+      "pricing": { "subtotal_cents": 200, "tax_total_cents": 0, "total_cents": 200 },
+      "scope_boundaries": { "included": [], "not_included": [] }
+    }
+  },
+  "selection": { "selected_option_key": "better" }
+}
+

--- a/command-center/tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.selected_missing_pricing.json
+++ b/command-center/tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.selected_missing_pricing.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "estimate_judgment_v1.0",
+  "tenant_id": "vent-guys",
+  "estimate_record_id": "ESTREC-BAD-SEL-NO-PRICING",
+  "estimate_number": "BAD-0003",
+  "job_id": "JOB-BAD-0003",
+  "status": "draft",
+  "issue_date": "2026-04-09",
+  "valid_through_date": "2026-04-15",
+  "timezone": "America/New_York",
+  "currency_code": "USD",
+  "version_label": "v1",
+  "evidence_refs": [
+    { "type": "crm_quote_pdf", "id": "BAD-0003", "uri": "./source/BAD.pdf" }
+  ],
+  "situation_summary": { "headline": "Bad fixture", "observations": [], "notes": [] },
+  "risk_impact": { "risk_level": "low", "customer_facing_impacts": [], "what_if_ignored": [] },
+  "recommendation": { "recommended_option_key": "good", "reason": "Bad fixture." },
+  "approval_terms": { "terms_reference": "standard_estimate_terms_v1", "approval_copy": "Bad fixture." },
+  "boundary_inheritance_policy": "render_universal_plus_selected_option",
+  "universal_boundaries": { "not_included": [] },
+  "options": {
+    "good": {
+      "label": "GOOD",
+      "name": "Good",
+      "recommended": true,
+      "is_fully_quoted": true,
+      "line_items": [
+        { "line_id": "LI-1", "name": "X", "quantity": 1, "unit": "ea", "unit_price_cents": 100, "amount_cents": 100, "taxable": false }
+      ],
+      "pricing": { "subtotal_cents": 100, "tax_total_cents": 0, "total_cents": 100 },
+      "scope_boundaries": { "included": [], "not_included": [] }
+    },
+    "better": {
+      "label": "BETTER",
+      "name": "Better",
+      "recommended": false,
+      "is_fully_quoted": false,
+      "line_items": [
+        { "line_id": "LI-2", "name": "Y", "quantity": 1, "unit": "ea", "unit_price_cents": 200, "amount_cents": 200, "taxable": false }
+      ],
+      "price_range": { "min_total_cents": 200, "max_total_cents": 300, "notes": "Bad fixture." },
+      "scope_boundaries": { "included": [], "not_included": [] }
+    }
+  },
+  "selection": { "selected_option_key": "better" }
+}

--- a/command-center/tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.unknown_boundary_policy.json
+++ b/command-center/tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.unknown_boundary_policy.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "estimate_judgment_v1.0",
+  "tenant_id": "vent-guys",
+  "estimate_record_id": "ESTREC-BAD-BOUNDARY-POLICY",
+  "estimate_number": "BAD-0004",
+  "job_id": "JOB-BAD-0004",
+  "status": "draft",
+  "issue_date": "2026-04-09",
+  "valid_through_date": "2026-04-15",
+  "timezone": "America/New_York",
+  "currency_code": "USD",
+  "version_label": "v1",
+  "evidence_refs": [
+    { "type": "crm_quote_pdf", "id": "BAD-0004", "uri": "./source/BAD.pdf" }
+  ],
+  "situation_summary": { "headline": "Bad fixture", "observations": [], "notes": [] },
+  "risk_impact": { "risk_level": "low", "customer_facing_impacts": [], "what_if_ignored": [] },
+  "recommendation": { "recommended_option_key": "better", "reason": "Bad fixture." },
+  "approval_terms": { "terms_reference": "standard_estimate_terms_v1", "approval_copy": "Bad fixture." },
+  "boundary_inheritance_policy": "render_magic_maybe",
+  "universal_boundaries": { "not_included": [] },
+  "options": {
+    "better": {
+      "label": "BETTER",
+      "name": "Better",
+      "recommended": true,
+      "is_fully_quoted": true,
+      "line_items": [
+        { "line_id": "LI-2", "name": "Y", "quantity": 1, "unit": "ea", "unit_price_cents": 200, "amount_cents": 200, "taxable": false }
+      ],
+      "pricing": { "subtotal_cents": 200, "tax_total_cents": 0, "total_cents": 200 },
+      "scope_boundaries": { "included": [], "not_included": [] }
+    }
+  },
+  "selection": { "selected_option_key": "better" }
+}
+

--- a/command-center/tmp/orchestrator-v2/estimate/render_estimate_raw.mjs
+++ b/command-center/tmp/orchestrator-v2/estimate/render_estimate_raw.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { renderEstimateRawV1 } from './_render_estimate_raw_lib.mjs';
+
+const [inputPath, outputPath] = process.argv.slice(2);
+if (!inputPath || !outputPath) {
+  console.error('Usage: node tmp/orchestrator-v2/estimate/render_estimate_raw.mjs <estimate_judgment.json> <out.md>');
+  process.exit(2);
+}
+
+const readJson = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
+const ensureDir = (p) => fs.mkdirSync(path.dirname(p), { recursive: true });
+
+const estimateJson = readJson(inputPath);
+const out = renderEstimateRawV1({ inputJsonPath: inputPath, estimateJson });
+
+ensureDir(outputPath);
+fs.writeFileSync(outputPath, out, 'utf8');
+

--- a/command-center/tmp/orchestrator-v2/estimate/render_estimate_review.mjs
+++ b/command-center/tmp/orchestrator-v2/estimate/render_estimate_review.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { renderEstimateReviewV1 } from './_render_estimate_review_lib.mjs';
+
+const parseArgs = (argv) => {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') args.json = argv[++i];
+    else if (a === '--out') args.out = argv[++i];
+    else if (a === '--raw') args.raw = argv[++i];
+    else if (a === '--help') args.help = true;
+  }
+  return args;
+};
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help || !args.json || !args.out) {
+  console.error(
+    'Usage:\n' +
+      '  node tmp/orchestrator-v2/estimate/render_estimate_review.mjs --json <estimate_judgment.json> --out <review.md> [--raw <raw.md>]'
+  );
+  process.exit(2);
+}
+
+const readJson = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
+const ensureDir = (p) => fs.mkdirSync(path.dirname(p), { recursive: true });
+const existsFile = (p) => {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+};
+
+const deriveSiblingRaw = (reviewOutPath) => {
+  if (!reviewOutPath) return null;
+  const candidate = path.join(path.dirname(reviewOutPath), 'estimate_raw.md');
+  return existsFile(candidate) ? candidate : null;
+};
+
+const estimateJson = readJson(args.json);
+const rawDocPath = args.raw || deriveSiblingRaw(args.out) || './tmp/orchestrator-v2/estimate/_baseline_estimate_raw.md';
+
+const out = renderEstimateReviewV1({
+  inputJsonPath: args.json,
+  reviewDocPath: args.out,
+  rawDocPath,
+  estimateJson,
+});
+
+ensureDir(args.out);
+fs.writeFileSync(args.out, out, 'utf8');
+

--- a/command-center/tmp/orchestrator-v2/estimate/run_estimate_fixtures.mjs
+++ b/command-center/tmp/orchestrator-v2/estimate/run_estimate_fixtures.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { assertEstimateInvariants } from './_estimate_lib.mjs';
+
+const repoRoot = process.cwd();
+const fixturesDir = path.resolve(repoRoot, 'tmp/orchestrator-v2/estimate/fixtures');
+
+const fail = (msg) => {
+  console.error(`ESTIMATE FIXTURES: FAILED\n\n${msg}\n`);
+  process.exit(1);
+};
+
+const ok = () => {
+  console.log('ESTIMATE FIXTURES: PASSED');
+};
+
+const readJson = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
+
+const cases = [
+  {
+    id: 'good_sample',
+    expect: 'PASS',
+    path: 'tmp/orchestrator-v2/estimate/estimate_judgment.sample.json',
+  },
+  {
+    id: 'bad_multiple_recommended',
+    expect: 'FAIL',
+    path: 'tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.multiple_recommended.json',
+    contains: 'exactly one recommended option',
+  },
+  {
+    id: 'bad_recommended_key_mismatch',
+    expect: 'FAIL',
+    path: 'tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.recommended_key_mismatch.json',
+    contains: 'recommended option mismatch',
+  },
+  {
+    id: 'bad_selected_missing_pricing',
+    expect: 'FAIL',
+    path: 'tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.selected_missing_pricing.json',
+    contains: 'selected option must include pricing',
+  },
+  {
+    id: 'bad_unknown_boundary_policy',
+    expect: 'FAIL',
+    path: 'tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.unknown_boundary_policy.json',
+    contains: 'unsupported boundary_inheritance_policy',
+  },
+  {
+    id: 'bad_missing_evidence_uri',
+    expect: 'FAIL',
+    path: 'tmp/orchestrator-v2/estimate/fixtures/estimate_judgment.bad.missing_evidence_uri.json',
+    contains: 'evidence_refs[] must include',
+  },
+];
+
+const failures = [];
+
+for (const c of cases) {
+  const abs = path.resolve(repoRoot, c.path);
+  if (!fs.existsSync(abs)) {
+    failures.push(`${c.id}: missing fixture file: ${c.path}`);
+    continue;
+  }
+  try {
+    const json = readJson(abs);
+    assertEstimateInvariants(json);
+    if (c.expect !== 'PASS') failures.push(`${c.id}: expected FAIL, got PASS`);
+  } catch (e) {
+    const msg = e?.message || String(e);
+    if (c.expect !== 'FAIL') failures.push(`${c.id}: expected PASS, got FAIL: ${msg}`);
+    if (c.expect === 'FAIL' && c.contains && !msg.includes(c.contains)) {
+      failures.push(`${c.id}: failure message mismatch; expected to contain "${c.contains}", got "${msg}"`);
+    }
+  }
+}
+
+if (failures.length) fail(failures.join('\n'));
+ok();
+

--- a/command-center/tmp/orchestrator-v2/estimate/validate_estimate_raw_output.mjs
+++ b/command-center/tmp/orchestrator-v2/estimate/validate_estimate_raw_output.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import { normalizeNewlines } from './_estimate_lib.mjs';
+import { renderEstimateRawV1 } from './_render_estimate_raw_lib.mjs';
+
+const parseArgs = (argv) => {
+  const args = { mode: 'exact' };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--mode') args.mode = argv[++i];
+    else if (a === '--json') args.json = argv[++i];
+    else if (a === '--doc') args.doc = argv[++i];
+    else if (a === '--help') args.help = true;
+  }
+  return args;
+};
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help || !args.doc || (args.mode === 'exact' && !args.json)) {
+  console.error(
+    'Usage:\n' +
+      '  node tmp/orchestrator-v2/estimate/validate_estimate_raw_output.mjs --mode exact --json <estimate_judgment.json> --doc <estimate_raw.md>\n' +
+      '  node tmp/orchestrator-v2/estimate/validate_estimate_raw_output.mjs --mode structural --doc <estimate_raw.md>'
+  );
+  process.exit(2);
+}
+
+const docText = normalizeNewlines(fs.readFileSync(args.doc, 'utf8'));
+
+const requiredHeadings = [
+  '# Estimate v1 (Raw) — Judgment Contract',
+  '## Snapshot',
+  '## Evidence Refs',
+  '## Situation Summary',
+  '## Risk & Impact',
+  '## Recommendation',
+  '## Options',
+  '## Universal Boundaries — Not Included',
+  '## Approval Terms',
+];
+
+const idx = (h) => docText.indexOf(h);
+for (const h of requiredHeadings) {
+  if (idx(h) < 0) {
+    console.error(`ESTIMATE RAW VALIDATION: FAILED\n\nMissing heading: ${h}`);
+    process.exit(1);
+  }
+}
+for (let i = 1; i < requiredHeadings.length; i++) {
+  if (idx(requiredHeadings[i]) <= idx(requiredHeadings[i - 1])) {
+    console.error(
+      'ESTIMATE RAW VALIDATION: FAILED\n\nHeading order mismatch:\n' +
+        `- expected: ${requiredHeadings[i - 1]} before ${requiredHeadings[i]}`
+    );
+    process.exit(1);
+  }
+}
+
+if (args.mode === 'structural') {
+  console.log('ESTIMATE RAW VALIDATION: PASSED (structural)');
+  process.exit(0);
+}
+
+const estimateJson = JSON.parse(fs.readFileSync(args.json, 'utf8'));
+const expected = renderEstimateRawV1({ inputJsonPath: args.json, estimateJson });
+const normExpected = normalizeNewlines(expected).trimEnd() + '\n';
+const normActual = normalizeNewlines(docText).trimEnd() + '\n';
+
+if (normExpected !== normActual) {
+  const expLines = normExpected.split('\n');
+  const actLines = normActual.split('\n');
+  const max = Math.max(expLines.length, actLines.length);
+  let firstDiff = -1;
+  for (let i = 0; i < max; i++) {
+    if ((expLines[i] || '') !== (actLines[i] || '')) {
+      firstDiff = i + 1;
+      break;
+    }
+  }
+  console.error('ESTIMATE RAW VALIDATION: FAILED\n');
+  if (firstDiff > 0) {
+    console.error(`First difference at line ${firstDiff}:`);
+    console.error(`- expected: ${(expLines[firstDiff - 1] || '').slice(0, 240)}`);
+    console.error(`- actual:   ${(actLines[firstDiff - 1] || '').slice(0, 240)}`);
+    console.error('');
+  }
+  console.error('Fix: re-render the doc from the JSON input:');
+  console.error(`- node tmp/orchestrator-v2/estimate/render_estimate_raw.mjs ${args.json} ${args.doc}`);
+  process.exit(1);
+}
+
+console.log('ESTIMATE RAW VALIDATION: PASSED (exact)');
+

--- a/command-center/tmp/orchestrator-v2/estimate/validate_estimate_review_output.mjs
+++ b/command-center/tmp/orchestrator-v2/estimate/validate_estimate_review_output.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { normalizeNewlines } from './_estimate_lib.mjs';
+import { renderEstimateReviewV1 } from './_render_estimate_review_lib.mjs';
+
+const parseArgs = (argv) => {
+  const args = { mode: 'exact' };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--mode') args.mode = argv[++i];
+    else if (a === '--json') args.json = argv[++i];
+    else if (a === '--doc') args.doc = argv[++i];
+    else if (a === '--raw') args.raw = argv[++i];
+    else if (a === '--help') args.help = true;
+  }
+  return args;
+};
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help || !args.doc) {
+  console.error(
+    'Usage:\n' +
+      '  node tmp/orchestrator-v2/estimate/validate_estimate_review_output.mjs --mode exact --json <estimate_judgment.json> --doc <estimate_review.md> [--raw <estimate_raw.md>]\n' +
+      '  node tmp/orchestrator-v2/estimate/validate_estimate_review_output.mjs --mode structural --doc <estimate_review.md>'
+  );
+  process.exit(2);
+}
+
+const doc = normalizeNewlines(fs.readFileSync(args.doc, 'utf8'));
+
+const requiredHeadings = [
+  '# Estimate — Review Summary',
+  '## Inputs',
+  '## Snapshot',
+  '## Situation',
+  '## Recommendation',
+  '## Options',
+  '## Selected Scope (What You Are Approving)',
+  '## Investment',
+  '## Scope Boundaries (How to Read This)',
+  '## Not Included (Universal)',
+  '## Included / Not Included (Selected Option)',
+  '## Approval Terms',
+  '## Evidence',
+  '## Re-render',
+];
+
+const idx = (h) => doc.indexOf(h);
+for (const h of requiredHeadings) {
+  if (idx(h) < 0) {
+    console.error(`ESTIMATE REVIEW VALIDATION: FAILED\n\nMissing heading: ${h}`);
+    process.exit(1);
+  }
+}
+for (let i = 1; i < requiredHeadings.length; i++) {
+  if (idx(requiredHeadings[i]) <= idx(requiredHeadings[i - 1])) {
+    console.error(
+      'ESTIMATE REVIEW VALIDATION: FAILED\n\nHeading order mismatch:\n' +
+        `- expected: ${requiredHeadings[i - 1]} before ${requiredHeadings[i]}`
+    );
+    process.exit(1);
+  }
+}
+
+if (args.mode === 'structural') {
+  console.log('ESTIMATE REVIEW VALIDATION: PASSED (structural)');
+  process.exit(0);
+}
+
+if (args.mode !== 'exact' || !args.json) {
+  console.error('ESTIMATE REVIEW VALIDATION: FAILED\n\nInvalid mode or missing --json for exact mode.');
+  process.exit(2);
+}
+
+const deriveSiblingRaw = (reviewDocPath) => {
+  if (!reviewDocPath) return null;
+  const candidate = path.join(path.dirname(reviewDocPath), 'estimate_raw.md');
+  return fs.existsSync(candidate) ? candidate : null;
+};
+
+const rawDocPath = args.raw || deriveSiblingRaw(args.doc) || './tmp/orchestrator-v2/estimate/_baseline_estimate_raw.md';
+
+const estimateJson = JSON.parse(fs.readFileSync(args.json, 'utf8'));
+const expected = renderEstimateReviewV1({
+  inputJsonPath: args.json,
+  reviewDocPath: args.doc,
+  rawDocPath,
+  estimateJson,
+});
+
+const normExpected = normalizeNewlines(expected).trimEnd() + '\n';
+const normActual = normalizeNewlines(doc).trimEnd() + '\n';
+
+if (normExpected !== normActual) {
+  const expLines = normExpected.split('\n');
+  const actLines = normActual.split('\n');
+  const max = Math.max(expLines.length, actLines.length);
+  let firstDiff = -1;
+  for (let i = 0; i < max; i++) {
+    if ((expLines[i] || '') !== (actLines[i] || '')) {
+      firstDiff = i + 1;
+      break;
+    }
+  }
+  console.error('ESTIMATE REVIEW VALIDATION: FAILED\n');
+  if (firstDiff > 0) {
+    console.error(`First difference at line ${firstDiff}:`);
+    console.error(`- expected: ${(expLines[firstDiff - 1] || '').slice(0, 240)}`);
+    console.error(`- actual:   ${(actLines[firstDiff - 1] || '').slice(0, 240)}`);
+    console.error('');
+  }
+  console.error('Fix: re-render the review doc from the JSON input:');
+  const rawHint = args.raw ? ` --raw ${args.raw}` : '';
+  console.error(`- node tmp/orchestrator-v2/estimate/render_estimate_review.mjs --json ${args.json} --out ${args.doc}${rawHint}`);
+  process.exit(1);
+}
+
+console.log('ESTIMATE REVIEW VALIDATION: PASSED (exact)');
+


### PR DESCRIPTION
**Summary**
Adds a locked Estimate v1 contract sample plus deterministic raw/review renderers, exact validators, and contract pressure-tests (negative fixtures).

**What changed**
* `tmp/orchestrator-v2/estimate/estimate_judgment.sample.json` (contract candidate)
* Raw artifact: `render_estimate_raw.mjs` + `validate_estimate_raw_output.mjs` (exact mode)
* Review artifact: `render_estimate_review.mjs` + `validate_estimate_review_output.mjs` (exact mode)
* Contract + semantics: `docs/governance/ESTIMATE_RENDERER_CONTRACT.md`
* Negative fixtures + invariant runner: `tmp/orchestrator-v2/estimate/fixtures/**` + `run_estimate_fixtures.mjs`

**Why**
Moves Estimate v1 from schema discussion to artifact generation with an exact raw contract, a governed human-readable doc, and explicit failure-surface tests.

**Non-goals**
No tax engine, no pricing calculator, no CRM sync, no template variants.

**How to run**
- `node tmp/orchestrator-v2/estimate/run_estimate_fixtures.mjs`
- `node tmp/orchestrator-v2/estimate/render_estimate_raw.mjs tmp/orchestrator-v2/estimate/estimate_judgment.sample.json tmp/orchestrator-v2/estimate/estimate_raw.sample.md`
- `node tmp/orchestrator-v2/estimate/validate_estimate_raw_output.mjs --mode exact --json tmp/orchestrator-v2/estimate/estimate_judgment.sample.json --doc tmp/orchestrator-v2/estimate/estimate_raw.sample.md`
- `node tmp/orchestrator-v2/estimate/render_estimate_review.mjs --json tmp/orchestrator-v2/estimate/estimate_judgment.sample.json --out tmp/orchestrator-v2/estimate/estimate_review.sample.md --raw tmp/orchestrator-v2/estimate/estimate_raw.sample.md`
- `node tmp/orchestrator-v2/estimate/validate_estimate_review_output.mjs --mode exact --json tmp/orchestrator-v2/estimate/estimate_judgment.sample.json --doc tmp/orchestrator-v2/estimate/estimate_review.sample.md --raw tmp/orchestrator-v2/estimate/estimate_raw.sample.md`