### PR TITLE
fix(data): stabilize legacy property relationship handling

### DIFF
--- a/command-center/docs/stabilization/R1_IDENTITY_RELATIONSHIP_PLAN.md
+++ b/command-center/docs/stabilization/R1_IDENTITY_RELATIONSHIP_PLAN.md
@@ -1,0 +1,385 @@
+# R1 — Identity & Relationship Safety Plan
+
+**Status:** R1A implementation in progress on `stabilize/r1a-property-relationship-safety`  
+**Base tip:** `b3d2599d2ba3c4f994a7e1ed8254496df4913fa2`  
+**Worktree used for audit:** `F:\Dev\BHFOS-stabilize-r1-plan` (detached `origin/main`)  
+**R1A worktree:** `F:\Dev\BHFOS-stabilize-r1a-property`  
+**Dirty tree `F:\Dev\BHFOS`:** not used  
+**Backlog seeds:** B-001, B-002, B-011, B-014 (and related embed/identity items)
+
+### R1A production read-only verification (2026-07-15)
+
+| Question | Result |
+| --- | --- |
+| Invoice `property_id` populated? | **0** non-null rows observed |
+| Invoice `service_address` column? | **Absent** (customer_name/email/phone present) |
+| jobs→properties PostgREST relation? | **None** (`Could not find a relationship between 'jobs' and 'properties'`) |
+| Live `/pay/:token` path | `PaymentPage` → `public-invoice` + `public-pay` (**not** `paymentService`) |
+| `paymentService` imported in src? | **No** — still fixed as release-critical dead path |
+| leads.property_id → properties | Still invalid (UUID vs bigint; embed fails) |
+
+---
+
+## 1. Confirmed production type contracts
+
+| Contract | Production reality | Local migration assumption | V1 ruling |
+| --- | --- | --- | --- |
+| `leads.property_id` | **uuid** | uuid FK → `properties(id)` | Treat as opaque pointer; **do not join** to hosted `properties` |
+| `public.properties.id` | **bigint** (marketing/scouting) | uuid in `20260101_…` | Not CRM SoT |
+| Property street column | **`address_line_1`** | `address1` in money-loop DDL | Never select `address1` from hosted `properties` |
+| Service address SoT (field) | `property_formatted_address` → inspection/job `service_address` → `leads.address` | N/A | Keep hotfix priority from #37/#38 |
+| `technicians.id` | uuid PK | uuid | **Assignment FK target** |
+| `technicians.user_id` | uuid unique → `auth.users` | uuid | **Auth mapping only** |
+| `jobs.technician_id` | FK → **`technicians.id`** (phase 1.5) | Earlier migration stored `user_id` | Writes must be `technicians.id` |
+| `appointments.technician_id` | FK → **`technicians.id`** (phase 1.5) | Earlier FK to `user_id` | Writes must be `technicians.id` |
+| `inspections.technician_id` | FK → **`technicians.id`** | uuid | Same |
+
+Hotfixes verified present on tip:
+
+- `inspectionFieldAddress.js`: `hydrateLeadsWithProperties`, numeric-id guard, `property_formatted_address`, no nested embed select
+- Tech inspection pages use `LEAD_FIELD_SELECT` + hydrate
+
+---
+
+## 2. Property relationship findings
+
+### Classification legend
+
+- **SAFE** — no PostgREST lead→properties embed; uses freeform / denormalized address; or numeric-only hydrate with catch
+- **UNSAFE** — active path can fail load or write wrong address due to embed/FK/column mismatch
+- **LEGACY BUT CONTAINED** — orphaned / unrouted / fallback chain eventually reaches `*`
+- **UNKNOWN** — needs production read-only confirmation
+- **V2 DEFER** — full CRM property model redesign
+
+### Unsafe (active)
+
+| File | Location | Workflow | Assumption | Production reality | Failure mode | Smallest safe fix | Test |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `src/services/paymentService.js` | `getInvoiceByToken` ~L27–32 | Public pay | `lead → properties!fk_leads_property(address1…)` | No FK; bigint id; no `address1` | Pay page load / address blank / PostgREST error | Remove embed; select `leads.address`, `property_formatted_address`, invoice denorm fields | Public invoice/pay select contract + smoke |
+| `src/services/paymentService.js` | `getInvoiceById` ~L56 | Office invoice | `property:properties!fk_invoices_property(*)` | Same drift if invoice.property_id uuid vs bigint properties | Invoice detail fail | Drop embed; use invoice/lead address columns | Invoice-by-id select contract |
+| `src/pages/crm/proposals/ProposalBuilder.jsx` | `fetchLeadsWithFallback` L211–212 | Estimates/quotes | Tries `property:property_id(address1…)` before `*` | Embed fails; falls through to `*` if relation error handler catches | Extra failed requests; if error classifier wrong → hard fail | Remove embed variants; select lead address columns only; reuse address helper | Lead fetch fallback unit/source test |
+| `src/pages/crm/AuditInspector.jsx` | select ~L57 | Audit/debug CRM | `property:properties(address1…)` | Same | Screen fail | Remove embed or gate behind feature | Source ban test |
+| `src/pages/tech/TechSchedule.jsx` | jobs select L45 | Tech schedule (orphaned route) | `jobs → properties(address1…)` | Unclear jobs↔properties FK; `address1` wrong | Query error if route remounted | Use `jobs.service_address` / lead address | If remounted in R3, contract test |
+| `src/pages/tech/TechDashboard.jsx` | jobs select ~L35 | Orphaned tech dashboard | Nested `properties(address1…)` | Same | Same | Prefer `service_address` | Contained until routed |
+| `src/components/crm/jobs/JobManager.jsx` | select ~L27 | Jobs UI helper | Nested `properties(address1)` | Same | List fail | Prefer `service_address` | Source/contract |
+
+### Safe (keep)
+
+| File | Pattern | Why SAFE |
+| --- | --- | --- |
+| `src/lib/inspectionFieldAddress.js` | Separate hydrate; UUID skip; catch; `address_line_1` | Hotfix contract |
+| Tech inspection session/review + `InspectionFieldCustomerStep` | `LEAD_FIELD_SELECT` + hydrate; freeform lead address write | Hotfix #37/#38 |
+| `InspectionEditor.jsx` | Selects lead `property_id` scalar only (no embed) | Pointer only |
+
+### Legacy but contained / lower priority
+
+| File | Note |
+| --- | --- |
+| `TechSchedule.jsx` / `TechDashboard.jsx` | Not in `TechRoutes.jsx` — still fix if touched; else R1A optional cleanup only if zero risk |
+| `CallConsole.jsx` / `InspectionReport.jsx` | Uses `lead.address1` form fields — may be empty in prod (leads use `address`); not PostgREST embed — classify **UNKNOWN** integrity, not embed outage |
+| `QuoteView.jsx` mock `address1` | Mock data only |
+
+### V2 defer
+
+- Redesign CRM `properties` table / unify with marketing properties  
+- Backfill all historical `leads.property_id` to a new CRM property entity  
+- Multi-tenant property graph
+
+---
+
+## 3. Technician identity findings
+
+### Authoritative V1 contract (recommended — minimize change)
+
+```
+auth.users.id  ←→  technicians.user_id   (login / RLS actor)
+technicians.id  ←→  jobs.technician_id
+                ←→  appointments.technician_id
+                ←→  inspections.technician_id
+```
+
+**Meaning:**
+
+- **Auth identity** = `auth.users.id`  
+- **Roster identity** = `technicians.id`  
+- **Assignment columns always store roster identity (`technicians.id`)**  
+- Resolve login → roster via `technicians.user_id = auth.uid()`
+
+### Conflicting migrations (historical)
+
+| Migration | Direction |
+| --- | --- |
+| `20260416220000_unify_technician_id_on_user_id.sql` | Forced `jobs`/`appointments.technician_id` = `user_id` |
+| `20260512184500_phase1_fix_appointment_technician_fk.sql` | Reversed appointments → `technicians.id` |
+| `20260512205000` + `20260512210000_phase1_5_jobs_technician_fk.sql` | Backfilled jobs user_id→id; FK to `technicians.id` |
+
+**Latest wins:** assignment FKs → `technicians.id`.
+
+### Code alignment
+
+| Area | Behavior | Risk |
+| --- | --- | --- |
+| Tech PWA (`TechQueue`, `TechJobDetail`, `TechSchedule`) | Look up tech by `user_id`, filter jobs by `tech.id` | **SAFE** |
+| `AppointmentScheduler.jsx` | Select writes `tech.id` | **SAFE** |
+| `InspectionEditor.jsx` | Assigns technician roster id | **SAFE** (verify create payload) |
+| `inspection-report-pdf` | Loads technician by `eq('id', inspection.technician_id)` | **SAFE** |
+| **`Jobs.jsx`** | SelectItem `value={tech.user_id}`; `resolveTechnicianSelection` returns `user_id`; writes that to `jobs.technician_id` | **UNSAFE** — FK / silent mis-assign |
+| **`Schedule.jsx` (dispatch)** | Sets `dispatch_id: tech.user_id \|\| tech.id`; writes `technician_id: dispatchTechnicianId` | **UNSAFE** — same |
+| `TechDashboard.jsx` comment | Mentions filter by userId | Orphaned; misleading |
+
+### Edge functions
+
+| Function | Notes |
+| --- | --- |
+| `work-order-update` | Passes `technician_id` through; assumes caller sends correct id |
+| `create-appointment` / `update-appointment-status` | Accept `technician_id`; PostgREST join `technicians (full_name)` implies FK to `technicians.id` |
+| PDF | Uses `technicians.id` |
+
+---
+
+## 4. Unsafe active code locations (implementation hit list)
+
+### Property / address
+
+1. `src/services/paymentService.js` — public + auth invoice selects  
+2. `src/pages/crm/proposals/ProposalBuilder.jsx` — `fetchLeadsWithFallback`  
+3. `src/pages/crm/AuditInspector.jsx` — lead property embed  
+4. `src/components/crm/jobs/JobManager.jsx` — jobs→properties embed  
+5. `src/pages/tech/TechSchedule.jsx` / `TechDashboard.jsx` — jobs→properties embed (orphaned but dangerous if remounted)
+
+### Technician
+
+6. `src/pages/crm/Jobs.jsx` — writes `user_id` into `technician_id`  
+7. `src/pages/crm/Schedule.jsx` — dispatch writes `user_id` via `dispatch_id`
+
+---
+
+## 5. Safe fallback patterns already in use (preserve)
+
+1. **Lead field select without embeds** — `LEAD_FIELD_SELECT`  
+2. **Numeric-only properties hydrate + swallow errors** — `hydrateLeadsWithProperties`  
+3. **Address priority** — attached property → `property_formatted_address` → inspection/job service address → `leads.address`  
+4. **New lead from field** — freeform `leads.address` + `property_formatted_address` only (no properties insert)  
+5. **Tech auth bootstrap** — `technicians.user_id = auth.uid()` then use `technicians.id` for queries  
+
+Do **not** regress these in R1.
+
+---
+
+## 6. Proposed shared helpers
+
+### A. Expand / centralize address resolution (prefer reuse)
+
+**Module:** `src/lib/inspectionFieldAddress.js` (or rename-neutral export surface)
+
+Add thin CRM-facing wrappers (names indicative):
+
+- `LEAD_ADDRESS_SELECT` — columns only: `address, property_formatted_address, property_id, …`  
+- `resolveLeadServiceAddress(lead, extras)` — already mostly `resolveServiceAddress`  
+- Document: **never** export a PostgREST embed string for property
+
+Avoid a second parallel address library.
+
+### B. Technician identity helper (new small module)
+
+**Proposed:** `src/lib/technicianIdentity.js`
+
+```text
+resolveTechnicianRosterId({ technicians, value }) → technicians.id | null
+resolveTechnicianAuthUserId({ technicians, value }) → user_id | null  // display/debug only
+assertAssignmentIdIsRosterId(value) // dev/test helper
+TECHNICIAN_ROSTER_SELECT = 'id, user_id, full_name, is_active'
+```
+
+Rules baked into helper JSDoc:
+
+- UI selects for assignment must use `technicians.id`  
+- Mapping from session uses `user_id`  
+
+---
+
+## 7. Proposed tests and guardrails
+
+### Static / source contract tests (Playwright or node assert specs)
+
+1. **Ban nested lead→property embeds** in active paths:
+   - Fail if `src/**` matches `property:property_id(` or `properties!fk_leads_property`  
+   - Allowlist empty (or only docs)
+
+2. **Ban jobs nested `properties (` embeds** in tech/CRM job loaders (or require `service_address`)
+
+3. **Technician write contract:**
+   - `Jobs.jsx` / `Schedule.jsx` must not use `SelectItem value={tech.user_id}` for assignment  
+   - Prefer assert helper usage / `value={tech.id}`
+
+### Focused behavior tests
+
+4. PaymentService select string does not include property embeds; includes lead address fields  
+5. ProposalBuilder lead fetch does not attempt property embed  
+6. Jobs assignment payload uses roster id (unit with mock tech list)  
+7. Existing `inspection-field-address-schema.spec.js` remains green  
+
+### Review-gate / docs
+
+8. Short note in `docs/stabilization/` or helper header: forbidden patterns  
+9. Optional CI grep step in existing smoke/lint — **prefer test file over new framework**  
+10. Migration immutability: **out of R1 code**; keep as R8 hygiene unless a one-line check is free
+
+---
+
+## 8. Files expected to change
+
+### R1A — Property relationship safety
+
+- `src/services/paymentService.js`
+- `src/pages/crm/proposals/ProposalBuilder.jsx`
+- `src/pages/crm/AuditInspector.jsx`
+- `src/components/crm/jobs/JobManager.jsx`
+- Optionally orphaned: `TechSchedule.jsx`, `TechDashboard.jsx` (same PR if tiny; else leave with TODO + ban test exemption until R3)
+- `src/lib/inspectionFieldAddress.js` — only if exporting shared select helpers
+- `tests/smoke/*` contract specs
+
+### R1B — Technician identity lock
+
+- `src/lib/technicianIdentity.js` (**new**, small)
+- `src/pages/crm/Jobs.jsx`
+- `src/pages/crm/Schedule.jsx`
+- Focused tests
+- Docs comment in ownership map (optional cross-link)
+
+### R1C — Guards / regression nets
+
+- New/updated smoke contract tests  
+- Possibly `package.json` script `test:identity-contracts` calling the same specs  
+- No workflow YAML change unless checks already cover `npm test` (they don’t today) — **keep guards as smoke tests run in PR checklist / local CI optional**
+
+---
+
+## 9. Migration required?
+
+**No** for R1.
+
+Rationale:
+
+- Hotfixes already prove app-level fallbacks work without schema change  
+- Redesigning properties is V2  
+- Technician FK already points at `technicians.id` per latest migrations; fix is **write-path alignment**, not a new migration  
+
+If production probe shows `jobs.technician_id` still contains many `user_id` values despite FK, that becomes **UNKNOWN → read-only verification** before any data backfill migration (separate approved release).
+
+---
+
+## 10. Migration risk
+
+| Item | Risk |
+| --- | --- |
+| R1A/R1B/R1C as planned | **None** (no migration) |
+| Accidental property redesign | High — forbidden |
+| Silent data backfill of technician ids | Medium — do not include without approval + inventory query |
+
+---
+
+## 11. Bounded PR sequence
+
+### R1A — Remove unsafe property relationship assumptions
+
+| Field | Value |
+| --- | --- |
+| Goal | Ban/fix active PostgREST property embeds; preserve address fallbacks |
+| Includes | paymentService, ProposalBuilder lead fetch, AuditInspector, JobManager; shared select helpers if needed |
+| Excludes | Technician changes; property schema; money status authority |
+| Branch | `stabilize/r1a-property-relationship-safety` |
+| Worktree | `F:\Dev\BHFOS-stabilize-r1a` from `origin/main` |
+| Acceptance | No forbidden embed patterns in owned files; public pay + quote lead load succeed with lead address; inspection field tests still pass |
+
+### R1B — Lock technician identity usage
+
+| Field | Value |
+| --- | --- |
+| Goal | Assignment UIs write `technicians.id` only |
+| Includes | Jobs.jsx, Schedule.jsx, `technicianIdentity.js`, tests |
+| Excludes | Property work; remounting TechSchedule |
+| Branch | `stabilize/r1b-technician-identity-contract` |
+| Depends on | R1A merged preferred (low file overlap — can parallelize if orchestrator assigns different files) |
+| Acceptance | Assign tech from Jobs + Dispatch; DB value equals `technicians.id`; tech queue still shows job |
+
+**Overlap note:** `Schedule.jsx` may also touch address display — keep address fixes in R1A only; R1B only technician fields.
+
+### R1C — Static guards and regression tests
+
+| Field | Value |
+| --- | --- |
+| Goal | Prevent recurrence |
+| Includes | Repo-wide source contract tests; document forbidden patterns |
+| Excludes | Feature changes |
+| Branch | `stabilize/r1c-identity-guardrails` |
+| Depends on | R1A + R1B merged so bans don’t fail on known violators |
+| Acceptance | Contract suite fails if embed/`user_id` assignment pattern reintroduced |
+
+**Do not combine A+B+C** into one PR: different risk domains and clearer rollback.
+
+---
+
+## 12. Acceptance criteria (R1 complete)
+
+1. No active `property:property_id(` or `properties!fk_leads_property` in `src/`  
+2. Public pay invoice load does not depend on properties embed  
+3. Quote/estimate lead picker loads without property embed  
+4. Inspection field address tests remain green  
+5. Jobs + Dispatch assignment persist `technicians.id`  
+6. Tech PWA queue still resolves via `user_id` → `id`  
+7. Contract tests exist and pass  
+8. No migration  
+9. No production schema change  
+10. Docs: this plan + backlog dispositions updated after merge  
+
+---
+
+## 13. Deployment and rollback
+
+| Topic | Guidance |
+| --- | --- |
+| Deploy | Frontend-only Hostinger deploy after each PR or after R1A–C bundle — **human approved**, clean worktree |
+| Edge functions | No redeploy unless a function file changes (not planned) |
+| Rollback | Redeploy previous Hostinger asset pair; no DB rollback |
+| Smoke | Synthetic: open public invoice token path (if available safely), CRM quote lead list, assign technician on job, tech queue still lists job; inspection open with UUID `property_id` |
+
+---
+
+## 14. Explicit V2 deferrals
+
+- Unified CRM property entity replacing marketing `properties`  
+- Migrating `leads.property_id` to a valid FK  
+- Multi-property customers  
+- Full user/technician role redesign  
+- Rewriting dispatch board architecture  
+- Invoice/payment authority (R5)  
+- Deploy tooling on main (R8)  
+
+---
+
+## Unknowns requiring production read-only verification
+
+1. Whether `invoices.property_id` is populated in prod and of what type  
+2. Whether `jobs` has any PostgREST relationship to `properties` (TechSchedule embed)  
+3. Distribution of `jobs.technician_id` values still equal to `technicians.user_id` vs `technicians.id`  
+4. Whether `paymentService.getInvoiceByToken` is on the live `/pay/:token` path or superseded by edge `public-pay`  
+5. Whether ProposalBuilder’s relation-error fallback always triggers (classifier robustness)
+
+**Method:** read-only SQL/API probes with service role; no writes; no customer contact.
+
+---
+
+## Most dangerous active code path
+
+**`paymentService.getInvoiceByToken`** — customer-facing payment load embeds broken lead→properties relationship with non-existent `address1` columns. Closely followed by **`Jobs.jsx` / `Schedule.jsx` writing `technicians.user_id` into `jobs.technician_id`** against an FK to `technicians.id`.
+
+---
+
+## Change control
+
+| Action | Status |
+| --- | --- |
+| Implementation | **Not started** — awaiting explicit approval |
+| Deployment | None |
+| Production modification | None |

--- a/command-center/src/components/crm/jobs/JobManager.jsx
+++ b/command-center/src/components/crm/jobs/JobManager.jsx
@@ -23,8 +23,7 @@ const JobManager = () => {
             .from('jobs')
             .select(`
                 *,
-                leads (first_name, last_name, email),
-                properties (address1, city)
+                leads (first_name, last_name, email, address, property_formatted_address)
             `)
             .order('scheduled_start', { ascending: false });
         
@@ -136,7 +135,12 @@ const JobManager = () => {
                                             <div className="text-xs text-muted-foreground">{job.leads?.email}</div>
                                         </TableCell>
                                         <TableCell>{job.scheduled_start ? format(new Date(job.scheduled_start), 'MMM d, h:mm a') : 'Unscheduled'}</TableCell>
-                                        <TableCell>{job.properties?.address1}</TableCell>
+                                        <TableCell>
+                                          {job.service_address
+                                            || job.leads?.property_formatted_address
+                                            || job.leads?.address
+                                            || 'No address on file'}
+                                        </TableCell>
                                         <TableCell>{getStatusBadge(job.status)}</TableCell>
                                         <TableCell>{getPaymentBadge(job.payment_status)}</TableCell>
                                         <TableCell className="text-right font-medium">${job.total_amount?.toLocaleString()}</TableCell>

--- a/command-center/src/lib/inspectionFieldAddress.js
+++ b/command-center/src/lib/inspectionFieldAddress.js
@@ -124,4 +124,42 @@ export const resolveServiceAddress = ({
   return asText(lead?.address) || '';
 };
 
+/**
+ * CRM / invoice / job address resolution that never depends on PostgREST
+ * lead→properties embeds.
+ *
+ * Priority:
+ *   a. snapshot / formatted address already on the record
+ *   b. job or invoice service_address
+ *   c. leads.property_formatted_address
+ *   d. leads.address
+ *   e. empty
+ */
+export const resolveLegacyServiceAddress = ({
+  snapshotAddress = '',
+  serviceAddress = '',
+  lead = null,
+  property = null,
+} = {}) => {
+  const snapshot = asText(snapshotAddress);
+  if (snapshot) return snapshot;
+
+  const fromService = asText(serviceAddress);
+  if (fromService) return fromService;
+
+  const attached =
+    property || (Array.isArray(lead?.property) ? lead.property[0] : lead?.property) || null;
+  const fromProperty = formatPropertyAddress(attached);
+  if (fromProperty) return fromProperty;
+
+  const fromFormatted = asText(lead?.property_formatted_address);
+  if (fromFormatted) return fromFormatted;
+
+  return asText(lead?.address) || '';
+};
+
+/** Lead columns safe for CRM selects — no nested property embeds. */
+export const LEAD_ADDRESS_SELECT =
+  'id, first_name, last_name, company, email, phone, address, property_id, property_formatted_address, contact_id';
+
 export const leadHasUsableAddress = (lead) => Boolean(resolveServiceAddress({ lead }));

--- a/command-center/src/pages/crm/AuditInspector.jsx
+++ b/command-center/src/pages/crm/AuditInspector.jsx
@@ -53,8 +53,10 @@ export default function AuditInspector() {
           created_at,
           notes,
           is_test_data,
-          contact:contacts!leads_contact_id_fkey(first_name, last_name, email),
-          property:properties(address1, city, state)
+          address,
+          property_formatted_address,
+          property_id,
+          contact:contacts!leads_contact_id_fkey(first_name, last_name, email)
         `)
         .order('created_at', { ascending: false });
       
@@ -350,17 +352,14 @@ export default function AuditInspector() {
                             )}
                           </TableCell>
                           <TableCell>
-                            {lead.property ? (
+                            {(lead.property_formatted_address || lead.address) ? (
                               <div className="text-sm">
                                 <div className="font-medium text-slate-700">
-                                  {lead.property.address1}
-                                </div>
-                                <div className="text-xs text-slate-500">
-                                  {lead.property.city}, {lead.property.state}
+                                  {lead.property_formatted_address || lead.address}
                                 </div>
                               </div>
                             ) : (
-                              <span className="text-xs text-slate-400 italic">No linked property</span>
+                              <span className="text-xs text-slate-400 italic">No address on file</span>
                             )}
                           </TableCell>
                           <TableCell>

--- a/command-center/src/pages/crm/jobs/JobCompletion.jsx
+++ b/command-center/src/pages/crm/jobs/JobCompletion.jsx
@@ -43,7 +43,7 @@ const JobCompletion = () => {
         try {
             const { data, error } = await supabase
                 .from('jobs')
-                .select('*, leads(*), properties(*)')
+                .select('*, leads(id, first_name, last_name, email, address, property_formatted_address)')
                 .eq('id', jobId)
                 .single();
 
@@ -88,7 +88,10 @@ const JobCompletion = () => {
             if (emailCustomer && job.leads?.email) {
                 const emailHtml = generateHygieneReportEmail({
                     customerName: job.leads.first_name,
-                    serviceAddress: job.properties?.address1 || 'Your Address',
+                    serviceAddress: job.service_address
+                      || job.leads?.property_formatted_address
+                      || job.leads?.address
+                      || 'Your Address',
                     serviceDate: new Date().toLocaleDateString(),
                     technicianName: 'The Vent Guys Tech',
                     findings: findings,

--- a/command-center/src/pages/crm/proposals/ProposalBuilder.jsx
+++ b/command-center/src/pages/crm/proposals/ProposalBuilder.jsx
@@ -35,6 +35,9 @@ import { Badge } from '@/components/ui/badge';
 import AddressAutocomplete from '@/components/AddressAutocomplete';
 import { formatPhoneNumber } from '@/lib/formUtils';
 import {
+  resolveLegacyServiceAddress,
+} from '@/lib/inspectionFieldAddress';
+import {
   getDeliveryPreferenceLabel,
   resolveLeadDelivery,
 } from '@/lib/documentDelivery';
@@ -207,9 +210,9 @@ const insertQuoteItemsWithSchemaFallback = async (items) => {
 };
 
 const fetchLeadsWithFallback = async (tenantId) => {
+  // Never nest PostgREST property embeds from leads — production has no leads→properties FK.
   const selectVariants = [
-    '*, contact:contacts!leads_contact_id_fkey(preferred_contact_method), property:property_id(address1,address2,city,state,zip)',
-    '*, property:property_id(address1,address2,city,state,zip)',
+    '*, contact:contacts!leads_contact_id_fkey(preferred_contact_method)',
     '*',
   ];
 
@@ -234,18 +237,12 @@ const fetchLeadsWithFallback = async (tenantId) => {
 
 const formatLeadServiceAddress = (lead) => {
   if (!lead) return '';
-  const property = Array.isArray(lead.property) ? lead.property[0] : lead.property;
-  if (!property || typeof property !== 'object') return '';
-  return [
-    property.address1,
-    property.address2,
-    property.city,
-    property.state,
-    property.zip,
-  ]
-    .map((part) => normalizeAddress(part))
-    .filter(Boolean)
-    .join(', ');
+  return normalizeAddress(
+    resolveLegacyServiceAddress({
+      snapshotAddress: lead.property_formatted_address || '',
+      lead,
+    }),
+  );
 };
 
 const formatSelectedAddress = (addressData) => {

--- a/command-center/src/pages/tech/TechDashboard.jsx
+++ b/command-center/src/pages/tech/TechDashboard.jsx
@@ -31,8 +31,7 @@ const TechDashboard = () => {
             .from('jobs')
             .select(`
                 *,
-                leads (first_name, last_name, phone, health_risk_flags),
-                properties (address1, city, zip, gate_code)
+                leads (first_name, last_name, phone, health_risk_flags, address, property_formatted_address)
             `)
             .in('status', ['scheduled', 'in_progress'])
             .order('scheduled_start', { ascending: true });
@@ -102,11 +101,12 @@ const TechDashboard = () => {
                                         <div className="flex items-start text-sm">
                                             <MapPin className="h-4 w-4 text-gray-400 mr-2 mt-0.5" />
                                             <div>
-                                                <p className="text-gray-800">{job.properties?.address1}</p>
-                                                <p className="text-gray-500">{job.properties?.city}, {job.properties?.zip}</p>
-                                                {job.properties?.gate_code && (
-                                                    <p className="text-xs font-mono bg-gray-100 inline-block px-1 rounded mt-1">Gate: {job.properties.gate_code}</p>
-                                                )}
+                                                <p className="text-gray-800">
+                                                  {job.service_address
+                                                    || job.leads?.property_formatted_address
+                                                    || job.leads?.address
+                                                    || 'No address on file'}
+                                                </p>
                                             </div>
                                         </div>
                                         

--- a/command-center/src/pages/tech/TechSchedule.jsx
+++ b/command-center/src/pages/tech/TechSchedule.jsx
@@ -41,8 +41,7 @@ const TechSchedule = () => {
                 .from('jobs')
                 .select(`
                     *,
-                    leads ( first_name, last_name, phone ),
-                    properties ( address1, city, zip )
+                    leads ( first_name, last_name, phone, address, property_formatted_address )
                 `)
                 .eq('technician_id', techData.id)
                 .gte('scheduled_start', start)
@@ -129,8 +128,10 @@ const TechSchedule = () => {
                                     <div className="flex items-start">
                                         <MapPin className="h-4 w-4 mr-2 mt-0.5 text-slate-400 shrink-0" />
                                         <span>
-                                            {job.properties?.address1}<br/>
-                                            {job.properties?.city}, {job.properties?.zip}
+                                            {job.service_address
+                                              || job.leads?.property_formatted_address
+                                              || job.leads?.address
+                                              || 'No address on file'}
                                         </span>
                                     </div>
                                     <div className="flex items-center">

--- a/command-center/src/services/paymentService.js
+++ b/command-center/src/services/paymentService.js
@@ -1,9 +1,37 @@
 import { supabase } from '@/lib/supabaseClient';
+import {
+  LEAD_ADDRESS_SELECT,
+  normalizeLeadRecord,
+  resolveLegacyServiceAddress,
+} from '@/lib/inspectionFieldAddress';
 
 /**
- * Service to handle payment processing and invoice retrieval
- * explicitly using the new Foreign Key naming conventions to avoid ambiguity.
+ * Payment / invoice retrieval.
+ *
+ * Never embed leads→properties. Production does not expose a valid
+ * leads.property_id → properties.id relationship.
  */
+
+const INVOICE_LEAD_SELECT = `lead:leads!fk_invoices_lead(${LEAD_ADDRESS_SELECT})`;
+
+const attachResolvedServiceAddress = (invoice) => {
+  if (!invoice) return invoice;
+  const lead = normalizeLeadRecord(
+    Array.isArray(invoice.lead) ? invoice.lead[0] : invoice.lead,
+  );
+  const job = Array.isArray(invoice.job) ? invoice.job[0] : invoice.job;
+  const serviceAddress = resolveLegacyServiceAddress({
+    snapshotAddress: invoice.service_address || '',
+    serviceAddress: job?.service_address || invoice.service_address || '',
+    lead,
+  });
+  return {
+    ...invoice,
+    lead,
+    job: job || null,
+    resolved_service_address: serviceAddress || null,
+  };
+};
 
 export const paymentService = {
   /**
@@ -17,29 +45,16 @@ export const paymentService = {
       .select(`
         *,
         items:invoice_items(*),
-        lead:leads!fk_invoices_lead(
-          id, 
-          first_name, 
-          last_name, 
-          email, 
-          phone, 
-          company,
-          property:properties!fk_leads_property(
-            address1, 
-            city, 
-            state, 
-            zip
-          )
-        ),
+        ${INVOICE_LEAD_SELECT},
         organization:organizations(*),
-        job:jobs!fk_invoices_job(job_number, status),
+        job:jobs!fk_invoices_job(job_number, status, service_address),
         estimate:estimates!fk_invoices_estimate(estimate_number)
       `)
       .eq('public_token', token)
       .single();
 
     if (error) throw error;
-    return data;
+    return attachResolvedServiceAddress(data);
   },
 
   /**
@@ -51,10 +66,9 @@ export const paymentService = {
       .select(`
         *,
         items:invoice_items(*),
-        lead:leads!fk_invoices_lead(*),
+        ${INVOICE_LEAD_SELECT},
         account:accounts!fk_invoices_account(id, name, type),
-        property:properties!fk_invoices_property(*),
-        job:jobs!fk_invoices_job(*),
+        job:jobs!fk_invoices_job(id, job_number, status, service_address),
         quote:quotes!fk_invoices_quote(*),
         estimate:estimates!fk_invoices_estimate(*)
       `)
@@ -62,7 +76,7 @@ export const paymentService = {
       .single();
 
     if (error) throw error;
-    return data;
+    return attachResolvedServiceAddress(data);
   },
 
   /**
@@ -78,17 +92,17 @@ export const paymentService = {
        console.warn('Payment amount exceeds balance due');
     }
 
-    // 2. Call Supabase RPC to handle transaction safely
+    // 2. Call Supabase RPC to handle transaction safely (financial authority unchanged)
     const { data, error } = await supabase.rpc('process_public_payment', {
       p_token: token,
       p_amount: amount,
-      p_method: method
+      p_method: method,
     });
 
     if (error) throw error;
     return data;
   },
-  
+
   /**
    * Fetch all transactions for an invoice
    */
@@ -98,8 +112,8 @@ export const paymentService = {
       .select('*')
       .eq('invoice_id', invoiceId)
       .order('created_at', { ascending: false });
-      
+
     if (error) throw error;
     return data;
-  }
+  },
 };

--- a/command-center/tests/smoke/r1a-property-relationship-safety.spec.js
+++ b/command-center/tests/smoke/r1a-property-relationship-safety.spec.js
@@ -1,0 +1,163 @@
+/* eslint-disable testing-library/prefer-screen-queries, jest/valid-title */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test, expect } from '@playwright/test';
+import {
+  LEAD_ADDRESS_SELECT,
+  LEAD_FIELD_SELECT,
+  resolveLegacyServiceAddress,
+  resolveServiceAddress,
+} from '../../src/lib/inspectionFieldAddress.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(here, '../..');
+const srcRoot = path.join(root, 'src');
+
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+const walkJsFiles = (dir, out = []) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkJsFiles(full, out);
+    else if (/\.(js|jsx)$/.test(entry.name)) out.push(full);
+  }
+  return out;
+};
+
+const BANNED_EMBED = /property\s*:\s*property_id\s*\(/;
+const BANNED_FK_LEAD = /properties!fk_leads_property/;
+const BANNED_FK_INVOICE = /properties!fk_invoices_property/;
+const BANNED_JOBS_PROPERTIES = /properties\s*\(\s*address1/;
+
+test('active src never uses banned lead/property PostgREST embeds', async () => {
+  const files = walkJsFiles(srcRoot);
+  const offenders = [];
+  for (const file of files) {
+    const source = fs.readFileSync(file, 'utf8');
+    // Allow comments that mention the banned pattern only if not actual select syntax.
+    const lines = source.split(/\r?\n/);
+    lines.forEach((line, idx) => {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) return;
+      if (BANNED_EMBED.test(line) || BANNED_FK_LEAD.test(line) || BANNED_FK_INVOICE.test(line)) {
+        offenders.push(`${path.relative(root, file)}:${idx + 1}`);
+      }
+      if (BANNED_JOBS_PROPERTIES.test(line) && !trimmed.startsWith('//')) {
+        offenders.push(`${path.relative(root, file)}:${idx + 1}:jobs-properties-address1`);
+      }
+    });
+  }
+  expect(offenders, offenders.join('\n')).toEqual([]);
+});
+
+test('paymentService does not use unsafe property embeds and resolves address fallbacks', async () => {
+  const source = read('src/services/paymentService.js');
+  expect(source).not.toMatch(BANNED_EMBED);
+  expect(source).not.toMatch(BANNED_FK_LEAD);
+  expect(source).not.toMatch(BANNED_FK_INVOICE);
+  expect(source).toContain('LEAD_ADDRESS_SELECT');
+  expect(source).toContain('resolveLegacyServiceAddress');
+  expect(source).toContain('resolved_service_address');
+
+  // Financial authority unchanged
+  expect(source).toMatch(/process_public_payment/);
+  expect(source).not.toMatch(/p_metadata/);
+});
+
+test('invoice/service address fallback order is correct', async () => {
+  const lead = {
+    property_id: '13662027-a547-46b6-ada6-f89f4fe0ec09',
+    property_formatted_address: '201 Secondary Property Rd, Titusville, FL 32780',
+    address: 'FALLBACK LEAD ADDRESS ONLY',
+  };
+
+  expect(
+    resolveLegacyServiceAddress({
+      snapshotAddress: 'SNAP SHOT ADDR',
+      serviceAddress: '99 Job Service St',
+      lead,
+    }),
+  ).toBe('SNAP SHOT ADDR');
+
+  expect(
+    resolveLegacyServiceAddress({
+      snapshotAddress: '',
+      serviceAddress: '99 Job Service St',
+      lead,
+    }),
+  ).toBe('99 Job Service St');
+
+  expect(
+    resolveLegacyServiceAddress({
+      snapshotAddress: '',
+      serviceAddress: '',
+      lead,
+    }),
+  ).toMatch(/201 Secondary Property Rd/);
+
+  expect(
+    resolveLegacyServiceAddress({
+      snapshotAddress: '',
+      serviceAddress: '',
+      lead: { property_id: '13662027-a547-46b6-ada6-f89f4fe0ec09', address: '101 Lead Only Lane' },
+    }),
+  ).toBe('101 Lead Only Lane');
+
+  expect(
+    resolveLegacyServiceAddress({
+      snapshotAddress: '',
+      serviceAddress: '',
+      lead: { property_id: '13662027-a547-46b6-ada6-f89f4fe0ec09', address: '' },
+    }),
+  ).toBe('');
+});
+
+test('UUID property_id does not require properties join for address resolution', async () => {
+  const lead = {
+    property_id: '13662027-a547-46b6-ada6-f89f4fe0ec09',
+    address: '101 Lead Only Lane',
+  };
+  expect(resolveLegacyServiceAddress({ lead })).toBe('101 Lead Only Lane');
+  expect(resolveServiceAddress({ lead })).toBe('101 Lead Only Lane');
+});
+
+test('lead without property_id still resolves leads.address', async () => {
+  const lead = { property_id: null, address: '55 Brand New Lead Way' };
+  expect(resolveLegacyServiceAddress({ lead })).toBe('55 Brand New Lead Way');
+});
+
+test('ProposalBuilder loads leads without nested property embed', async () => {
+  const source = read('src/pages/crm/proposals/ProposalBuilder.jsx');
+  expect(source).not.toMatch(BANNED_EMBED);
+  expect(source).toContain('resolveLegacyServiceAddress');
+  expect(source).toMatch(/contact:contacts!leads_contact_id_fkey/);
+});
+
+test('office job/audit paths do not embed incompatible properties', async () => {
+  const jobManager = read('src/components/crm/jobs/JobManager.jsx');
+  const audit = read('src/pages/crm/AuditInspector.jsx');
+  const completion = read('src/pages/crm/jobs/JobCompletion.jsx');
+  for (const source of [jobManager, audit, completion]) {
+    expect(source).not.toMatch(BANNED_EMBED);
+    expect(source).not.toMatch(/properties\s*\(/);
+  }
+  expect(jobManager).toContain('service_address');
+  expect(audit).toContain('property_formatted_address');
+});
+
+test('inspection safe helper contract remains unchanged for field selects', async () => {
+  expect(LEAD_FIELD_SELECT).toContain('property_formatted_address');
+  expect(LEAD_FIELD_SELECT).not.toMatch(BANNED_EMBED);
+  expect(LEAD_ADDRESS_SELECT).not.toMatch(BANNED_EMBED);
+  const helper = read('src/lib/inspectionFieldAddress.js');
+  expect(helper).toContain('hydrateLeadsWithProperties');
+  expect(helper).toContain('isNumericPropertyId');
+});
+
+test('technician assignment selectors are untouched by R1A', async () => {
+  const jobs = read('src/pages/crm/Jobs.jsx');
+  // R1B territory — must still be present unchanged in this PR
+  expect(jobs).toContain('value={tech.user_id}');
+  expect(jobs).toContain('resolveTechnicianSelection');
+});


### PR DESCRIPTION
## Summary

R1A removes active PostgREST assumptions that `leads.property_id` can join to `public.properties.id`.

## Production verification (read-only)

- Live `/pay/:token` uses `public-invoice` + `public-pay` (not `paymentService`)
- `jobs → properties` relationship does not exist in PostgREST
- `leads.property_id` UUID still cannot resolve to bigint `properties.id`
- Invoice `property_id` unused in sampled production data

## Changes

- Remove unsafe property embeds from paymentService, ProposalBuilder, AuditInspector, JobManager, JobCompletion, and orphaned tech schedule/dashboard loaders
- Preserve inspection hotfix helpers; add `resolveLegacyServiceAddress` / `LEAD_ADDRESS_SELECT`
- Add focused source-contract + fallback tests

## Out of scope

- Technician identity (R1B)
- Broader identity guardrails (R1C)
- Property schema redesign (V2)
- No migration / no deploy / no payments processed

## Test plan

- [x] `r1a-property-relationship-safety.spec.js`
- [x] `inspection-field-address-schema.spec.js`
- [x] lint / build / review:gate
- [ ] CI required checks
