### PR TITLE
chore(db): restore applied April migration history

### DIFF
--- a/command-center/supabase/migrations/20260405012000_fix_job_operational_stage_invoice_authority.sql
+++ b/command-center/supabase/migrations/20260405012000_fix_job_operational_stage_invoice_authority.sql
@@ -1,0 +1,139 @@
+begin;
+-- Fix: operational_stage should treat the latest invoice as authority when present.
+-- This prevents jobs marked `payment_status='paid'` from appearing operationally paid
+-- when the linked invoice is still unpaid/sent/partial/etc.
+
+create or replace view public.job_operational_state_v1
+with (security_invoker = true)
+as
+with latest_invoice as (
+  select distinct on (i.job_id)
+    i.job_id,
+    i.id,
+    lower(btrim(coalesce(i.status, ''))) as status,
+    i.invoice_number,
+    i.due_date,
+    i.sent_at,
+    i.balance_due,
+    i.total_amount,
+    i.created_at
+  from public.invoices as i
+  where i.job_id is not null
+  order by i.job_id, i.created_at desc, i.id desc
+),
+base as (
+  select
+    j.id,
+    j.tenant_id,
+    lower(btrim(coalesce(j.status, 'unscheduled'))) as status,
+    lower(btrim(coalesce(j.payment_status, 'unpaid'))) as payment_status,
+    j.scheduled_start,
+    j.scheduled_end,
+    j.service_address,
+    j.technician_id,
+    j.updated_at,
+    j.completed_at,
+    j.total_amount,
+    j.work_order_number,
+    j.job_number,
+    j.quote_id,
+    j.quote_number,
+    j.lead_id,
+    j.created_at,
+    upper(btrim(coalesce(j.payment_terms, public.default_job_payment_terms(j.customer_type_snapshot)))) as payment_terms,
+    public.normalize_job_customer_type(j.customer_type_snapshot) as customer_type_snapshot,
+    li.id as latest_invoice_id,
+    li.status as latest_invoice_status,
+    li.invoice_number as latest_invoice_number,
+    li.due_date as latest_invoice_due_date,
+    li.balance_due as latest_invoice_balance_due,
+    l.first_name as lead_first_name,
+    l.last_name as lead_last_name,
+    l.phone as lead_phone,
+    l.email as lead_email
+  from public.jobs as j
+  left join latest_invoice as li
+    on li.job_id = j.id
+  left join public.leads as l
+    on l.id = j.lead_id
+),
+staged as (
+  select
+    b.*,
+    case
+      -- When an invoice exists, invoice status is the operational authority for stage.
+      when b.latest_invoice_id is not null and b.latest_invoice_status = 'paid' then 'paid'
+      when b.latest_invoice_id is not null and b.latest_invoice_status = 'draft' then 'invoice_draft'
+      when b.latest_invoice_id is not null and b.latest_invoice_status in ('sent', 'partial', 'overdue', 'accepted', 'approved') then 'invoiced'
+      when b.latest_invoice_id is not null then 'invoiced'
+
+      -- Legacy / invoice-less jobs fall back to the job payment flag.
+      when b.payment_status = 'paid' then 'paid'
+
+      when b.status in ('unscheduled', 'pending_schedule', 'scheduled', 'en_route', 'in_progress', 'on_hold', 'completed', 'cancelled') then b.status
+      else 'unscheduled'
+    end as operational_stage
+  from base as b
+),
+timed as (
+  select
+    s.*,
+    case
+      when s.operational_stage in ('unscheduled', 'pending_schedule')
+        then coalesce(s.updated_at, s.created_at) + interval '24 hours'
+      when s.operational_stage = 'scheduled'
+        then s.scheduled_start
+      when s.operational_stage = 'invoice_draft'
+        then coalesce(s.completed_at, s.updated_at, s.created_at) + interval '12 hours'
+      when s.operational_stage = 'invoiced'
+        then coalesce(
+          s.latest_invoice_due_date::timestamptz,
+          s.completed_at + make_interval(days => public.payment_terms_due_days(s.payment_terms)),
+          s.updated_at + make_interval(days => public.payment_terms_due_days(s.payment_terms))
+        )
+      else null
+    end as due_at
+  from staged as s
+)
+select
+  t.*,
+  case
+    when t.operational_stage in ('unscheduled', 'pending_schedule') then 10
+    when t.operational_stage = 'scheduled' then 20
+    when t.operational_stage = 'en_route' then 30
+    when t.operational_stage = 'in_progress' then 40
+    when t.operational_stage = 'on_hold' then 45
+    when t.operational_stage = 'invoice_draft' then 50
+    when t.operational_stage = 'invoiced' then 60
+    when t.operational_stage = 'completed' then 70
+    when t.operational_stage = 'paid' then 80
+    when t.operational_stage = 'cancelled' then 90
+    else 95
+  end as operational_sort,
+  (
+    t.due_at is not null
+    and t.due_at < now()
+    and t.operational_stage not in ('paid', 'cancelled')
+  ) as is_overdue,
+  case
+    when t.due_at is null then null
+    when t.due_at >= now() then null
+    when t.operational_stage in ('unscheduled', 'pending_schedule') then 'Scheduling overdue'
+    when t.operational_stage = 'scheduled' then 'Dispatch overdue'
+    when t.operational_stage = 'invoice_draft' then 'Invoice draft overdue'
+    when t.operational_stage = 'invoiced' then 'Invoice overdue'
+    else 'Attention needed'
+  end as overdue_reason,
+  case
+    when t.operational_stage in ('unscheduled', 'pending_schedule') then 'Schedule'
+    when t.operational_stage = 'scheduled' then 'Start'
+    when t.operational_stage in ('en_route', 'in_progress') then 'Complete'
+    when t.operational_stage = 'invoice_draft' then 'Send Invoice'
+    when t.operational_stage = 'invoiced' then 'Collect Payment'
+    when t.operational_stage = 'paid' then 'Closed'
+    when t.operational_stage = 'on_hold' then 'Resume'
+    else 'Open'
+  end as next_action_label
+from timed as t;
+grant select on public.job_operational_state_v1 to authenticated, service_role;
+commit;

--- a/command-center/supabase/migrations/20260405013000_legacy_paid_job_invoice_continuity_backfill.sql
+++ b/command-center/supabase/migrations/20260405013000_legacy_paid_job_invoice_continuity_backfill.sql
@@ -1,0 +1,216 @@
+begin;
+-- Purpose
+-- - Legacy work orders may have `jobs.payment_status='paid'` while the invoice is not linked (`invoices.job_id is null`)
+--   or has no settlement-backed money proof (no `transaction_applications`), which causes UI and reporting drift.
+--
+-- This migration is intentionally conservative:
+-- 1) Link invoices -> jobs only when the mapping is unambiguous (invoice.quote_id -> job.quote_id is 1:1).
+-- 2) For jobs marked paid, if the linked invoice has no settlement applications, create a single deterministic
+--    legacy-backfill transaction + application (idempotent via unique idempotency_key), then recompute settlement.
+--
+-- Non-goals:
+-- - Does not guess linkage based on lead_id alone.
+-- - Does not backfill partial payments (amount is ambiguous without a trusted source).
+-- - Does not modify webhook/public-pay logic.
+
+create temporary table if not exists tmp_legacy_invoice_job_link_candidates as
+with invoice_candidates as (
+  select
+    i.id as invoice_id,
+    i.tenant_id as tenant_id,
+    i.quote_id as quote_id
+  from public.invoices i
+  where i.job_id is null
+    and i.quote_id is not null
+),
+job_matches as (
+  select
+    ic.invoice_id,
+    ic.tenant_id,
+    j.id as job_id
+  from invoice_candidates ic
+  join public.jobs j
+    on j.quote_id = ic.quote_id
+   and j.tenant_id is not distinct from ic.tenant_id
+),
+unique_matches as (
+  select
+    jm.invoice_id,
+    jm.tenant_id,
+    max(jm.job_id::text)::uuid as job_id,
+    count(*) as match_count
+  from job_matches jm
+  group by jm.invoice_id, jm.tenant_id
+)
+select invoice_id, tenant_id, job_id
+from unique_matches
+where match_count = 1;
+update public.invoices i
+set
+  job_id = c.job_id,
+  updated_at = now()
+from tmp_legacy_invoice_job_link_candidates c
+where i.id = c.invoice_id
+  and i.tenant_id is not distinct from c.tenant_id
+  and i.job_id is null;
+create temporary table if not exists tmp_legacy_paid_invoices_to_backfill as
+select
+  i.id as invoice_id,
+  i.tenant_id as tenant_id,
+  i.job_id as job_id,
+  coalesce(i.total_amount, 0) as total_amount
+from public.invoices i
+join public.jobs j
+  on j.id = i.job_id
+ and j.tenant_id is not distinct from i.tenant_id
+where lower(btrim(coalesce(j.payment_status, ''))) = 'paid'
+  and lower(btrim(coalesce(i.status, ''))) not in ('paid', 'void')
+  and coalesce(i.total_amount, 0) > 0
+  and not exists (
+    select 1
+    from public.transaction_applications ta
+    where ta.invoice_id = i.id
+      and ta.tenant_id is not distinct from i.tenant_id
+  );
+-- Create one deterministic legacy backfill transaction per invoice.
+do $$
+begin
+  -- Production may enforce additional NOT NULL / CHECK constraints on transactions.
+  -- In particular, some environments require:
+  -- - transactions.type in ('charge','refund','adjustment')
+  -- - transactions.method in ('card','ach','cash','check','financing')
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'transactions'
+      and column_name = 'type'
+  ) then
+    execute $sql$
+      insert into public.transactions (
+        tenant_id,
+        invoice_id,
+        amount,
+        type,
+        method,
+        status,
+        source,
+        currency,
+        provider_reference,
+        idempotency_key,
+        recorded_at,
+        created_by_user_id
+      )
+      select
+        t.tenant_id,
+        t.invoice_id,
+        t.total_amount,
+        'charge',
+        'cash',
+        'succeeded',
+        'legacy_backfill',
+        'usd',
+        null,
+        'legacy_job_paid:' || t.job_id::text || ':' || t.invoice_id::text,
+        now(),
+        null
+      from tmp_legacy_paid_invoices_to_backfill t
+      on conflict (tenant_id, idempotency_key) do nothing
+    $sql$;
+  else
+    execute $sql$
+      insert into public.transactions (
+        tenant_id,
+        invoice_id,
+        amount,
+        method,
+        status,
+        source,
+        currency,
+        provider_reference,
+        idempotency_key,
+        recorded_at,
+        created_by_user_id
+      )
+      select
+        t.tenant_id,
+        t.invoice_id,
+        t.total_amount,
+        'cash',
+        'succeeded',
+        'legacy_backfill',
+        'usd',
+        null,
+        'legacy_job_paid:' || t.job_id::text || ':' || t.invoice_id::text,
+        now(),
+        null
+      from tmp_legacy_paid_invoices_to_backfill t
+      on conflict (tenant_id, idempotency_key) do nothing
+    $sql$;
+  end if;
+end $$;
+-- Apply the transaction to the invoice (idempotent via unique index).
+insert into public.transaction_applications (
+  tenant_id,
+  transaction_id,
+  invoice_id,
+  applied_amount,
+  application_type,
+  metadata,
+  created_by_user_id,
+  applied_at
+)
+select
+  t.tenant_id,
+  tx.id as transaction_id,
+  t.invoice_id,
+  t.total_amount,
+  'payment',
+  jsonb_build_object(
+    'source', 'legacy_job_paid_backfill',
+    'job_id', t.job_id
+  ),
+  null,
+  now()
+from tmp_legacy_paid_invoices_to_backfill t
+join public.transactions tx
+  on tx.tenant_id is not distinct from t.tenant_id
+ and tx.idempotency_key = ('legacy_job_paid:' || t.job_id::text || ':' || t.invoice_id::text)
+on conflict (transaction_id, invoice_id) do nothing;
+-- Recompute settlement for invoices affected by this backfill.
+do $$
+declare
+  r record;
+begin
+  -- Some environments define invoices.balance_due as a generated column, which breaks
+  -- older settlement recompute routines that try to write balance_due directly.
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'invoices'
+      and column_name = 'balance_due'
+      and is_generated = 'ALWAYS'
+  ) then
+    update public.invoices i
+    set
+      amount_paid = greatest(coalesce(i.amount_paid, 0), coalesce(i.total_amount, 0)),
+      updated_at = now()
+    where i.id in (select invoice_id from tmp_legacy_paid_invoices_to_backfill);
+  else
+    for r in (select invoice_id from tmp_legacy_paid_invoices_to_backfill) loop
+      perform public.recalculate_invoice_settlement(r.invoice_id);
+    end loop;
+  end if;
+end $$;
+-- Minimal audit breadcrumb (does not affect money truth).
+insert into public.events (tenant_id, entity_type, entity_id, event_type, actor_type, payload)
+select
+  t.tenant_id,
+  'invoice',
+  t.invoice_id,
+  'LegacyPaid_BackfillApplied',
+  'system',
+  jsonb_build_object('job_id', t.job_id, 'idempotency_key', 'legacy_job_paid:' || t.job_id::text || ':' || t.invoice_id::text)
+from tmp_legacy_paid_invoices_to_backfill t;
+commit;

--- a/command-center/supabase/migrations/20260407033000_ops_projects_registry.sql
+++ b/command-center/supabase/migrations/20260407033000_ops_projects_registry.sql
@@ -1,0 +1,145 @@
+-- Project Operating System v1: tenant-scoped project registry for Ops Visibility dashboard.
+
+create extension if not exists pgcrypto;
+create table if not exists public.ops_projects (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id text not null,
+  project_key text not null,
+  name text not null,
+  type text not null default 'project',
+  owner text,
+  status text not null default 'queued',
+  stage text not null default 'discovery',
+  outcome text,
+  definition_of_done jsonb not null default '[]'::jsonb,
+  next_action text,
+  dependencies jsonb not null default '[]'::jsonb,
+  priority_score integer not null default 0,
+  risk text not null default 'med',
+  blast_radius text,
+  emergency boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint ops_projects_project_key_tenant_uniq unique (tenant_id, project_key),
+  constraint ops_projects_priority_score_range check (priority_score >= 0 and priority_score <= 12),
+  constraint ops_projects_type_check check (type in ('project', 'change')),
+  constraint ops_projects_status_check check (status in ('active', 'queued', 'paused', 'blocked', 'complete')),
+  constraint ops_projects_stage_check check (stage in ('discovery', 'design', 'build', 'test', 'deploy')),
+  constraint ops_projects_risk_check check (risk in ('low', 'med', 'high'))
+);
+create index if not exists ops_projects_tenant_id_idx on public.ops_projects (tenant_id);
+create index if not exists ops_projects_tenant_status_idx on public.ops_projects (tenant_id, status);
+create index if not exists ops_projects_updated_at_idx on public.ops_projects (updated_at desc);
+alter table public.ops_projects enable row level security;
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'ops_projects'
+      and policyname = 'Ops projects readable by tenant'
+  ) then
+    create policy "Ops projects readable by tenant"
+      on public.ops_projects
+      for select
+      to authenticated
+      using (
+        tenant_id = coalesce(
+          auth.jwt() -> 'app_metadata' ->> 'tenant_id',
+          auth.jwt() -> 'user_metadata' ->> 'tenant_id'
+        )
+      );
+  end if;
+end
+$$;
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'ops_projects'
+      and policyname = 'Ops projects insertable by tenant'
+  ) then
+    create policy "Ops projects insertable by tenant"
+      on public.ops_projects
+      for insert
+      to authenticated
+      with check (
+        tenant_id = coalesce(
+          auth.jwt() -> 'app_metadata' ->> 'tenant_id',
+          auth.jwt() -> 'user_metadata' ->> 'tenant_id'
+        )
+      );
+  end if;
+end
+$$;
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'ops_projects'
+      and policyname = 'Ops projects updatable by tenant'
+  ) then
+    create policy "Ops projects updatable by tenant"
+      on public.ops_projects
+      for update
+      to authenticated
+      using (
+        tenant_id = coalesce(
+          auth.jwt() -> 'app_metadata' ->> 'tenant_id',
+          auth.jwt() -> 'user_metadata' ->> 'tenant_id'
+        )
+      )
+      with check (
+        tenant_id = coalesce(
+          auth.jwt() -> 'app_metadata' ->> 'tenant_id',
+          auth.jwt() -> 'user_metadata' ->> 'tenant_id'
+        )
+      );
+  end if;
+end
+$$;
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'ops_projects'
+      and policyname = 'Ops projects deletable by tenant'
+  ) then
+    create policy "Ops projects deletable by tenant"
+      on public.ops_projects
+      for delete
+      to authenticated
+      using (
+        tenant_id = coalesce(
+          auth.jwt() -> 'app_metadata' ->> 'tenant_id',
+          auth.jwt() -> 'user_metadata' ->> 'tenant_id'
+        )
+      );
+  end if;
+end
+$$;
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'ops_projects'
+      and policyname = 'Ops projects service role full access'
+  ) then
+    create policy "Ops projects service role full access"
+      on public.ops_projects
+      for all
+      to service_role
+      using (true)
+      with check (true);
+  end if;
+end
+$$;

--- a/command-center/supabase/migrations/20260407070000_ops_visibility_queues.sql
+++ b/command-center/supabase/migrations/20260407070000_ops_visibility_queues.sql
@@ -1,0 +1,152 @@
+-- Ops Visibility queue tables required by UI (`/crm/ops`).
+-- Creates:
+--  - public.event_jobs
+--  - public.messages
+-- Tenant-scoped with optional superuser read/update for global Ops view.
+
+create extension if not exists pgcrypto;
+create table if not exists public.event_jobs (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id text not null,
+  type text not null,
+  status text not null default 'queued',
+  idempotency_key text,
+  payload jsonb,
+  attempts integer not null default 0,
+  max_attempts integer not null default 5,
+  run_at timestamptz not null default now(),
+  locked_at timestamptz,
+  last_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint event_jobs_attempts_range check (attempts >= 0),
+  constraint event_jobs_max_attempts_range check (max_attempts >= 0)
+);
+create index if not exists event_jobs_tenant_id_idx on public.event_jobs (tenant_id);
+create index if not exists event_jobs_tenant_status_idx on public.event_jobs (tenant_id, status);
+create index if not exists event_jobs_run_at_idx on public.event_jobs (run_at);
+alter table public.event_jobs enable row level security;
+create table if not exists public.messages (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id text not null,
+  channel text not null default 'email',
+  recipient text,
+  status text not null default 'queued',
+  idempotency_key text,
+  payload jsonb,
+  attempts integer not null default 0,
+  max_attempts integer not null default 5,
+  scheduled_at timestamptz not null default now(),
+  locked_at timestamptz,
+  last_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint messages_attempts_range check (attempts >= 0),
+  constraint messages_max_attempts_range check (max_attempts >= 0)
+);
+create index if not exists messages_tenant_id_idx on public.messages (tenant_id);
+create index if not exists messages_tenant_status_idx on public.messages (tenant_id, status);
+create index if not exists messages_scheduled_at_idx on public.messages (scheduled_at);
+alter table public.messages enable row level security;
+-- RLS helpers
+-- Tenant id can live in app_metadata or user_metadata.
+-- Superuser flag is optional; if present it enables global ops visibility.
+create or replace function public._auth_tenant_id()
+returns text
+language sql
+stable
+as $$
+  select coalesce(
+    auth.jwt() -> 'app_metadata' ->> 'tenant_id',
+    auth.jwt() -> 'user_metadata' ->> 'tenant_id'
+  );
+$$;
+create or replace function public._auth_is_superuser()
+returns boolean
+language sql
+stable
+as $$
+  select coalesce(
+    (auth.jwt() -> 'app_metadata' ->> 'is_superuser')::boolean,
+    (auth.jwt() -> 'user_metadata' ->> 'is_superuser')::boolean,
+    false
+  );
+$$;
+-- event_jobs policies
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='event_jobs' and policyname='event_jobs select'
+  ) then
+    create policy "event_jobs select"
+      on public.event_jobs
+      for select
+      to authenticated
+      using (tenant_id = public._auth_tenant_id() or public._auth_is_superuser());
+  end if;
+end$$;
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='event_jobs' and policyname='event_jobs update'
+  ) then
+    create policy "event_jobs update"
+      on public.event_jobs
+      for update
+      to authenticated
+      using (tenant_id = public._auth_tenant_id() or public._auth_is_superuser())
+      with check (tenant_id = public._auth_tenant_id() or public._auth_is_superuser());
+  end if;
+end$$;
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='event_jobs' and policyname='event_jobs service_role'
+  ) then
+    create policy "event_jobs service_role"
+      on public.event_jobs
+      for all
+      to service_role
+      using (true)
+      with check (true);
+  end if;
+end$$;
+-- messages policies
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='messages' and policyname='messages select'
+  ) then
+    create policy "messages select"
+      on public.messages
+      for select
+      to authenticated
+      using (tenant_id = public._auth_tenant_id() or public._auth_is_superuser());
+  end if;
+end$$;
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='messages' and policyname='messages update'
+  ) then
+    create policy "messages update"
+      on public.messages
+      for update
+      to authenticated
+      using (tenant_id = public._auth_tenant_id() or public._auth_is_superuser())
+      with check (tenant_id = public._auth_tenant_id() or public._auth_is_superuser());
+  end if;
+end$$;
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='messages' and policyname='messages service_role'
+  ) then
+    create policy "messages service_role"
+      on public.messages
+      for all
+      to service_role
+      using (true)
+      with check (true);
+  end if;
+end$$;

--- a/command-center/supabase/migrations/20260407082000_jobs_missing_fields_for_quote_approval.sql
+++ b/command-center/supabase/migrations/20260407082000_jobs_missing_fields_for_quote_approval.sql
@@ -1,0 +1,10 @@
+begin;
+-- Ops/Work-order invariants expect these columns to exist on `public.jobs`.
+-- Some environments already have `public.jobs` from earlier eras without these fields,
+-- and `create table if not exists` migrations will not add them retroactively.
+
+alter table public.jobs
+  add column if not exists estimate_id uuid,
+  add column if not exists amount_paid numeric,
+  add column if not exists payment_method text;
+commit;

--- a/command-center/supabase/migrations/20260407090000_postgrest_reload_schema_ops_visibility.sql
+++ b/command-center/supabase/migrations/20260407090000_postgrest_reload_schema_ops_visibility.sql
@@ -1,0 +1,4 @@
+-- Ops Visibility: ensure PostgREST picks up newly created tables/columns.
+-- This prevents UI errors like:
+--   "Could not find the table 'public.event_jobs' in the schema cache"
+select pg_notify('pgrst', 'reload schema');

--- a/command-center/supabase/migrations/20260407130000_price_book_discounts_and_invoice_discount_functions.sql
+++ b/command-center/supabase/migrations/20260407130000_price_book_discounts_and_invoice_discount_functions.sql
@@ -1,0 +1,318 @@
+-- PRICE BOOK + INVOICE DISCOUNT SUPPORT
+-- Adds:
+--   - price_book classification + discount metadata (percent/fixed)
+--   - invoice_items line typing + price_book linkage
+--   - helper functions to calculate + apply a discount as a negative invoice line
+--
+-- Notes:
+-- - Additive/idempotent where possible (safe to run on live).
+-- - Existing code continues to work if it ignores the new columns.
+-- - This does NOT automatically recalculate invoices.total_amount/subtotal; it only manages invoice_items lines.
+
+-- =========================================================
+-- PRICE BOOK ENHANCEMENTS
+-- =========================================================
+
+ALTER TABLE public.price_book
+  ADD COLUMN IF NOT EXISTS item_type text NOT NULL DEFAULT 'service';
+ALTER TABLE public.price_book
+  ADD COLUMN IF NOT EXISTS discount_type text;
+ALTER TABLE public.price_book
+  ADD COLUMN IF NOT EXISTS discount_value numeric(10,2);
+ALTER TABLE public.price_book
+  ADD COLUMN IF NOT EXISTS discount_eligible boolean NOT NULL DEFAULT true;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'price_book_item_type_check'
+  ) THEN
+    ALTER TABLE public.price_book
+      ADD CONSTRAINT price_book_item_type_check
+      CHECK (item_type IN ('service', 'fee', 'discount'));
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'price_book_discount_type_check'
+  ) THEN
+    ALTER TABLE public.price_book
+      ADD CONSTRAINT price_book_discount_type_check
+      CHECK (discount_type IS NULL OR discount_type IN ('percent', 'fixed'));
+  END IF;
+END $$;
+-- Guardrail:
+-- - If item_type = discount, require discount_type + discount_value
+-- - If percent, require 0..100
+-- - If fixed, require >= 0
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'price_book_discount_fields_check'
+  ) THEN
+    ALTER TABLE public.price_book
+      ADD CONSTRAINT price_book_discount_fields_check
+      CHECK (
+        (item_type <> 'discount')
+        OR
+        (
+          item_type = 'discount'
+          AND discount_type IS NOT NULL
+          AND discount_value IS NOT NULL
+          AND (
+            (discount_type = 'percent' AND discount_value >= 0 AND discount_value <= 100)
+            OR
+            (discount_type = 'fixed' AND discount_value >= 0)
+          )
+        )
+      );
+  END IF;
+END $$;
+-- Best-effort backfill for existing fixed discount-style rows.
+-- (This repo historically represented discounts via negative base_price/category='discount'.)
+UPDATE public.price_book
+SET
+  item_type = 'discount',
+  discount_type = COALESCE(discount_type, 'fixed'),
+  discount_value = COALESCE(discount_value, ABS(base_price)),
+  discount_eligible = false
+WHERE
+  COALESCE(item_type, '') <> 'discount'
+  AND (
+    COALESCE(category, '') = 'discount'
+    OR COALESCE(base_price, 0) < 0
+  );
+-- Ensure non-discount items default to service classification.
+UPDATE public.price_book
+SET item_type = 'service'
+WHERE item_type IS NULL;
+-- =========================================================
+-- SEED: MILITARY DISCOUNT (10% eligible subtotal)
+-- =========================================================
+
+INSERT INTO public.price_book (
+  id,
+  tenant_id,
+  code,
+  name,
+  category,
+  base_price,
+  price_type,
+  description,
+  active,
+  created_at,
+  item_type,
+  discount_type,
+  discount_value,
+  discount_eligible
+)
+VALUES (
+  '8a9bbab9-68c5-4cd3-9a86-6a05be5c68e6',
+  'default',
+  'DISC-MIL-10PCT',
+  'Military Discount',
+  'discount',
+  0.00,
+  'percent',
+  '10 percent discount for eligible military customers.',
+  true,
+  NOW(),
+  'discount',
+  'percent',
+  10.00,
+  false
+)
+ON CONFLICT (tenant_id, code) DO UPDATE SET
+  name = EXCLUDED.name,
+  category = EXCLUDED.category,
+  base_price = EXCLUDED.base_price,
+  price_type = EXCLUDED.price_type,
+  description = EXCLUDED.description,
+  active = EXCLUDED.active,
+  item_type = EXCLUDED.item_type,
+  discount_type = EXCLUDED.discount_type,
+  discount_value = EXCLUDED.discount_value,
+  discount_eligible = EXCLUDED.discount_eligible;
+-- Optional examples: only fill description when blank/missing.
+UPDATE public.price_book
+SET description = 'Professional air duct cleaning focused on removing dust, debris, and buildup from the HVAC duct system.'
+WHERE name = 'Air Duct Cleaning'
+  AND COALESCE(NULLIF(description, ''), '') = '';
+UPDATE public.price_book
+SET description = 'Professional dryer vent cleaning to remove lint buildup, improve airflow, and reduce fire risk.'
+WHERE name = 'Dryer Vent Cleaning'
+  AND COALESCE(NULLIF(description, ''), '') = '';
+UPDATE public.price_book
+SET description = 'Treatment applied to key HVAC components to support cleaner system conditions.'
+WHERE name = 'Air Handler Sanitization'
+  AND COALESCE(NULLIF(description, ''), '') = '';
+UPDATE public.price_book
+SET description = 'Deep cleaning of blower components and evaporator coil to improve cleanliness and system performance.'
+WHERE name = 'Blower and A-Coil Cleaning'
+  AND COALESCE(NULLIF(description, ''), '') = '';
+UPDATE public.price_book
+SET description = 'Travel charge applied for service locations outside the standard operating zone.'
+WHERE name = 'Travel Charge'
+  AND COALESCE(NULLIF(description, ''), '') = '';
+-- =========================================================
+-- INVOICE ITEMS: LINE TYPING + PRICE BOOK LINK
+-- =========================================================
+
+ALTER TABLE public.invoice_items
+  ADD COLUMN IF NOT EXISTS line_type text NOT NULL DEFAULT 'service';
+ALTER TABLE public.invoice_items
+  ADD COLUMN IF NOT EXISTS source_price_book_id uuid;
+ALTER TABLE public.invoice_items
+  ADD COLUMN IF NOT EXISTS sort_order integer NOT NULL DEFAULT 100;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'invoice_items_line_type_check'
+  ) THEN
+    ALTER TABLE public.invoice_items
+      ADD CONSTRAINT invoice_items_line_type_check
+      CHECK (line_type IN ('service', 'fee', 'discount'));
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'invoice_items_source_price_book_fkey'
+  ) THEN
+    ALTER TABLE public.invoice_items
+      ADD CONSTRAINT invoice_items_source_price_book_fkey
+      FOREIGN KEY (source_price_book_id)
+      REFERENCES public.price_book(id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+CREATE INDEX IF NOT EXISTS invoice_items_invoice_id_sort_order_idx
+  ON public.invoice_items (invoice_id, sort_order, created_at, id);
+CREATE INDEX IF NOT EXISTS invoice_items_invoice_id_line_type_idx
+  ON public.invoice_items (invoice_id, line_type);
+-- =========================================================
+-- FUNCTIONS: DISCOUNT CALCULATION + APPLICATION
+-- =========================================================
+
+CREATE OR REPLACE FUNCTION public.calculate_invoice_discount_amount(
+  p_invoice_id uuid,
+  p_discount_price_book_id uuid
+)
+RETURNS numeric
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_discount_type text;
+  v_discount_value numeric(10,2);
+  v_eligible_subtotal numeric(12,2) := 0;
+BEGIN
+  -- Get discount rule from price_book
+  SELECT
+    discount_type,
+    discount_value
+  INTO
+    v_discount_type,
+    v_discount_value
+  FROM public.price_book
+  WHERE id = p_discount_price_book_id
+    AND item_type = 'discount';
+
+  IF v_discount_type IS NULL OR v_discount_value IS NULL THEN
+    RAISE EXCEPTION 'Selected price_book item is not a valid discount';
+  END IF;
+
+  -- Sum only eligible, non-discount invoice lines
+  SELECT COALESCE(SUM(CASE WHEN ii.total_price > 0 THEN ii.total_price ELSE 0 END), 0)
+  INTO v_eligible_subtotal
+  FROM public.invoice_items ii
+  LEFT JOIN public.price_book pb
+    ON pb.id = ii.source_price_book_id
+  WHERE ii.invoice_id = p_invoice_id
+    AND ii.line_type IN ('service', 'fee')
+    AND COALESCE(pb.discount_eligible, true) = true;
+
+  IF v_discount_type = 'percent' THEN
+    RETURN ROUND(v_eligible_subtotal * (v_discount_value / 100.0), 2);
+  ELSIF v_discount_type = 'fixed' THEN
+    RETURN LEAST(v_discount_value, v_eligible_subtotal);
+  ELSE
+    RAISE EXCEPTION 'Unsupported discount type: %', v_discount_type;
+  END IF;
+END;
+$$;
+CREATE OR REPLACE FUNCTION public.apply_invoice_discount(
+  p_invoice_id uuid,
+  p_discount_price_book_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_discount_name text;
+  v_discount_description text;
+  v_discount_amount numeric(10,2);
+BEGIN
+  SELECT
+    name,
+    description
+  INTO
+    v_discount_name,
+    v_discount_description
+  FROM public.price_book
+  WHERE id = p_discount_price_book_id
+    AND item_type = 'discount';
+
+  IF v_discount_name IS NULL THEN
+    RAISE EXCEPTION 'Invalid discount price book item';
+  END IF;
+
+  v_discount_amount := public.calculate_invoice_discount_amount(
+    p_invoice_id,
+    p_discount_price_book_id
+  );
+
+  -- Remove prior instance of this exact discount
+  DELETE FROM public.invoice_items
+  WHERE invoice_id = p_invoice_id
+    AND line_type = 'discount'
+    AND source_price_book_id = p_discount_price_book_id;
+
+  -- Only insert if there is a real amount to discount
+  IF v_discount_amount > 0 THEN
+    INSERT INTO public.invoice_items (
+      invoice_id,
+      description,
+      quantity,
+      unit_price,
+      total_price,
+      line_type,
+      source_price_book_id,
+      sort_order
+    )
+    VALUES (
+      p_invoice_id,
+      COALESCE(NULLIF(v_discount_name, ''), COALESCE(NULLIF(v_discount_description, ''), 'Discount')),
+      1,
+      -v_discount_amount,
+      -v_discount_amount,
+      'discount',
+      p_discount_price_book_id,
+      999
+    );
+  END IF;
+END;
+$$;

--- a/command-center/supabase/migrations/20260416043000_remove_estimate_id_from_quote_job_trigger.sql
+++ b/command-center/supabase/migrations/20260416043000_remove_estimate_id_from_quote_job_trigger.sql
@@ -1,0 +1,217 @@
+begin;
+
+-- Align quote → job flow to canonical contract:
+-- - Jobs originate from quotes via jobs.quote_id
+-- - Do NOT insert/upsert jobs.estimate_id (column does not exist in canonical schema)
+--
+-- Scope: update the active trigger function only.
+
+create or replace function public.ensure_job_and_optional_draft_invoice_for_accepted_quote()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_new_status text;
+  v_old_status text;
+  v_job_id uuid;
+  v_auto text;
+  v_should_invoice boolean := false;
+  v_now timestamptz := now();
+begin
+  v_new_status := public.normalize_quote_status(new.status);
+
+  if tg_op = 'INSERT' then
+    v_old_status := '';
+  else
+    v_old_status := public.normalize_quote_status(old.status);
+  end if;
+
+  if new.tenant_id is null or btrim(new.tenant_id) = '' then
+    return new;
+  end if;
+
+  -- Quote accepted: ensure exactly one job per quote (idempotent).
+  if v_new_status = 'accepted' and v_old_status <> 'accepted' then
+    insert into public.jobs (
+      tenant_id,
+      lead_id,
+      quote_id,
+      quote_number,
+      status,
+      payment_status,
+      total_amount,
+      work_order_number
+    ) values (
+      new.tenant_id,
+      new.lead_id,
+      new.id,
+      new.quote_number,
+      'unscheduled',
+      'unpaid',
+      coalesce(new.total_amount, 0),
+      public.next_work_order_number(new.tenant_id, coalesce(new.created_at, v_now))
+    )
+    on conflict (quote_id) where quote_id is not null
+    do update set
+      updated_at = v_now,
+      total_amount = coalesce(public.jobs.total_amount, excluded.total_amount)
+    returning id into v_job_id;
+
+    insert into public.events (tenant_id, entity_type, entity_id, event_type, actor_type, payload)
+    values (new.tenant_id, 'quote', new.id, 'QuoteAccepted_JobEnsured', 'system', jsonb_build_object('job_id', v_job_id));
+
+    select value into v_auto
+    from public.global_config
+    where key = 'auto_create_draft_invoice_on_acceptance'
+    limit 1;
+
+    v_should_invoice := lower(btrim(coalesce(v_auto, 'false'))) in ('1','true','yes','on');
+
+    if v_should_invoice then
+      insert into public.invoices (
+        tenant_id,
+        lead_id,
+        quote_id,
+        job_id,
+        estimate_id,
+        status,
+        invoice_type,
+        release_approved,
+        subtotal,
+        tax_rate,
+        tax_amount,
+        total_amount,
+        issue_date,
+        due_date,
+        customer_email,
+        customer_name,
+        customer_phone,
+        notes
+      ) values (
+        new.tenant_id,
+        new.lead_id,
+        new.id,
+        v_job_id,
+        new.estimate_id,
+        'draft',
+        'final',
+        false,
+        new.subtotal,
+        new.tax_rate,
+        new.tax_amount,
+        coalesce(new.total_amount, 0),
+        current_date,
+        coalesce(new.valid_until, current_date + 14),
+        new.customer_email,
+        new.customer_name,
+        new.customer_phone,
+        case when new.quote_number is not null then 'Draft created on acceptance for Quote #' || new.quote_number else 'Draft created on acceptance' end
+      )
+      on conflict (tenant_id, job_id, invoice_type)
+        where lower(coalesce(status, '')) = 'draft'
+      do nothing;
+
+      insert into public.events (tenant_id, entity_type, entity_id, event_type, actor_type, payload)
+      values (new.tenant_id, 'quote', new.id, 'QuoteAccepted_DraftInvoiceEnsured', 'system', jsonb_build_object('job_id', v_job_id));
+    end if;
+
+    return new;
+  end if;
+
+  -- Quote marked paid: sync job payment + invoice payment (idempotent).
+  if lower(btrim(coalesce(new.status, ''))) = 'paid'
+     and lower(btrim(coalesce(old.status, ''))) <> 'paid' then
+
+    insert into public.jobs (
+      tenant_id,
+      lead_id,
+      quote_id,
+      quote_number,
+      status,
+      payment_status,
+      total_amount,
+      work_order_number
+    ) values (
+      new.tenant_id,
+      new.lead_id,
+      new.id,
+      new.quote_number,
+      'unscheduled',
+      'paid',
+      coalesce(new.total_amount, 0),
+      public.next_work_order_number(new.tenant_id, coalesce(new.created_at, v_now))
+    )
+    on conflict (quote_id) where quote_id is not null
+    do update set
+      payment_status = 'paid',
+      updated_at = v_now
+    returning id into v_job_id;
+
+    update public.jobs
+    set payment_status = 'paid',
+        updated_at = v_now
+    where quote_id = new.id
+      and tenant_id is not distinct from new.tenant_id
+      and lower(coalesce(status, '')) <> 'cancelled';
+
+    -- Step 1: draft -> sent (idempotent)
+    begin
+      update public.invoices
+      set status = 'sent',
+          sent_at = coalesce(sent_at, v_now),
+          release_approved = true,
+          release_approved_at = coalesce(release_approved_at, v_now),
+          updated_at = v_now
+      where quote_id = new.id
+        and tenant_id is not distinct from new.tenant_id
+        and lower(coalesce(status, 'draft')) = 'draft';
+    exception
+      when others then
+        update public.invoices
+        set status = 'sent',
+            sent_at = coalesce(sent_at, v_now),
+            updated_at = v_now
+        where quote_id = new.id
+          and tenant_id is not distinct from new.tenant_id
+          and lower(coalesce(status, 'draft')) = 'draft';
+    end;
+
+    -- Step 2: sent -> paid
+    begin
+      update public.invoices
+      set status = 'paid',
+          paid_at = coalesce(paid_at, v_now),
+          amount_paid = case when coalesce(total_amount, 0) > 0 then coalesce(total_amount, 0) else coalesce(amount_paid, 0) end,
+          balance_due = 0,
+          payment_method = coalesce(payment_method, 'offline'),
+          updated_at = v_now
+      where quote_id = new.id
+        and tenant_id is not distinct from new.tenant_id
+        and lower(coalesce(status, 'draft')) <> 'void';
+    exception
+      when others then
+        update public.invoices
+        set status = 'paid',
+            paid_at = coalesce(paid_at, v_now),
+            amount_paid = case when coalesce(total_amount, 0) > 0 then coalesce(total_amount, 0) else coalesce(amount_paid, 0) end,
+            payment_method = coalesce(payment_method, 'offline'),
+            updated_at = v_now
+        where quote_id = new.id
+          and tenant_id is not distinct from new.tenant_id
+          and lower(coalesce(status, 'draft')) <> 'void';
+    end;
+
+    insert into public.events (tenant_id, entity_type, entity_id, event_type, actor_type, payload)
+    values (new.tenant_id, 'quote', new.id, 'QuotePaid_Synced', 'system', jsonb_build_object('job_id', v_job_id));
+
+    return new;
+  end if;
+
+  return new;
+end;
+$$;
+
+commit;
+

--- a/command-center/supabase/migrations/20260416043500_drop_legacy_on_quote_approved_v2_trigger.sql
+++ b/command-center/supabase/migrations/20260416043500_drop_legacy_on_quote_approved_v2_trigger.sql
@@ -1,0 +1,13 @@
+begin;
+
+-- PROD drift cleanup (idempotent):
+-- - PROD currently has a legacy trigger `on_quote_approved_v2` that creates jobs on status='approved'
+-- - Canonical flow is handled by:
+--   - `trg_quotes_normalize_status` (approved -> accepted)
+--   - `trg_quotes_ensure_job_and_invoice` (accepted -> ensure job)
+-- This drop keeps behavior but removes the non-canonical job creation path.
+
+drop trigger if exists on_quote_approved_v2 on public.quotes;
+
+commit;
+

--- a/command-center/supabase/migrations/20260416184500_drift_fix_leads_add_updated_at.sql
+++ b/command-center/supabase/migrations/20260416184500_drift_fix_leads_add_updated_at.sql
@@ -1,0 +1,35 @@
+-- DRIFT-001 (PROD): public.leads is missing updated_at but canonical migrations + app code assume it exists.
+--
+-- Canonical intent:
+-- - supabase/migrations/20260101_create_money_loop_core_tables.sql defines public.leads.updated_at timestamptz not null default now()
+--
+-- Why this migration exists:
+-- - PROD already has a legacy public.leads table, so CREATE TABLE IF NOT EXISTS cannot converge the shape.
+-- - This is an additive, idempotent drift-fix migration to align PROD to canonical schema expectations.
+
+do $$
+begin
+  if not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'leads'
+      and column_name = 'updated_at'
+  ) then
+    alter table public.leads
+      add column updated_at timestamptz;
+
+    -- Best-effort backfill: prefer last_touch_at when present, otherwise created_at.
+    -- This keeps scheduling/customer ordering roughly correct without requiring a full historical reconstruction.
+    update public.leads
+      set updated_at = coalesce(last_touch_at, created_at, now())
+      where updated_at is null;
+
+    alter table public.leads
+      alter column updated_at set default now();
+
+    alter table public.leads
+      alter column updated_at set not null;
+  end if;
+end $$;
+

--- a/command-center/supabase/migrations/20260416191500_add_superusers_and_check_is_superuser_rpc.sql
+++ b/command-center/supabase/migrations/20260416191500_add_superusers_and_check_is_superuser_rpc.sql
@@ -1,0 +1,50 @@
+-- Local parity / UI contract:
+-- The CRM UI calls `supabase.rpc('check_is_superuser')` (TenantGuard / sidebar / Ops dashboard).
+-- PROD already has:
+-- - public.superusers (RLS enabled, no policies)
+-- - public.check_is_superuser() SECURITY DEFINER
+-- Local Supabase bootstraps from `supabase/migrations/` and was missing both,
+-- causing PostgREST 404 (PGRST202) for /rest/v1/rpc/check_is_superuser.
+
+create table if not exists public.superusers (
+  id uuid primary key default gen_random_uuid(),
+  email text not null,
+  is_active boolean default true,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- Ensure constraints exist even if the table pre-exists (idempotent).
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.superusers'::regclass
+      and conname = 'superusers_email_key'
+  ) then
+    alter table public.superusers
+      add constraint superusers_email_key unique (email);
+  end if;
+exception
+  when undefined_table then
+    -- ignore; table creation above should succeed in normal migration ordering
+    null;
+end $$;
+
+alter table public.superusers enable row level security;
+
+create or replace function public.check_is_superuser() returns boolean
+  language sql
+  security definer
+as $$
+  select exists (
+    select 1
+    from public.superusers
+    where email = (auth.jwt() ->> 'email')
+      and is_active = true
+  );
+$$;
+
+grant execute on function public.check_is_superuser() to anon, authenticated, service_role;
+

--- a/command-center/supabase/migrations/20260416201500_add_contacts_preferred_contact_method.sql
+++ b/command-center/supabase/migrations/20260416201500_add_contacts_preferred_contact_method.sql
@@ -1,0 +1,6 @@
+-- Add contact-level delivery preference used by CRM selects.
+-- Canonical schema lives in supabase/migrations/.
+-- This is additive + idempotent.
+
+alter table if exists public.contacts
+  add column if not exists preferred_contact_method text;

--- a/command-center/supabase/migrations/20260416210000_backfill_job_service_address_on_quote_accept.sql
+++ b/command-center/supabase/migrations/20260416210000_backfill_job_service_address_on_quote_accept.sql
@@ -1,0 +1,257 @@
+begin;
+
+-- Ensure the canonical quote→job trigger writes a dispatchable service address when possible.
+-- Priority:
+-- 1) quotes.service_address
+-- 2) leads.property_id → properties.address*
+--
+-- Scope: replace the trigger function only (no trigger rewiring).
+
+create or replace function public.ensure_job_and_optional_draft_invoice_for_accepted_quote()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_new_status text;
+  v_old_status text;
+  v_job_id uuid;
+  v_auto text;
+  v_should_invoice boolean := false;
+  v_now timestamptz := now();
+  v_service_address text;
+begin
+  v_new_status := public.normalize_quote_status(new.status);
+
+  if tg_op = 'INSERT' then
+    v_old_status := '';
+  else
+    v_old_status := public.normalize_quote_status(old.status);
+  end if;
+
+  if new.tenant_id is null or btrim(new.tenant_id) = '' then
+    return new;
+  end if;
+
+  -- Resolve service address for job creation/backfill.
+  v_service_address := nullif(btrim(coalesce(new.service_address, '')), '');
+  if v_service_address is null and new.lead_id is not null then
+    select nullif(
+      btrim(
+        concat_ws(
+          ', ',
+          nullif(btrim(concat_ws(' ', nullif(p.address1, ''), nullif(p.address2, ''))), ''),
+          nullif(btrim(p.city), ''),
+          nullif(btrim(p.state), ''),
+          nullif(btrim(p.zip), '')
+        )
+      ),
+      ''
+    )
+    into v_service_address
+    from public.leads l
+    left join public.properties p on p.id = l.property_id
+    where l.id = new.lead_id
+    limit 1;
+  end if;
+
+  -- Quote accepted: ensure exactly one job per quote (idempotent).
+  if v_new_status = 'accepted' and v_old_status <> 'accepted' then
+    insert into public.jobs (
+      tenant_id,
+      lead_id,
+      quote_id,
+      quote_number,
+      status,
+      payment_status,
+      total_amount,
+      service_address,
+      work_order_number
+    ) values (
+      new.tenant_id,
+      new.lead_id,
+      new.id,
+      new.quote_number,
+      'unscheduled',
+      'unpaid',
+      coalesce(new.total_amount, 0),
+      v_service_address,
+      public.next_work_order_number(new.tenant_id, coalesce(new.created_at, v_now))
+    )
+    on conflict (quote_id) where quote_id is not null
+    do update set
+      updated_at = v_now,
+      total_amount = coalesce(public.jobs.total_amount, excluded.total_amount),
+      service_address = case
+        when public.jobs.service_address is null or btrim(public.jobs.service_address) = '' then excluded.service_address
+        else public.jobs.service_address
+      end
+    returning id into v_job_id;
+
+    insert into public.events (tenant_id, entity_type, entity_id, event_type, actor_type, payload)
+    values (new.tenant_id, 'quote', new.id, 'QuoteAccepted_JobEnsured', 'system', jsonb_build_object('job_id', v_job_id));
+
+    select value into v_auto
+    from public.global_config
+    where key = 'auto_create_draft_invoice_on_acceptance'
+    limit 1;
+
+    v_should_invoice := lower(btrim(coalesce(v_auto, 'false'))) in ('1','true','yes','on');
+
+    if v_should_invoice then
+      insert into public.invoices (
+        tenant_id,
+        lead_id,
+        quote_id,
+        job_id,
+        estimate_id,
+        status,
+        invoice_type,
+        release_approved,
+        subtotal,
+        tax_rate,
+        tax_amount,
+        total_amount,
+        issue_date,
+        due_date,
+        customer_email,
+        customer_name,
+        customer_phone,
+        notes
+      ) values (
+        new.tenant_id,
+        new.lead_id,
+        new.id,
+        v_job_id,
+        new.estimate_id,
+        'draft',
+        'final',
+        false,
+        new.subtotal,
+        new.tax_rate,
+        new.tax_amount,
+        coalesce(new.total_amount, 0),
+        current_date,
+        coalesce(new.valid_until, current_date + 14),
+        new.customer_email,
+        new.customer_name,
+        new.customer_phone,
+        case when new.quote_number is not null then 'Draft created on acceptance for Quote #' || new.quote_number else 'Draft created on acceptance' end
+      )
+      on conflict (tenant_id, job_id, invoice_type)
+        where lower(coalesce(status, '')) = 'draft'
+      do nothing;
+
+      insert into public.events (tenant_id, entity_type, entity_id, event_type, actor_type, payload)
+      values (new.tenant_id, 'quote', new.id, 'QuoteAccepted_DraftInvoiceEnsured', 'system', jsonb_build_object('job_id', v_job_id));
+    end if;
+
+    return new;
+  end if;
+
+  -- Quote marked paid: sync job payment + invoice payment (idempotent).
+  if lower(btrim(coalesce(new.status, ''))) = 'paid'
+     and lower(btrim(coalesce(old.status, ''))) <> 'paid' then
+
+    insert into public.jobs (
+      tenant_id,
+      lead_id,
+      quote_id,
+      quote_number,
+      status,
+      payment_status,
+      total_amount,
+      service_address,
+      work_order_number
+    ) values (
+      new.tenant_id,
+      new.lead_id,
+      new.id,
+      new.quote_number,
+      'unscheduled',
+      'paid',
+      coalesce(new.total_amount, 0),
+      v_service_address,
+      public.next_work_order_number(new.tenant_id, coalesce(new.created_at, v_now))
+    )
+    on conflict (quote_id) where quote_id is not null
+    do update set
+      payment_status = 'paid',
+      updated_at = v_now,
+      service_address = case
+        when public.jobs.service_address is null or btrim(public.jobs.service_address) = '' then excluded.service_address
+        else public.jobs.service_address
+      end
+    returning id into v_job_id;
+
+    update public.jobs
+    set payment_status = 'paid',
+        updated_at = v_now,
+        service_address = case
+          when (service_address is null or btrim(service_address) = '') then v_service_address
+          else service_address
+        end
+    where quote_id = new.id
+      and tenant_id is not distinct from new.tenant_id
+      and lower(coalesce(status, '')) <> 'cancelled';
+
+    -- Step 1: draft -> sent (idempotent)
+    begin
+      update public.invoices
+      set status = 'sent',
+          sent_at = coalesce(sent_at, v_now),
+          release_approved = true,
+          release_approved_at = coalesce(release_approved_at, v_now),
+          updated_at = v_now
+      where quote_id = new.id
+        and tenant_id is not distinct from new.tenant_id
+        and lower(coalesce(status, 'draft')) = 'draft';
+    exception
+      when others then
+        update public.invoices
+        set status = 'sent',
+            sent_at = coalesce(sent_at, v_now),
+            updated_at = v_now
+        where quote_id = new.id
+          and tenant_id is not distinct from new.tenant_id
+          and lower(coalesce(status, 'draft')) = 'draft';
+    end;
+
+    -- Step 2: sent -> paid
+    begin
+      update public.invoices
+      set status = 'paid',
+          paid_at = coalesce(paid_at, v_now),
+          amount_paid = case when coalesce(total_amount, 0) > 0 then coalesce(total_amount, 0) else coalesce(amount_paid, 0) end,
+          balance_due = 0,
+          payment_method = coalesce(payment_method, 'offline'),
+          updated_at = v_now
+      where quote_id = new.id
+        and tenant_id is not distinct from new.tenant_id
+        and lower(coalesce(status, 'draft')) <> 'void';
+    exception
+      when others then
+        update public.invoices
+        set status = 'paid',
+            paid_at = coalesce(paid_at, v_now),
+            amount_paid = case when coalesce(total_amount, 0) > 0 then coalesce(total_amount, 0) else coalesce(amount_paid, 0) end,
+            payment_method = coalesce(payment_method, 'offline'),
+            updated_at = v_now
+        where quote_id = new.id
+          and tenant_id is not distinct from new.tenant_id
+          and lower(coalesce(status, 'draft')) <> 'void';
+    end;
+
+    insert into public.events (tenant_id, entity_type, entity_id, event_type, actor_type, payload)
+    values (new.tenant_id, 'quote', new.id, 'QuotePaid_Synced', 'system', jsonb_build_object('job_id', v_job_id));
+
+    return new;
+  end if;
+
+  return new;
+end;
+$$;
+
+commit;
+

--- a/command-center/supabase/migrations/20260416213000_backfill_existing_jobs_service_address.sql
+++ b/command-center/supabase/migrations/20260416213000_backfill_existing_jobs_service_address.sql
@@ -1,0 +1,38 @@
+begin;
+
+-- Backfill existing jobs that predate the quote→job address propagation fix.
+-- Only fills when an address can be resolved; otherwise leaves null.
+
+with resolved as (
+  select
+    j.id as job_id,
+    coalesce(
+      nullif(btrim(q.service_address), ''),
+      nullif(
+        btrim(
+          concat_ws(
+            ', ',
+            nullif(btrim(concat_ws(' ', nullif(p.address1, ''), nullif(p.address2, ''))), ''),
+            nullif(btrim(p.city), ''),
+            nullif(btrim(p.state), ''),
+            nullif(btrim(p.zip), '')
+          )
+        ),
+        ''
+      )
+    ) as service_address
+  from public.jobs j
+  left join public.quotes q on q.id = j.quote_id
+  left join public.leads l on l.id = j.lead_id
+  left join public.properties p on p.id = l.property_id
+  where j.service_address is null or btrim(j.service_address) = ''
+)
+update public.jobs j
+set service_address = r.service_address,
+    updated_at = now()
+from resolved r
+where r.job_id = j.id
+  and r.service_address is not null;
+
+commit;
+

--- a/command-center/supabase/migrations/20260416220000_unify_technician_id_on_user_id.sql
+++ b/command-center/supabase/migrations/20260416220000_unify_technician_id_on_user_id.sql
@@ -1,0 +1,39 @@
+-- Technician ID contract unification (Packet 005)
+--
+-- Canonical rule:
+-- - jobs.technician_id stores technicians.user_id (NOT technicians.id)
+-- - appointments.technician_id stores technicians.user_id (NOT technicians.id)
+--
+-- This migration is intentionally narrow:
+-- - normalize existing rows where technician_id currently matches technicians.id
+-- - switch appointments FK to reference technicians(user_id) so PostgREST joins remain valid
+
+-- 1) Normalize jobs.technician_id values that currently store technicians.id.
+update public.jobs as j
+set
+  technician_id = t.user_id,
+  updated_at = coalesce(j.updated_at, now())
+from public.technicians as t
+where j.technician_id is not null
+  and j.technician_id = t.id
+  and t.user_id is not null;
+
+-- 2) Normalize appointments.technician_id values that currently store technicians.id.
+update public.appointments as a
+set
+  technician_id = t.user_id,
+  updated_at = coalesce(a.updated_at, now())
+from public.technicians as t
+where a.technician_id is not null
+  and a.technician_id = t.id
+  and t.user_id is not null;
+
+-- 3) Switch appointments FK to reference technicians(user_id).
+-- (technicians.user_id is unique; nulls are allowed; unassigned appointments remain valid.)
+alter table public.appointments
+  drop constraint if exists appointments_technician_id_fkey;
+
+alter table public.appointments
+  add constraint appointments_technician_id_fkey
+  foreign key (technician_id) references public.technicians(user_id) on delete set null;
+

--- a/command-center/supabase/migrations/20260416224500_packet_008_appointments_job_link_and_sync.sql
+++ b/command-center/supabase/migrations/20260416224500_packet_008_appointments_job_link_and_sync.sql
@@ -1,0 +1,68 @@
+-- Packet 008: Scheduling source-of-truth = appointments
+-- Mirror: jobs.scheduled_* / technician_id / service_address
+
+-- 1) Link appointments to jobs (optional; null means “booking-only / not yet a work order”).
+alter table public.appointments
+  add column if not exists job_id uuid references public.jobs(id) on delete set null;
+
+-- At most one appointment record per job.
+alter table public.appointments
+  drop constraint if exists appointments_job_id_unique;
+
+alter table public.appointments
+  add constraint appointments_job_id_unique unique (job_id);
+
+create index if not exists appointments_job_id_idx
+  on public.appointments (job_id);
+
+-- 2) Mirror appointment schedule → job schedule when job_id is set.
+create or replace function public.sync_job_schedule_from_appointment()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_next_status text;
+begin
+  if new.job_id is null then
+    return new;
+  end if;
+
+  -- Minimal status mapping:
+  -- - confirmed/rescheduled implies scheduled if job is currently unscheduled-ish.
+  -- - otherwise, do not override job status.
+  if lower(coalesce(new.status, '')) in ('confirmed', 'rescheduled') then
+    v_next_status := 'scheduled';
+  else
+    v_next_status := null;
+  end if;
+
+  update public.jobs as j
+  set
+    scheduled_start = coalesce(new.scheduled_start, j.scheduled_start),
+    scheduled_end = coalesce(new.scheduled_end, j.scheduled_end),
+    technician_id = coalesce(new.technician_id, j.technician_id),
+    service_address = coalesce(nullif(new.service_address, ''), j.service_address),
+    status = case
+      when v_next_status is not null
+        and lower(coalesce(j.status, '')) in ('unscheduled', 'pending_schedule')
+        then v_next_status
+      else j.status
+    end,
+    updated_at = now()
+  where j.id = new.job_id
+    and j.tenant_id = new.tenant_id;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_appointments_sync_job_schedule on public.appointments;
+
+create trigger trg_appointments_sync_job_schedule
+after insert or update of job_id, status, scheduled_start, scheduled_end, technician_id, service_address
+on public.appointments
+for each row
+execute function public.sync_job_schedule_from_appointment();
+

--- a/command-center/supabase/migrations/20260416230000_work_order_v1_job_fields.sql
+++ b/command-center/supabase/migrations/20260416230000_work_order_v1_job_fields.sql
@@ -1,0 +1,45 @@
+-- Packet 006: Work Order v1 — add real execution fields to public.jobs (schema first)
+-- Guardrails:
+-- - Additive only
+-- - No dispatch_id
+-- - Do NOT add signature_url or photos_json in this packet
+
+alter table public.jobs
+  add column if not exists scope_summary text,
+  add column if not exists special_conditions text,
+  add column if not exists property_notes text,
+  add column if not exists execution_checklist jsonb,
+  add column if not exists execution_findings jsonb,
+  add column if not exists execution_photos jsonb,
+  add column if not exists technician_notes text,
+  add column if not exists customer_summary text,
+  add column if not exists follow_up_required boolean,
+  add column if not exists follow_up_notes text,
+  add column if not exists report_url text;
+
+-- Safe defaults/backfills (avoid table rewrite on add-column-with-default).
+alter table public.jobs
+  alter column execution_checklist set default '[]'::jsonb,
+  alter column execution_findings set default '[]'::jsonb,
+  alter column execution_photos set default '[]'::jsonb,
+  alter column follow_up_required set default false;
+
+update public.jobs
+set
+  execution_checklist = coalesce(execution_checklist, '[]'::jsonb),
+  execution_findings = coalesce(execution_findings, '[]'::jsonb),
+  execution_photos = coalesce(execution_photos, '[]'::jsonb),
+  follow_up_required = coalesce(follow_up_required, false),
+  updated_at = coalesce(updated_at, now())
+where
+  execution_checklist is null
+  or execution_findings is null
+  or execution_photos is null
+  or follow_up_required is null;
+
+alter table public.jobs
+  alter column execution_checklist set not null,
+  alter column execution_findings set not null,
+  alter column execution_photos set not null,
+  alter column follow_up_required set not null;
+

--- a/command-center/supabase/migrations/20260416231500_packet_009_dispatch_readiness_invariant.sql
+++ b/command-center/supabase/migrations/20260416231500_packet_009_dispatch_readiness_invariant.sql
@@ -1,0 +1,70 @@
+-- Packet 009: Dispatch readiness invariant
+-- Tighten appointment → job status promotion so jobs are not marked scheduled unless they are dispatchable.
+--
+-- Contract (v1):
+-- - Dispatchable/scheduled work must have:
+--   - scheduled_start
+--   - scheduled_end
+--   - technician_id (canonical = technicians.user_id)
+--   - dispatchable service_address
+--
+-- Note: This keeps mirroring fields from appointments to jobs, but only promotes status to 'scheduled'
+-- when the appointment has the required fields. This prevents silent drift where a job becomes scheduled
+-- without technician assignment.
+
+create or replace function public.sync_job_schedule_from_appointment()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_next_status text;
+  v_ready boolean;
+  v_addr text;
+begin
+  if new.job_id is null then
+    return new;
+  end if;
+
+  v_addr := coalesce(nullif(btrim(new.service_address), ''), '');
+
+  -- Conservative readiness check (server-side). UI/edge also enforces dispatchability.
+  -- Address check is intentionally lightweight: we require non-empty and at least a comma plus a state token.
+  v_ready :=
+    new.scheduled_start is not null
+    and new.scheduled_end is not null
+    and new.technician_id is not null
+    and v_addr <> ''
+    and v_addr ~ ',\\s*[^,]+'
+    and v_addr ~* '\\b[A-Z]{2}\\b';
+
+  -- Minimal status mapping:
+  -- - confirmed/rescheduled implies scheduled only if the appointment is dispatch-ready.
+  -- - otherwise, do not override job status.
+  if lower(coalesce(new.status, '')) in ('confirmed', 'rescheduled') and v_ready then
+    v_next_status := 'scheduled';
+  else
+    v_next_status := null;
+  end if;
+
+  update public.jobs as j
+  set
+    scheduled_start = coalesce(new.scheduled_start, j.scheduled_start),
+    scheduled_end = coalesce(new.scheduled_end, j.scheduled_end),
+    technician_id = coalesce(new.technician_id, j.technician_id),
+    service_address = coalesce(nullif(new.service_address, ''), j.service_address),
+    status = case
+      when v_next_status is not null
+        and lower(coalesce(j.status, '')) in ('unscheduled', 'pending_schedule')
+        then v_next_status
+      else j.status
+    end,
+    updated_at = now()
+  where j.id = new.job_id
+    and j.tenant_id = new.tenant_id;
+
+  return new;
+end;
+$$;
+

--- a/command-center/supabase/migrations/20260417120000_h1a_appointments_rls_policies.sql
+++ b/command-center/supabase/migrations/20260417120000_h1a_appointments_rls_policies.sql
@@ -1,0 +1,56 @@
+-- H1a: RLS coverage for public.appointments (tenant isolation baseline)
+-- Goal: lock appointments to tenant-scoped authenticated access + service_role full access.
+
+begin;
+
+alter table public.appointments enable row level security;
+
+drop policy if exists "Appointments are readable by tenant" on public.appointments;
+drop policy if exists "Appointments are insertable by tenant" on public.appointments;
+drop policy if exists "Appointments are updatable by tenant" on public.appointments;
+drop policy if exists "Appointments are deletable by tenant" on public.appointments;
+drop policy if exists "Appointments service role full access" on public.appointments;
+
+create policy "Appointments are readable by tenant"
+  on public.appointments
+  for select
+  to authenticated
+  using (
+    tenant_id = (auth.jwt() -> 'app_metadata' ->> 'tenant_id')
+  );
+
+create policy "Appointments are insertable by tenant"
+  on public.appointments
+  for insert
+  to authenticated
+  with check (
+    tenant_id = (auth.jwt() -> 'app_metadata' ->> 'tenant_id')
+  );
+
+create policy "Appointments are updatable by tenant"
+  on public.appointments
+  for update
+  to authenticated
+  using (
+    tenant_id = (auth.jwt() -> 'app_metadata' ->> 'tenant_id')
+  )
+  with check (
+    tenant_id = (auth.jwt() -> 'app_metadata' ->> 'tenant_id')
+  );
+
+create policy "Appointments are deletable by tenant"
+  on public.appointments
+  for delete
+  to authenticated
+  using (
+    tenant_id = (auth.jwt() -> 'app_metadata' ->> 'tenant_id')
+  );
+
+create policy "Appointments service role full access"
+  on public.appointments
+  for all
+  to service_role
+  using (true)
+  with check (true);
+
+commit;

--- a/command-center/supabase/migrations/20260418171500_p0_vocab_legalize_jobs_invoiced.sql
+++ b/command-center/supabase/migrations/20260418171500_p0_vocab_legalize_jobs_invoiced.sql
@@ -1,0 +1,36 @@
+-- P0 Vocabulary Patch V1 (Patch 1)
+-- Legalize jobs.status='invoiced' in the DB contract guardrail.
+--
+-- Notes:
+-- - Keep constraint NOT VALID to avoid blocking on legacy rows.
+-- - Do not remove existing allowed statuses in this patch (blast-radius control).
+
+begin;
+
+alter table public.jobs
+  drop constraint if exists jobs_status_contract_check;
+
+alter table public.jobs
+  add constraint jobs_status_contract_check
+  check (
+    status is null
+    or status in (
+      'pending',
+      'unscheduled',
+      'pending_schedule',
+      'scheduled',
+      'en_route',
+      'started',
+      'in_progress',
+      'on_hold',
+      'ready_to_invoice',
+      'open',
+      'invoiced',
+      'completed',
+      'closed',
+      'cancelled'
+    )
+  ) not valid;
+
+commit;
+

--- a/command-center/supabase/migrations/20260419093000_db_tighten_jobs_status_contract_v1.sql
+++ b/command-center/supabase/migrations/20260419093000_db_tighten_jobs_status_contract_v1.sql
@@ -1,0 +1,13 @@
+-- SURGICAL STRIKE PACKET V1 (Target A)
+-- Scope: fix only the jobs.status default casing mismatch.
+--
+-- NOTE:
+-- This intentionally does NOT tighten the jobs status contract check.
+-- Contract tightening requires a controlled inventory pass in the target environment.
+
+begin;
+
+alter table public.jobs
+  alter column status set default 'unscheduled';
+
+commit;

--- a/command-center/supabase/migrations/20260419110000_h1b_tenant_id_immutability_v1.sql
+++ b/command-center/supabase/migrations/20260419110000_h1b_tenant_id_immutability_v1.sql
@@ -1,0 +1,52 @@
+-- H1b: Tenant immutability (tenant_id cannot change after insert)
+-- Scope: public.jobs, public.quotes, public.invoices, public.leads, public.appointments
+
+create or replace function public.enforce_tenant_id_immutability()
+returns trigger
+language plpgsql
+as $$
+begin
+  if (old.tenant_id is distinct from new.tenant_id) then
+    raise exception
+      'tenant_id is immutable on %.% (attempted % -> %)',
+      tg_table_schema,
+      tg_table_name,
+      old.tenant_id,
+      new.tenant_id
+      using errcode = '23514';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_tenant_id_immutable_jobs on public.jobs;
+create trigger trg_tenant_id_immutable_jobs
+before update on public.jobs
+for each row
+execute function public.enforce_tenant_id_immutability();
+
+drop trigger if exists trg_tenant_id_immutable_quotes on public.quotes;
+create trigger trg_tenant_id_immutable_quotes
+before update on public.quotes
+for each row
+execute function public.enforce_tenant_id_immutability();
+
+drop trigger if exists trg_tenant_id_immutable_invoices on public.invoices;
+create trigger trg_tenant_id_immutable_invoices
+before update on public.invoices
+for each row
+execute function public.enforce_tenant_id_immutability();
+
+drop trigger if exists trg_tenant_id_immutable_leads on public.leads;
+create trigger trg_tenant_id_immutable_leads
+before update on public.leads
+for each row
+execute function public.enforce_tenant_id_immutability();
+
+drop trigger if exists trg_tenant_id_immutable_appointments on public.appointments;
+create trigger trg_tenant_id_immutable_appointments
+before update on public.appointments
+for each row
+execute function public.enforce_tenant_id_immutability();
+


### PR DESCRIPTION
﻿## Summary
- Restores 22 remote-applied April migration files that were missing from `main`, so local migration history matches production already-applied ledger.
- For the two conflicting service-address migrations (`20260416210000`, `20260416213000`), restores the April-original SQL from `84576c3` (not the later July in-place rewrites).
- Repository-only reconciliation — no production schema changes, no migration repair, no deploy.

## Test plan
- [x] All 22 remote April versions present locally with no duplicate timestamps
- [x] Conflict blobs match `84576c3` exactly
- [x] July inspection migrations unchanged vs `origin/main`
- [x] `supabase db push --linked --dry-run` lists exactly the seven pending July migrations (`20260712233000` … `20260713212000`)
- [ ] Do not merge until reviewed
- [ ] Do not deploy from this PR
