### PR TITLE
fix(inspections): harden lead property hydrate for production schema

### DIFF
--- a/command-center/src/components/tech/InspectionFieldCustomerStep.jsx
+++ b/command-center/src/components/tech/InspectionFieldCustomerStep.jsx
@@ -297,32 +297,13 @@ export default function InspectionFieldCustomerStep({
 
       const serviceAddress = composeAddressFromParts(form);
 
-      // Structured address lives on properties (production schema).
-      let propertyId = null;
-      const propertyInsert = await supabase
-        .from('properties')
-        .insert({
-          tenant_id: tenantId,
-          address1: asText(form.address1) || null,
-          address2: asText(form.address2) || null,
-          city: asText(form.city) || null,
-          state: asText(form.state) || null,
-          zip: asText(form.zip) || null,
-        })
-        .select('id, address1, address2, city, state, zip')
-        .single();
-      if (propertyInsert.error) {
-        console.warn('Property create skipped:', propertyInsert.error.message);
-      } else {
-        propertyId = propertyInsert.data?.id || null;
-      }
-
-      // Freeform lead address + optional property link only (no leads.address1/city/…).
+      // Production public.properties uses bigint ids + address_line_1 and cannot be
+      // linked through leads.property_id (uuid). Persist freeform address on the lead only.
       const leadPatch = {
         address: serviceAddress || null,
+        property_formatted_address: serviceAddress || null,
         updated_at: new Date().toISOString(),
       };
-      if (propertyId) leadPatch.property_id = propertyId;
 
       const addressUpdate = await supabase
         .from('leads')
@@ -336,13 +317,13 @@ export default function InspectionFieldCustomerStep({
       const linkedLeadRow = {
         ...created,
         ...leadPatch,
-        property: propertyInsert.data || null,
+        property: null,
       };
 
       await linkSelection({
         leadId: created.id,
         jobId: null,
-        propertyId,
+        propertyId: null,
         contactId: created.contact_id || null,
         address: serviceAddress,
         lead: linkedLeadRow,

--- a/command-center/src/lib/inspectionFieldAddress.js
+++ b/command-center/src/lib/inspectionFieldAddress.js
@@ -2,24 +2,28 @@
  * Production-safe address helpers for the technician inspection field flow.
  *
  * Lead freeform address: leads.address
- * Structured address: properties.address1/address2/city/state/zip via property_id
+ * Denormalized property text on the lead: leads.property_formatted_address
  *
- * Do not read or write leads.address1/address2/city/state/zip — those columns
- * do not exist in production.
- *
- * Do not use nested PostgREST relationship embeds from leads onto properties.
- * Production does not expose a leads→properties FK relationship in the schema cache.
- * Load properties with a separate query and attach in application code.
+ * Important production facts:
+ * - Do not use nested PostgREST relationship embeds from leads onto properties.
+ * - public.properties.id is bigint (marketing/scouting table).
+ * - leads.property_id is uuid and is NOT a resolvable FK to public.properties.
+ * - Never let a failed properties lookup block inspection load.
  */
 
 const asText = (value) => (typeof value === 'string' ? value.trim() : '');
 
 /** Lead columns that exist in production. No nested relationship embeds. */
 export const LEAD_FIELD_SELECT =
-  'id, first_name, last_name, company, email, phone, address, property_id, contact_id';
+  'id, first_name, last_name, company, email, phone, address, property_id, property_formatted_address, contact_id';
 
-/** Property columns used for structured service addresses. */
-export const PROPERTY_FIELD_SELECT = 'id, address1, address2, city, state, zip';
+/**
+ * Columns for public.properties when a numeric id is present.
+ * Production uses address_line_1 (not address1/address2).
+ */
+export const PROPERTY_FIELD_SELECT = 'id, address_line_1, city, state, zip';
+
+const isNumericPropertyId = (value) => /^\d+$/.test(String(value ?? '').trim());
 
 export const normalizeLeadRecord = (lead) => {
   if (!lead) return null;
@@ -28,44 +32,50 @@ export const normalizeLeadRecord = (lead) => {
 };
 
 /**
- * Load properties by id and attach them onto lead rows as `property`.
- * Uses an explicit properties query — not a PostgREST relationship embed.
+ * Optionally attach a properties row for numeric property ids only.
+ * UUID leads.property_id values are left unresolved (no throw).
  */
-export const hydrateLeadsWithProperties = async (client, tenantId, leadsInput) => {
+export const hydrateLeadsWithProperties = async (client, _tenantId, leadsInput) => {
   const inputWasArray = Array.isArray(leadsInput);
   const leads = (inputWasArray ? leadsInput : [leadsInput])
     .filter(Boolean)
     .map(normalizeLeadRecord);
   if (!leads.length) return inputWasArray ? [] : null;
 
-  const propertyIds = [...new Set(leads.map((lead) => lead.property_id).filter(Boolean))];
+  const propertyIds = [
+    ...new Set(leads.map((lead) => lead.property_id).filter(isNumericPropertyId)),
+  ];
   if (!propertyIds.length) return inputWasArray ? leads : leads[0];
 
-  let query = client
-    .from('properties')
-    .select(PROPERTY_FIELD_SELECT)
-    .in('id', propertyIds);
-  if (tenantId) query = query.eq('tenant_id', tenantId);
+  try {
+    const { data, error } = await client
+      .from('properties')
+      .select(PROPERTY_FIELD_SELECT)
+      .in('id', propertyIds);
+    if (error) throw error;
 
-  const { data, error } = await query;
-  if (error) throw error;
-
-  const byId = new Map((data || []).map((row) => [row.id, row]));
-  const hydrated = leads.map((lead) => ({
-    ...lead,
-    property: (lead.property_id && byId.get(lead.property_id)) || lead.property || null,
-  }));
-  return inputWasArray ? hydrated : hydrated[0];
+    const byId = new Map((data || []).map((row) => [String(row.id), row]));
+    const hydrated = leads.map((lead) => ({
+      ...lead,
+      property:
+        (lead.property_id && byId.get(String(lead.property_id))) || lead.property || null,
+    }));
+    return inputWasArray ? hydrated : hydrated[0];
+  } catch (error) {
+    // Never block technician inspection load on properties lookup mismatch.
+    console.warn('Property hydrate skipped:', error?.message || error);
+    return inputWasArray ? leads : leads[0];
+  }
 };
 
 export const formatPropertyAddress = (property) => {
   if (!property || typeof property !== 'object') return '';
+  const line1 = asText(property.address_line_1 || property.address1);
+  const line2 = asText(property.address_line_2 || property.address2);
   const cityLine = [asText(property.city), asText(property.state), asText(property.zip)]
     .filter(Boolean)
     .join(' ');
-  return [asText(property.address1), asText(property.address2), cityLine]
-    .filter(Boolean)
-    .join(', ');
+  return [line1, line2, cityLine].filter(Boolean).join(', ');
 };
 
 /**
@@ -86,7 +96,7 @@ export const composeAddressFromParts = ({
 /**
  * Resolve the display/report service address.
  * Priority:
- *   a. linked property structured address
+ *   a. attached property structured address OR leads.property_formatted_address
  *   b. inspection / job service address already in context
  *   c. leads.address
  *   d. empty
@@ -97,10 +107,13 @@ export const resolveServiceAddress = ({
   jobServiceAddress = '',
   lead = null,
 } = {}) => {
-  const fromProperty = formatPropertyAddress(
-    property || (Array.isArray(lead?.property) ? lead.property[0] : lead?.property) || null,
-  );
+  const attached =
+    property || (Array.isArray(lead?.property) ? lead.property[0] : lead?.property) || null;
+  const fromProperty = formatPropertyAddress(attached);
   if (fromProperty) return fromProperty;
+
+  const fromFormatted = asText(lead?.property_formatted_address);
+  if (fromFormatted) return fromFormatted;
 
   const fromInspection = asText(inspectionServiceAddress);
   if (fromInspection) return fromInspection;

--- a/command-center/tests/smoke/inspection-field-address-schema.spec.js
+++ b/command-center/tests/smoke/inspection-field-address-schema.spec.js
@@ -26,36 +26,45 @@ const TECH_SOURCES = [
   'src/lib/inspectionFieldAddress.js',
 ];
 
-test('technician sources never select or write invalid lead address columns', async () => {
+test('technician sources never select nested lead/property PostgREST embeds', async () => {
   for (const relativePath of TECH_SOURCES) {
     const source = readSource(relativePath);
-    // Nested PostgREST embed syntax — not comments that merely mention the pattern.
     expect(source, relativePath).not.toMatch(/property\s*:\s*property_id\s*\(/);
     expect(source, relativePath).not.toMatch(/leads\([^)]*\baddress1\b/);
-    expect(source, relativePath).not.toMatch(/leads\([^)]*\baddress2\b/);
     if (relativePath.includes('TechInspection') || relativePath.includes('InspectionFieldCustomer')) {
       expect(source).toContain('LEAD_FIELD_SELECT');
       expect(source).toContain('hydrateLeadsWithProperties');
     }
   }
 
-  const customerStep = readSource('src/components/tech/InspectionFieldCustomerStep.jsx');
-  const leadPatchBlock = customerStep.match(/const leadPatch = \{[\s\S]*?\n\s*\};/);
-  expect(leadPatchBlock?.[0] || '').toMatch(/address:\s*serviceAddress/);
-  expect(leadPatchBlock?.[0] || '').not.toMatch(/\baddress1\s*:/);
-  expect(leadPatchBlock?.[0] || '').not.toMatch(/\bcity\s*:/);
-  expect(customerStep).toContain("from('properties')");
-  expect(customerStep).toContain('appointmentService.createCustomer');
-
   expect(LEAD_FIELD_SELECT).toMatch(/(^|,)\s*address\s*(,|$)/);
   expect(LEAD_FIELD_SELECT).toContain('property_id');
+  expect(LEAD_FIELD_SELECT).toContain('property_formatted_address');
   expect(LEAD_FIELD_SELECT).not.toMatch(/property\s*:\s*property_id/);
-  expect(LEAD_FIELD_SELECT).not.toMatch(/\baddress1\b/);
-  expect(LEAD_FIELD_SELECT).not.toMatch(/\bcity\b/);
-  expect(PROPERTY_FIELD_SELECT).toMatch(/\baddress1\b/);
+  expect(PROPERTY_FIELD_SELECT).toContain('address_line_1');
+  expect(PROPERTY_FIELD_SELECT).not.toMatch(/\baddress1\b/);
 });
 
-test('hydrateLeadsWithProperties loads properties via separate query', async () => {
+test('hydrate skips UUID property_id and never queries incompatible properties ids', async () => {
+  const client = {
+    from() {
+      throw new Error('properties query must not run for UUID property_id values');
+    },
+  };
+
+  const lead = await hydrateLeadsWithProperties(client, 'tvg', {
+    id: 'lead-uuid',
+    property_id: '13662027-a547-46b6-ada6-f89f4fe0ec09',
+    address: 'FALLBACK LEAD ADDRESS ONLY',
+    property_formatted_address: '201 Secondary Property Rd, Titusville, FL 32780',
+  });
+
+  expect(normalizeLeadRecord(lead).property).toBeNull();
+  expect(resolveServiceAddress({ lead })).toMatch(/201 Secondary Property Rd/);
+  expect(resolveServiceAddress({ lead })).not.toMatch(/FALLBACK LEAD ADDRESS ONLY/);
+});
+
+test('hydrate loads numeric property ids via separate query and swallows lookup errors', async () => {
   const calls = [];
   const client = {
     from(table) {
@@ -66,23 +75,18 @@ test('hydrateLeadsWithProperties loads properties via separate query', async () 
           return {
             in(column, ids) {
               calls.push({ column, ids });
-              return {
-                eq() {
-                  return Promise.resolve({
-                    data: [
-                      {
-                        id: 'prop-1',
-                        address1: '201 Secondary Property Rd',
-                        address2: null,
-                        city: 'Titusville',
-                        state: 'FL',
-                        zip: '32780',
-                      },
-                    ],
-                    error: null,
-                  });
-                },
-              };
+              return Promise.resolve({
+                data: [
+                  {
+                    id: 42,
+                    address_line_1: '42 Numeric Property Way',
+                    city: 'Titusville',
+                    state: 'FL',
+                    zip: '32780',
+                  },
+                ],
+                error: null,
+              });
             },
           };
         },
@@ -91,17 +95,37 @@ test('hydrateLeadsWithProperties loads properties via separate query', async () 
   };
 
   const withProperty = await hydrateLeadsWithProperties(client, 'tvg', [
-    { id: 'lead-1', property_id: 'prop-1', address: 'FALLBACK LEAD ADDRESS ONLY' },
+    { id: 'lead-1', property_id: 42, address: 'FALLBACK' },
     { id: 'lead-2', property_id: null, address: '101 Lead Only Lane' },
   ]);
 
   expect(calls[0]).toBe('properties');
   expect(calls[1]).toBe(PROPERTY_FIELD_SELECT);
-  expect(withProperty[0].property.address1).toBe('201 Secondary Property Rd');
-  expect(resolveServiceAddress({ lead: withProperty[0] })).toMatch(/201 Secondary Property Rd/);
-  expect(resolveServiceAddress({ lead: withProperty[0] })).not.toMatch(/FALLBACK LEAD ADDRESS ONLY/);
+  expect(formatPropertyAddress(withProperty[0].property)).toMatch(/42 Numeric Property Way/);
+  expect(resolveServiceAddress({ lead: withProperty[0] })).toMatch(/42 Numeric Property Way/);
   expect(withProperty[1].property).toBeNull();
   expect(resolveServiceAddress({ lead: withProperty[1] })).toBe('101 Lead Only Lane');
+
+  const failingClient = {
+    from() {
+      return {
+        select() {
+          return {
+            in() {
+              return Promise.resolve({ data: null, error: { message: 'boom' } });
+            },
+          };
+        },
+      };
+    },
+  };
+  const resilient = await hydrateLeadsWithProperties(failingClient, 'tvg', {
+    id: 'lead-3',
+    property_id: '99',
+    address: '101 Lead Only Lane',
+  });
+  expect(resilient.property).toBeNull();
+  expect(resolveServiceAddress({ lead: resilient })).toBe('101 Lead Only Lane');
 });
 
 test('lead without property_id still loads and uses leads.address', async () => {
@@ -119,10 +143,9 @@ test('lead without property_id still loads and uses leads.address', async () => 
   expect(resolveServiceAddress({ lead })).toContain('101 Test Airflow Lane');
 });
 
-test('resolveServiceAddress priority: property → inspection/job → leads.address', async () => {
+test('resolveServiceAddress priority: property → formatted → inspection/job → leads.address', async () => {
   const property = {
-    address1: '200 Property Ave',
-    address2: 'Unit 2',
+    address_line_1: '200 Property Ave',
     city: 'Titusville',
     state: 'FL',
     zip: '32780',
@@ -132,9 +155,18 @@ test('resolveServiceAddress priority: property → inspection/job → leads.addr
       property,
       inspectionServiceAddress: '999 Inspection St',
       jobServiceAddress: '888 Job Rd',
-      lead: { address: '777 Lead Lane' },
+      lead: { address: '777 Lead Lane', property_formatted_address: 'Formatted Property' },
     }),
   ).toBe(formatPropertyAddress(property));
+
+  expect(
+    resolveServiceAddress({
+      property: null,
+      inspectionServiceAddress: '999 Inspection St',
+      jobServiceAddress: '888 Job Rd',
+      lead: { address: '777 Lead Lane', property_formatted_address: 'Formatted Property' },
+    }),
+  ).toBe('Formatted Property');
 
   expect(
     resolveServiceAddress({
@@ -162,15 +194,6 @@ test('resolveServiceAddress priority: property → inspection/job → leads.addr
       lead: { address: '777 Lead Lane' },
     }),
   ).toBe('777 Lead Lane');
-
-  expect(
-    resolveServiceAddress({
-      property: null,
-      inspectionServiceAddress: '',
-      jobServiceAddress: '',
-      lead: { address: '' },
-    }),
-  ).toBe('');
 });
 
 test('composeAddressFromParts builds freeform text from form input without parsing leads.address', async () => {
@@ -184,14 +207,12 @@ test('composeAddressFromParts builds freeform text from form input without parsi
   expect(composed).toBe('55 Brand New Lead Way, Titusville FL 32780');
 });
 
-test('new-lead production payload uses createCustomer fields only on leads insert', async () => {
-  const appointmentSource = readSource('src/services/appointmentService.js');
-  expect(appointmentSource).toMatch(/async createCustomer/);
-  expect(appointmentSource).toMatch(/from\('leads'\)\.insert\(insertPayload\)/);
-  expect(appointmentSource).not.toMatch(/insertPayload[\s\S]{0,200}address1/);
-
+test('new-lead flow persists freeform lead address and does not write invalid properties.address1', async () => {
   const customerStep = readSource('src/components/tech/InspectionFieldCustomerStep.jsx');
+  const leadPatchBlock = customerStep.match(/const leadPatch = \{[\s\S]*?\n\s*\};/);
+  expect(leadPatchBlock?.[0] || '').toMatch(/address:\s*serviceAddress/);
+  expect(leadPatchBlock?.[0] || '').not.toMatch(/\baddress1\s*:/);
+  expect(customerStep).not.toMatch(/\.insert\(\{[\s\S]*address1:/);
+  expect(customerStep).toContain('appointmentService.createCustomer');
   expect(customerStep).toMatch(/source:\s*'field_inspection'/);
-  expect(customerStep).toMatch(/linkSelection\(/);
-  expect(customerStep).toMatch(/onContinue\?\.\(\)/);
 });


### PR DESCRIPTION
## Summary
- Follow-up to #37: production `properties.id` is bigint while `leads.property_id` is uuid, so a separate properties lookup was still able to break inspection load.
- Skip incompatible UUID property ids, never throw on properties lookup failure, and use `leads.property_formatted_address` / `leads.address` for display.
- New-lead flow writes freeform lead address only (no invalid `properties.address1` insert).

## Test plan
- [x] Focused address schema / hydrate tests
- [x] Existing inspection field UX smoke tests
- [x] build / review:gate
- [ ] Production smoke after deploy
