### PR TITLE
fix(inspections): resolve lead property without PostgREST relation

### DIFF
--- a/command-center/src/components/tech/InspectionFieldCustomerStep.jsx
+++ b/command-center/src/components/tech/InspectionFieldCustomerStep.jsx
@@ -7,6 +7,8 @@ import { formatPhoneNumber } from '@/lib/formUtils';
 import {
   LEAD_FIELD_SELECT,
   composeAddressFromParts,
+  hydrateLeadsWithProperties,
+  normalizeLeadRecord,
   resolveServiceAddress,
 } from '@/lib/inspectionFieldAddress';
 import { useToast } from '@/components/ui/use-toast';
@@ -24,12 +26,6 @@ const leadDisplayName = (lead) =>
   `${asText(lead?.first_name)} ${asText(lead?.last_name)}`.trim() ||
   asText(lead?.email) ||
   'Customer';
-
-const normalizeLead = (lead) => {
-  if (!lead) return null;
-  const property = Array.isArray(lead.property) ? lead.property[0] : lead.property;
-  return { ...lead, property: property || null };
-};
 
 const emptyLeadForm = () => ({
   first_name: '',
@@ -66,7 +62,7 @@ export default function InspectionFieldCustomerStep({
   const [saving, setSaving] = useState(false);
   const [addressDraft, setAddressDraft] = useState('');
 
-  const linkedLead = normalizeLead(inspection?.lead);
+  const linkedLead = normalizeLeadRecord(inspection?.lead);
   const linkedName = leadDisplayName(linkedLead);
   const linkedAddress = resolveServiceAddress({
     property: linkedLead?.property,
@@ -110,22 +106,20 @@ export default function InspectionFieldCustomerStep({
       if (leadRes.error) throw leadRes.error;
       if (jobRes.error) throw jobRes.error;
 
-      const leadRows = (leadRes.data || []).map((raw) => {
-        const lead = normalizeLead(raw);
-        return {
-          key: `lead-${lead.id}`,
-          type: 'Lead',
-          leadId: lead.id,
-          jobId: null,
-          propertyId: lead.property_id || lead.property?.id || null,
-          contactId: lead.contact_id || null,
-          name: leadDisplayName(lead),
-          phone: asText(lead.phone),
-          email: asText(lead.email),
-          address: resolveServiceAddress({ property: lead.property, lead }),
-          lead,
-        };
-      });
+      const hydratedLeads = await hydrateLeadsWithProperties(supabase, tenantId, leadRes.data || []);
+      const leadRows = hydratedLeads.map((lead) => ({
+        key: `lead-${lead.id}`,
+        type: 'Lead',
+        leadId: lead.id,
+        jobId: null,
+        propertyId: lead.property_id || lead.property?.id || null,
+        contactId: lead.contact_id || null,
+        name: leadDisplayName(lead),
+        phone: asText(lead.phone),
+        email: asText(lead.email),
+        address: resolveServiceAddress({ property: lead.property, lead }),
+        lead,
+      }));
 
       const jobLeadIds = [...new Set((jobRes.data || []).map((job) => job.lead_id).filter(Boolean))];
       let jobLeads = [];
@@ -136,7 +130,7 @@ export default function InspectionFieldCustomerStep({
           .eq('tenant_id', tenantId)
           .in('id', jobLeadIds);
         if (error) throw error;
-        jobLeads = (data || []).map(normalizeLead);
+        jobLeads = await hydrateLeadsWithProperties(supabase, tenantId, data || []);
       }
       const leadById = new Map(jobLeads.map((row) => [row.id, row]));
 
@@ -187,7 +181,7 @@ export default function InspectionFieldCustomerStep({
     if (!inspection?.id || locked || !leadId) return;
     setSaving(true);
     try {
-      const normalizedLead = normalizeLead(lead);
+      const normalizedLead = normalizeLeadRecord(lead);
       const serviceAddress = asText(address)
         || resolveServiceAddress({
           property: normalizedLead?.property,
@@ -214,9 +208,11 @@ export default function InspectionFieldCustomerStep({
         `)
         .single();
       if (error) throw error;
+      const rawLead = Array.isArray(data.lead) ? data.lead[0] : data.lead;
+      const hydratedLead = await hydrateLeadsWithProperties(supabase, tenantId, rawLead);
       const normalized = {
         ...data,
-        lead: normalizeLead(Array.isArray(data.lead) ? data.lead[0] : data.lead),
+        lead: hydratedLead,
         job: Array.isArray(data.job) ? data.job[0] : data.job,
       };
       toast({ title: 'Customer linked', description: 'Service address saved on this inspection.' });
@@ -252,7 +248,7 @@ export default function InspectionFieldCustomerStep({
       .or(filters.join(','))
       .limit(8);
     if (error) throw error;
-    const rows = (data || []).map(normalizeLead);
+    const rows = await hydrateLeadsWithProperties(supabase, tenantId, data || []);
     setDuplicates(rows);
     return rows;
   };
@@ -387,9 +383,11 @@ export default function InspectionFieldCustomerStep({
         `)
         .single();
       if (error) throw error;
+      const rawLead = Array.isArray(data.lead) ? data.lead[0] : data.lead;
+      const hydratedLead = await hydrateLeadsWithProperties(supabase, tenantId, rawLead);
       const normalized = {
         ...data,
-        lead: normalizeLead(Array.isArray(data.lead) ? data.lead[0] : data.lead),
+        lead: hydratedLead,
         job: Array.isArray(data.job) ? data.job[0] : data.job,
       };
       toast({ title: 'Address saved' });

--- a/command-center/src/lib/inspectionFieldAddress.js
+++ b/command-center/src/lib/inspectionFieldAddress.js
@@ -6,13 +6,57 @@
  *
  * Do not read or write leads.address1/address2/city/state/zip — those columns
  * do not exist in production.
+ *
+ * Do not use nested PostgREST relationship embeds from leads onto properties.
+ * Production does not expose a leads→properties FK relationship in the schema cache.
+ * Load properties with a separate query and attach in application code.
  */
 
 const asText = (value) => (typeof value === 'string' ? value.trim() : '');
 
-/** Lead columns + nested property embed that match production. */
+/** Lead columns that exist in production. No nested relationship embeds. */
 export const LEAD_FIELD_SELECT =
-  'id, first_name, last_name, company, email, phone, address, property_id, contact_id, property:property_id(id, address1, address2, city, state, zip)';
+  'id, first_name, last_name, company, email, phone, address, property_id, contact_id';
+
+/** Property columns used for structured service addresses. */
+export const PROPERTY_FIELD_SELECT = 'id, address1, address2, city, state, zip';
+
+export const normalizeLeadRecord = (lead) => {
+  if (!lead) return null;
+  const property = Array.isArray(lead.property) ? lead.property[0] : lead.property;
+  return { ...lead, property: property || null };
+};
+
+/**
+ * Load properties by id and attach them onto lead rows as `property`.
+ * Uses an explicit properties query — not a PostgREST relationship embed.
+ */
+export const hydrateLeadsWithProperties = async (client, tenantId, leadsInput) => {
+  const inputWasArray = Array.isArray(leadsInput);
+  const leads = (inputWasArray ? leadsInput : [leadsInput])
+    .filter(Boolean)
+    .map(normalizeLeadRecord);
+  if (!leads.length) return inputWasArray ? [] : null;
+
+  const propertyIds = [...new Set(leads.map((lead) => lead.property_id).filter(Boolean))];
+  if (!propertyIds.length) return inputWasArray ? leads : leads[0];
+
+  let query = client
+    .from('properties')
+    .select(PROPERTY_FIELD_SELECT)
+    .in('id', propertyIds);
+  if (tenantId) query = query.eq('tenant_id', tenantId);
+
+  const { data, error } = await query;
+  if (error) throw error;
+
+  const byId = new Map((data || []).map((row) => [row.id, row]));
+  const hydrated = leads.map((lead) => ({
+    ...lead,
+    property: (lead.property_id && byId.get(lead.property_id)) || lead.property || null,
+  }));
+  return inputWasArray ? hydrated : hydrated[0];
+};
 
 export const formatPropertyAddress = (property) => {
   if (!property || typeof property !== 'object') return '';

--- a/command-center/src/pages/tech/TechInspectionReview.jsx
+++ b/command-center/src/pages/tech/TechInspectionReview.jsx
@@ -18,7 +18,11 @@ import InspectionFindingsNarrativeCard from '@/components/tech/InspectionFinding
 import ManualConditionReviewControls, { isManualCondition, manualConditionStatus } from '@/components/tech/ManualConditionReviewControls';
 import InspectionPreflightBlockers from '@/components/tech/InspectionPreflightBlockers';
 import InspectionFieldStepper, { stepHref } from '@/components/tech/InspectionFieldStepper';
-import { LEAD_FIELD_SELECT, resolveServiceAddress } from '@/lib/inspectionFieldAddress';
+import {
+  LEAD_FIELD_SELECT,
+  hydrateLeadsWithProperties,
+  resolveServiceAddress,
+} from '@/lib/inspectionFieldAddress';
 import InspectionServiceRecommendationPicker from '@/components/tech/InspectionServiceRecommendationPicker';
 import {
   buildPreflightBlockerModel,
@@ -130,9 +134,11 @@ export default function TechInspectionReview() {
       if (error) throw error;
       if (!data) throw new Error('Inspection not found.');
 
+      const rawLead = Array.isArray(data.lead) ? data.lead[0] : data.lead;
+      const hydratedLead = await hydrateLeadsWithProperties(supabase, tenantId, rawLead);
       const normalized = {
         ...data,
-        lead: Array.isArray(data.lead) ? data.lead[0] : data.lead,
+        lead: hydratedLead,
         job: Array.isArray(data.job) ? data.job[0] : data.job,
       };
       setInspection(normalized);

--- a/command-center/src/pages/tech/TechInspectionSession.jsx
+++ b/command-center/src/pages/tech/TechInspectionSession.jsx
@@ -21,7 +21,11 @@ import {
 import { assessInspectionPhotoQuality } from '@/lib/inspectionPhotoQuality';
 import { normalizeInspectionStatus } from '@/lib/inspectionStatus';
 import InspectionFieldStepper, { stepHref } from '@/components/tech/InspectionFieldStepper';
-import { LEAD_FIELD_SELECT, resolveServiceAddress } from '@/lib/inspectionFieldAddress';
+import {
+  LEAD_FIELD_SELECT,
+  hydrateLeadsWithProperties,
+  resolveServiceAddress,
+} from '@/lib/inspectionFieldAddress';
 import InspectionFieldCustomerStep from '@/components/tech/InspectionFieldCustomerStep';
 
 const PHOTO_BUCKET = 'inspection-photos';
@@ -115,9 +119,11 @@ export default function TechInspectionSession() {
       if (error) throw error;
       if (!data) throw new Error('Inspection not found.');
 
+      const rawLead = Array.isArray(data.lead) ? data.lead[0] : data.lead;
+      const hydratedLead = await hydrateLeadsWithProperties(supabase, tenantId, rawLead);
       const normalized = {
         ...data,
-        lead: Array.isArray(data.lead) ? data.lead[0] : data.lead,
+        lead: hydratedLead,
         job: Array.isArray(data.job) ? data.job[0] : data.job,
         technician: Array.isArray(data.technician) ? data.technician[0] : data.technician,
       };

--- a/command-center/tests/smoke/inspection-field-address-schema.spec.js
+++ b/command-center/tests/smoke/inspection-field-address-schema.spec.js
@@ -5,8 +5,11 @@ import { fileURLToPath } from 'node:url';
 import { test, expect } from '@playwright/test';
 import {
   LEAD_FIELD_SELECT,
+  PROPERTY_FIELD_SELECT,
   composeAddressFromParts,
   formatPropertyAddress,
+  hydrateLeadsWithProperties,
+  normalizeLeadRecord,
   resolveServiceAddress,
 } from '../../src/lib/inspectionFieldAddress.js';
 
@@ -23,25 +26,20 @@ const TECH_SOURCES = [
   'src/lib/inspectionFieldAddress.js',
 ];
 
-const leadSelectTopLevelColumns = (select) => {
-  // Strip nested property embeds so we only inspect top-level lead columns.
-  const withoutPropertyEmbed = String(select).replace(/property:property_id\([^)]*\)/g, '');
-  return withoutPropertyEmbed;
-};
-
 test('technician sources never select or write invalid lead address columns', async () => {
   for (const relativePath of TECH_SOURCES) {
     const source = readSource(relativePath);
-    const leadTopLevel = leadSelectTopLevelColumns(source);
-    expect(leadTopLevel, relativePath).not.toMatch(/leads\([^)]*\baddress1\b/);
-    expect(leadTopLevel, relativePath).not.toMatch(/leads\([^)]*\baddress2\b/);
+    // Nested PostgREST embed syntax — not comments that merely mention the pattern.
+    expect(source, relativePath).not.toMatch(/property\s*:\s*property_id\s*\(/);
+    expect(source, relativePath).not.toMatch(/leads\([^)]*\baddress1\b/);
+    expect(source, relativePath).not.toMatch(/leads\([^)]*\baddress2\b/);
     if (relativePath.includes('TechInspection') || relativePath.includes('InspectionFieldCustomer')) {
       expect(source).toContain('LEAD_FIELD_SELECT');
+      expect(source).toContain('hydrateLeadsWithProperties');
     }
   }
 
   const customerStep = readSource('src/components/tech/InspectionFieldCustomerStep.jsx');
-  // Lead patch must write freeform address only (plus property_id), never structured lead cols.
   const leadPatchBlock = customerStep.match(/const leadPatch = \{[\s\S]*?\n\s*\};/);
   expect(leadPatchBlock?.[0] || '').toMatch(/address:\s*serviceAddress/);
   expect(leadPatchBlock?.[0] || '').not.toMatch(/\baddress1\s*:/);
@@ -49,14 +47,76 @@ test('technician sources never select or write invalid lead address columns', as
   expect(customerStep).toContain("from('properties')");
   expect(customerStep).toContain('appointmentService.createCustomer');
 
-  const topLevel = leadSelectTopLevelColumns(LEAD_FIELD_SELECT);
   expect(LEAD_FIELD_SELECT).toMatch(/(^|,)\s*address\s*(,|$)/);
-  expect(LEAD_FIELD_SELECT).toContain('property:property_id');
-  expect(LEAD_FIELD_SELECT).toMatch(/property:property_id\([^)]*address1/);
-  expect(topLevel).not.toMatch(/\baddress1\b/);
-  expect(topLevel).not.toMatch(/\bcity\b/);
-  expect(topLevel).not.toMatch(/\bstate\b/);
-  expect(topLevel).not.toMatch(/\bzip\b/);
+  expect(LEAD_FIELD_SELECT).toContain('property_id');
+  expect(LEAD_FIELD_SELECT).not.toMatch(/property\s*:\s*property_id/);
+  expect(LEAD_FIELD_SELECT).not.toMatch(/\baddress1\b/);
+  expect(LEAD_FIELD_SELECT).not.toMatch(/\bcity\b/);
+  expect(PROPERTY_FIELD_SELECT).toMatch(/\baddress1\b/);
+});
+
+test('hydrateLeadsWithProperties loads properties via separate query', async () => {
+  const calls = [];
+  const client = {
+    from(table) {
+      calls.push(table);
+      return {
+        select(columns) {
+          calls.push(columns);
+          return {
+            in(column, ids) {
+              calls.push({ column, ids });
+              return {
+                eq() {
+                  return Promise.resolve({
+                    data: [
+                      {
+                        id: 'prop-1',
+                        address1: '201 Secondary Property Rd',
+                        address2: null,
+                        city: 'Titusville',
+                        state: 'FL',
+                        zip: '32780',
+                      },
+                    ],
+                    error: null,
+                  });
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+
+  const withProperty = await hydrateLeadsWithProperties(client, 'tvg', [
+    { id: 'lead-1', property_id: 'prop-1', address: 'FALLBACK LEAD ADDRESS ONLY' },
+    { id: 'lead-2', property_id: null, address: '101 Lead Only Lane' },
+  ]);
+
+  expect(calls[0]).toBe('properties');
+  expect(calls[1]).toBe(PROPERTY_FIELD_SELECT);
+  expect(withProperty[0].property.address1).toBe('201 Secondary Property Rd');
+  expect(resolveServiceAddress({ lead: withProperty[0] })).toMatch(/201 Secondary Property Rd/);
+  expect(resolveServiceAddress({ lead: withProperty[0] })).not.toMatch(/FALLBACK LEAD ADDRESS ONLY/);
+  expect(withProperty[1].property).toBeNull();
+  expect(resolveServiceAddress({ lead: withProperty[1] })).toBe('101 Lead Only Lane');
+});
+
+test('lead without property_id still loads and uses leads.address', async () => {
+  const client = {
+    from() {
+      throw new Error('properties query should not run when no property_id values exist');
+    },
+  };
+  const lead = await hydrateLeadsWithProperties(client, 'tvg', {
+    id: 'lead-3',
+    property_id: null,
+    address: '101 Test Airflow Lane, Titusville, FL 32780',
+  });
+  expect(normalizeLeadRecord(lead).property).toBeNull();
+  expect(resolveServiceAddress({ lead })).toContain('101 Test Airflow Lane');
 });
 
 test('resolveServiceAddress priority: property → inspection/job → leads.address', async () => {
@@ -111,27 +171,6 @@ test('resolveServiceAddress priority: property → inspection/job → leads.addr
       lead: { address: '' },
     }),
   ).toBe('');
-});
-
-test('existing lead with leads.address loads without structured lead columns', async () => {
-  const lead = { id: 'lead-1', address: '101 Test Airflow Lane, Titusville, FL 32780', property: null };
-  const resolved = resolveServiceAddress({ lead });
-  expect(resolved).toContain('101 Test Airflow Lane');
-  expect(lead).not.toHaveProperty('address1');
-});
-
-test('linked property structured address takes precedence over leads.address', async () => {
-  const lead = {
-    address: 'FALLBACK LEAD ADDRESS ONLY',
-    property: {
-      address1: '201 Secondary Property Rd',
-      city: 'Titusville',
-      state: 'FL',
-      zip: '32780',
-    },
-  };
-  expect(resolveServiceAddress({ lead })).toMatch(/201 Secondary Property Rd/);
-  expect(resolveServiceAddress({ lead })).not.toMatch(/FALLBACK LEAD ADDRESS ONLY/);
 });
 
 test('composeAddressFromParts builds freeform text from form input without parsing leads.address', async () => {


### PR DESCRIPTION
## Summary
- Technician inspection load failed in production because PostgREST cannot resolve nested `property:property_id(...)` embeds from `leads`.
- Hotfix queries lead columns only, loads matching `properties` in a separate query, and merges in application code.
- Preserves address priority: linked property → inspection/job service address → `leads.address` → empty.

## Test plan
- [x] Focused address schema / hydrate tests
- [x] Existing inspection field UX smoke tests
- [x] lint / build / review:gate
- [ ] Production smoke after deploy: open inspection, customer step, address resolution, no relationship error
- [ ] Confirm PDF function remains v8; no migration
