### PR TITLE
fix(technicians): stabilize assignment identity usage

### DIFF
--- a/command-center/docs/stabilization/R1_IDENTITY_RELATIONSHIP_PLAN.md
+++ b/command-center/docs/stabilization/R1_IDENTITY_RELATIONSHIP_PLAN.md
@@ -1,9 +1,9 @@
 # R1 — Identity & Relationship Safety Plan
 
-**Status:** R1A implementation in progress on `stabilize/r1a-property-relationship-safety`  
-**Base tip:** `b3d2599d2ba3c4f994a7e1ed8254496df4913fa2`  
-**Worktree used for audit:** `F:\Dev\BHFOS-stabilize-r1-plan` (detached `origin/main`)  
-**R1A worktree:** `F:\Dev\BHFOS-stabilize-r1a-property`  
+**Status:** R1A deployed; R1B implementation on `stabilize/r1b-technician-identity`  
+**Base tip (R1B):** `6d398e7c8104b4717ed07c71cb82a6608adc0bc1`  
+**R1A merge tip:** `6d398e7c8104b4717ed07c71cb82a6608adc0bc1`  
+**R1B worktree:** `F:\Dev\BHFOS-stabilize-r1b-technician`  
 **Dirty tree `F:\Dev\BHFOS`:** not used  
 **Backlog seeds:** B-001, B-002, B-011, B-014 (and related embed/identity items)
 
@@ -123,8 +123,8 @@ technicians.id  ←→  jobs.technician_id
 | `AppointmentScheduler.jsx` | Select writes `tech.id` | **SAFE** |
 | `InspectionEditor.jsx` | Assigns technician roster id | **SAFE** (verify create payload) |
 | `inspection-report-pdf` | Loads technician by `eq('id', inspection.technician_id)` | **SAFE** |
-| **`Jobs.jsx`** | SelectItem `value={tech.user_id}`; `resolveTechnicianSelection` returns `user_id`; writes that to `jobs.technician_id` | **UNSAFE** — FK / silent mis-assign |
-| **`Schedule.jsx` (dispatch)** | Sets `dispatch_id: tech.user_id \|\| tech.id`; writes `technician_id: dispatchTechnicianId` | **UNSAFE** — same |
+| **`Jobs.jsx`** | SelectItem `value={tech.id}`; selection helper returns roster id via `technicianIdentity` | **CORRECT** (R1B) |
+| **`Schedule.jsx` (dispatch)** | SelectItem `value={technician.id}`; no `dispatch_id` alias | **CORRECT** (R1B) |
 | `TechDashboard.jsx` comment | Mentions filter by userId | Orphaned; misleading |
 
 ### Edge functions
@@ -376,10 +376,58 @@ If production probe shows `jobs.technician_id` still contains many `user_id` val
 
 ---
 
+## 15. R1B production verification (2026-07-15, read-only)
+
+| Question | Evidence | Result |
+| --- | --- | --- |
+| `jobs.technician_id` FK target | `jobs_technician_id_fkey` → `technicians.id` | **PASS** |
+| `appointments.technician_id` FK target | `appointments_technician_id_fkey` → `technicians.id` | **PASS** |
+| `inspections.technician_id` FK target | `inspections_technician_id_fkey` → `technicians.id` | **PASS** |
+| Column types | uuid for assignment columns + `technicians.id` / `user_id` | **PASS** |
+| Jobs rows storing `user_id` instead of roster id | 0 of 6 assigned jobs | **PASS** |
+| Appointments rows storing `user_id` | 0 assigned appointments | **PASS** |
+| Inspections rows storing `user_id` | 0 of 10 assigned inspections | **PASS** |
+| Orphan assignment ids (no roster match) | 0 | **PASS** |
+| Duplicate `technicians.user_id` | 0 groups | **PASS** |
+| Roster rows missing `user_id` | 1 of 2 (cannot log in as tech; not an assignment FK violation) | **REPORT** |
+| `technicians.user_id` FK to `auth.users` | Unique index present; no FK constraint in `pg_constraint` | **REPORT** (auth linkage by convention + unique index) |
+
+**Bad-row / repair need:** None for assignment columns. No data repair and no migration in R1B.
+
+### R1B code paths corrected
+
+| Path | Before | After |
+| --- | --- | --- |
+| `Jobs.jsx` SelectItem / selection helper | wrote/preferred `technicians.user_id` | writes `technicians.id` via `technicianIdentity` |
+| `Schedule.jsx` dispatch_id / SelectItem | preferred `user_id \|\| id` | roster id only; `dispatch_id` removed |
+| Shared helper | absent | `src/lib/technicianIdentity.js` |
+
+### Already correct (unchanged)
+
+- `TechQueue.jsx` / `TechJobDetail.jsx` — auth → `user_id` → filter by `technicians.id`
+- `AppointmentScheduler.jsx` / `InspectionEditor.jsx` — SelectItem `tech.id`
+- `inspection-report-pdf` — loads technician by roster id
+
+### Guardrails added
+
+- `tests/smoke/r1b-technician-identity-contract.spec.js`
+- R1A smoke no longer preserves the old `value={tech.user_id}` expectation
+
+### V2 / later deferrals (unchanged)
+
+- Add DB FK from `technicians.user_id` → `auth.users` if desired
+- Remount/fix orphaned `TechDashboard.jsx` / `TechSchedule.jsx` in scheduling UX work
+- Broader R1C static guard consolidation
+- Any historical data repair (not needed today)
+
+---
+
 ## Change control
 
 | Action | Status |
 | --- | --- |
-| Implementation | **Not started** — awaiting explicit approval |
-| Deployment | None |
-| Production modification | None |
+| R1A | Deployed |
+| R1B implementation | In progress on `stabilize/r1b-technician-identity` |
+| Deployment | Frontend-only after merge + checks |
+| Production data repair | None |
+| Migration | None |

--- a/command-center/src/lib/technicianIdentity.js
+++ b/command-center/src/lib/technicianIdentity.js
@@ -1,0 +1,84 @@
+/**
+ * V1 technician identity helpers.
+ *
+ * Approved production contract:
+ * - auth.users.id identifies the logged-in user
+ * - technicians.user_id links a roster row to auth.users.id (auth mapping only)
+ * - technicians.id is the authoritative technician assignment ID
+ * - jobs.technician_id / appointments.technician_id / inspections.technician_id
+ *   must store technicians.id
+ *
+ * Resolve login → roster via:
+ *   auth user id → technicians.user_id → technicians.id
+ *
+ * Assignment UI option values must be technicians.id, never technicians.user_id.
+ */
+
+const asText = (value) => (typeof value === 'string' ? value.trim() : '');
+
+/** Safe roster columns for assignment selectors and login resolution. */
+export const TECHNICIAN_ROSTER_SELECT = 'id, user_id, full_name, is_active';
+
+/**
+ * Find a technician roster row from a stored assignment value or select value.
+ * Accepts technicians.id (preferred) or legacy technicians.user_id for display/read.
+ */
+export const findTechnicianByAnyId = (technicians, value) => {
+  const needle = asText(value);
+  if (!needle || !Array.isArray(technicians)) return null;
+  return (
+    technicians.find((tech) => asText(tech?.id) === needle) ||
+    technicians.find((tech) => asText(tech?.user_id) === needle) ||
+    null
+  );
+};
+
+/**
+ * Normalize any known technician id shape to the roster assignment id.
+ * Returns null when the value cannot be mapped to a roster row.
+ */
+export const resolveTechnicianRosterId = ({ technicians, value }) => {
+  const needle = asText(value);
+  if (!needle || needle === 'unassigned') return null;
+  const technician = findTechnicianByAnyId(technicians, needle);
+  return technician?.id ? asText(technician.id) : null;
+};
+
+/**
+ * Select / form value for assignment controls.
+ * Always prefers technicians.id so writes store the roster FK target.
+ */
+export const resolveTechnicianSelectValue = ({ technicians, value }) => {
+  const rosterId = resolveTechnicianRosterId({ technicians, value });
+  return rosterId || 'unassigned';
+};
+
+/**
+ * Display name for a stored assignment id (roster id, or legacy user_id).
+ */
+export const resolveTechnicianDisplayName = ({
+  technicians,
+  value,
+  fallback = 'Unassigned',
+}) => {
+  const technician = findTechnicianByAnyId(technicians, value);
+  return asText(technician?.full_name) || fallback;
+};
+
+/**
+ * Auth-user mapping only — never write this into assignment columns.
+ */
+export const resolveTechnicianAuthUserId = ({ technicians, value }) => {
+  const technician = findTechnicianByAnyId(technicians, value);
+  return technician?.user_id ? asText(technician.user_id) : null;
+};
+
+/**
+ * Resolve the logged-in user's roster id from a technicians list.
+ */
+export const resolveLoggedInTechnicianRosterId = ({ technicians, authUserId }) => {
+  const userId = asText(authUserId);
+  if (!userId || !Array.isArray(technicians)) return null;
+  const technician = technicians.find((tech) => asText(tech?.user_id) === userId);
+  return technician?.id ? asText(technician.id) : null;
+};

--- a/command-center/src/pages/crm/Jobs.jsx
+++ b/command-center/src/pages/crm/Jobs.jsx
@@ -29,6 +29,11 @@ import AddressAutocomplete from '@/components/AddressAutocomplete';
 import { formatPhoneNumber } from '@/lib/formUtils';
 import { resolveLeadDelivery } from '@/lib/documentDelivery';
 import {
+  resolveTechnicianDisplayName,
+  resolveTechnicianSelectValue,
+  TECHNICIAN_ROSTER_SELECT,
+} from '@/lib/technicianIdentity';
+import {
   PAYMENT_TERM_OPTIONS,
   formatOperationalStageLabel,
   formatPaymentTermsLabel,
@@ -152,17 +157,12 @@ const Jobs = () => {
     return 'all';
   };
 
-  const getTechnicianName = (technicianId) => {
-    if (!technicianId) return 'Unassigned';
-    const technician = technicians.find((t) => t.user_id === technicianId || t.id === technicianId);
-    return technician?.full_name || 'Unassigned';
-  };
+  const getTechnicianName = (technicianId) =>
+    resolveTechnicianDisplayName({ technicians, value: technicianId });
 
-  const resolveTechnicianSelection = (technicianId) => {
-    if (!technicianId) return 'unassigned';
-    const technician = technicians.find((t) => t.user_id === technicianId || t.id === technicianId);
-    return technician?.user_id || 'unassigned';
-  };
+  // Assignment selects/forms always use technicians.id (roster FK target).
+  const resolveTechnicianSelection = (technicianId) =>
+    resolveTechnicianSelectValue({ technicians, value: technicianId });
 
   const toDatetimeLocal = (value) => {
     if (!value) return '';
@@ -296,7 +296,7 @@ const Jobs = () => {
     try {
       const { data, error } = await supabase
         .from('technicians')
-        .select('id, user_id, full_name')
+        .select(TECHNICIAN_ROSTER_SELECT)
         .eq('is_active', true)
         .order('full_name', { ascending: true });
       if (error) throw error;
@@ -994,7 +994,7 @@ const Jobs = () => {
                     <SelectContent>
                       <SelectItem value="unassigned">Unassigned</SelectItem>
                       {assignableTechnicians.map((tech) => (
-                        <SelectItem key={tech.id} value={tech.user_id}>
+                        <SelectItem key={tech.id} value={tech.id}>
                           {tech.full_name}
                         </SelectItem>
                       ))}
@@ -1158,7 +1158,7 @@ const Jobs = () => {
                 <SelectContent>
                   <SelectItem value="unassigned">Unassigned</SelectItem>
                   {assignableTechnicians.map((tech) => (
-                    <SelectItem key={tech.id} value={tech.user_id}>
+                    <SelectItem key={tech.id} value={tech.id}>
                       {tech.full_name}
                     </SelectItem>
                   ))}

--- a/command-center/src/pages/crm/Schedule.jsx
+++ b/command-center/src/pages/crm/Schedule.jsx
@@ -37,6 +37,11 @@ import {
   toDate,
 } from '@/lib/dispatchRules';
 import { formatPhoneNumber } from '@/lib/formUtils';
+import {
+  resolveTechnicianDisplayName,
+  resolveTechnicianSelectValue,
+  TECHNICIAN_ROSTER_SELECT,
+} from '@/lib/technicianIdentity';
 import { cn } from '@/lib/utils';
 import {
   formatOperationalStageLabel,
@@ -212,21 +217,12 @@ const statusLabel = (value) =>
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
 
-const getTechnicianDisplayName = (technicians, technicianId) => {
-  if (!technicianId) return 'Unassigned';
-  const technician = technicians.find((entry) =>
-    [entry.dispatch_id, entry.user_id, entry.id].filter(Boolean).includes(technicianId),
-  );
-  return technician?.full_name || 'Unassigned';
-};
+const getTechnicianDisplayName = (technicians, technicianId) =>
+  resolveTechnicianDisplayName({ technicians, value: technicianId });
 
-const resolveTechnicianSelection = (technicians, technicianId) => {
-  if (!technicianId) return 'unassigned';
-  const technician = technicians.find((entry) =>
-    [entry.dispatch_id, entry.user_id, entry.id].filter(Boolean).includes(technicianId),
-  );
-  return technician?.dispatch_id || 'unassigned';
-};
+// Assignment selects/forms always use technicians.id (roster FK target).
+const resolveTechnicianSelection = (technicians, technicianId) =>
+  resolveTechnicianSelectValue({ technicians, value: technicianId });
 
 const MetricCard = ({ icon: Icon, label, value, tone = 'slate', detail }) => (
   <Card
@@ -698,19 +694,16 @@ export default function Schedule() {
         await Promise.all([
           supabase
             .from('technicians')
-            .select('id, user_id, full_name, is_active')
+            .select(TECHNICIAN_ROSTER_SELECT)
             .order('full_name', { ascending: true }),
           workOrderBoardService.fetchWorkOrders(tenantId),
         ]);
 
       if (techniciansError && !isMissingRelationError(techniciansError)) throw techniciansError;
 
-      const technicianRows = ((techniciansError ? [] : techniciansData) || [])
-        .filter((tech) => tech?.is_active !== false)
-        .map((tech) => ({
-          ...tech,
-          dispatch_id: tech.user_id || tech.id,
-        }));
+      const technicianRows = ((techniciansError ? [] : techniciansData) || []).filter(
+        (tech) => tech?.is_active !== false,
+      );
 
       setTechnicians(technicianRows);
       setWorkOrders(
@@ -1431,7 +1424,7 @@ export default function Schedule() {
                               <SelectContent>
                                 <SelectItem value="unassigned">Unassigned</SelectItem>
                                 {technicians.map((technician) => (
-                                  <SelectItem key={technician.id} value={technician.dispatch_id}>
+                                  <SelectItem key={technician.id} value={technician.id}>
                                     {technician.full_name}
                                   </SelectItem>
                                 ))}

--- a/command-center/tests/smoke/r1a-property-relationship-safety.spec.js
+++ b/command-center/tests/smoke/r1a-property-relationship-safety.spec.js
@@ -155,9 +155,9 @@ test('inspection safe helper contract remains unchanged for field selects', asyn
   expect(helper).toContain('isNumericPropertyId');
 });
 
-test('technician assignment selectors are untouched by R1A', async () => {
+test('technician assignment selectors remain out of R1A property scope', async () => {
   const jobs = read('src/pages/crm/Jobs.jsx');
-  // R1B territory — must still be present unchanged in this PR
-  expect(jobs).toContain('value={tech.user_id}');
+  // R1B owns technician identity; R1A must not reintroduce property embeds there.
+  expect(jobs).not.toMatch(/property\s*:\s*property_id\s*\(/);
   expect(jobs).toContain('resolveTechnicianSelection');
 });

--- a/command-center/tests/smoke/r1b-technician-identity-contract.spec.js
+++ b/command-center/tests/smoke/r1b-technician-identity-contract.spec.js
@@ -1,0 +1,184 @@
+/* eslint-disable testing-library/prefer-screen-queries, jest/valid-title */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test, expect } from '@playwright/test';
+import {
+  resolveLoggedInTechnicianRosterId,
+  resolveTechnicianAuthUserId,
+  resolveTechnicianDisplayName,
+  resolveTechnicianRosterId,
+  resolveTechnicianSelectValue,
+  TECHNICIAN_ROSTER_SELECT,
+} from '../../src/lib/technicianIdentity.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(here, '../..');
+const srcRoot = path.join(root, 'src');
+
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+const walkJsFiles = (dir, out = []) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkJsFiles(full, out);
+    else if (/\.(js|jsx)$/.test(entry.name)) out.push(full);
+  }
+  return out;
+};
+
+const TECH_ROSTER_ID = '11111111-1111-4111-8111-111111111111';
+const TECH_USER_ID = '22222222-2222-4222-8222-222222222222';
+const OTHER_ROSTER_ID = '33333333-3333-4333-8333-333333333333';
+
+const technicians = [
+  {
+    id: TECH_ROSTER_ID,
+    user_id: TECH_USER_ID,
+    full_name: 'Roster Tech',
+    is_active: true,
+  },
+  {
+    id: OTHER_ROSTER_ID,
+    user_id: null,
+    full_name: 'No Login Tech',
+    is_active: true,
+  },
+];
+
+test('helper resolves auth user → roster id and never returns user_id for assignment writes', async () => {
+  expect(TECHNICIAN_ROSTER_SELECT).toContain('id');
+  expect(TECHNICIAN_ROSTER_SELECT).toContain('user_id');
+
+  expect(resolveTechnicianRosterId({ technicians, value: TECH_ROSTER_ID })).toBe(TECH_ROSTER_ID);
+  expect(resolveTechnicianRosterId({ technicians, value: TECH_USER_ID })).toBe(TECH_ROSTER_ID);
+  expect(resolveTechnicianSelectValue({ technicians, value: TECH_USER_ID })).toBe(TECH_ROSTER_ID);
+  expect(resolveTechnicianSelectValue({ technicians, value: null })).toBe('unassigned');
+
+  expect(resolveLoggedInTechnicianRosterId({ technicians, authUserId: TECH_USER_ID })).toBe(
+    TECH_ROSTER_ID,
+  );
+  expect(resolveTechnicianAuthUserId({ technicians, value: TECH_ROSTER_ID })).toBe(TECH_USER_ID);
+  expect(resolveTechnicianDisplayName({ technicians, value: TECH_USER_ID })).toBe('Roster Tech');
+
+  // Assignment payload shape: select value is always roster id.
+  const assignmentPayload = {
+    technician_id:
+      resolveTechnicianSelectValue({ technicians, value: TECH_USER_ID }) === 'unassigned'
+        ? null
+        : resolveTechnicianSelectValue({ technicians, value: TECH_USER_ID }),
+  };
+  expect(assignmentPayload.technician_id).toBe(TECH_ROSTER_ID);
+  expect(assignmentPayload.technician_id).not.toBe(TECH_USER_ID);
+});
+
+test('Jobs assignment selector writes technicians.id', async () => {
+  const jobs = read('src/pages/crm/Jobs.jsx');
+  expect(jobs).toContain("from '@/lib/technicianIdentity'");
+  expect(jobs).toContain('resolveTechnicianSelectValue');
+  expect(jobs).toContain('value={tech.id}');
+  expect(jobs).not.toContain('value={tech.user_id}');
+  expect(jobs).toContain('TECHNICIAN_ROSTER_SELECT');
+  // Save payload still uses the select state (now roster id).
+  expect(jobs).toMatch(/technician_id:\s*recordTechnicianId/);
+  expect(jobs).toMatch(/technician_id:\s*scheduleTechnicianId|payload\.technician_id\s*=\s*scheduleTechnicianId/);
+});
+
+test('Dispatch Schedule assignment selector writes technicians.id', async () => {
+  const schedule = read('src/pages/crm/Schedule.jsx');
+  expect(schedule).toContain("from '@/lib/technicianIdentity'");
+  expect(schedule).toContain('resolveTechnicianSelectValue');
+  expect(schedule).toContain('value={technician.id}');
+  expect(schedule).not.toContain('dispatch_id');
+  expect(schedule).not.toContain('tech.user_id || tech.id');
+  expect(schedule).toContain('technician_id: dispatchTechnicianId');
+});
+
+test('AppointmentScheduler continues to write technicians.id', async () => {
+  const source = read('src/pages/crm/appointments/AppointmentScheduler.jsx');
+  expect(source).toContain('value={tech.id}');
+  expect(source).not.toContain('value={tech.user_id}');
+  expect(source).toMatch(/technician_id/);
+});
+
+test('TechQueue and TechJobDetail resolve auth user then filter by roster id', async () => {
+  const queue = read('src/pages/tech/TechQueue.jsx');
+  const detail = read('src/pages/tech/TechJobDetail.jsx');
+
+  expect(queue).toContain(".eq('user_id', user.id)");
+  expect(queue).toContain(".eq('technician_id', tech.id)");
+  expect(queue).not.toMatch(/\.eq\(\s*['"]technician_id['"]\s*,\s*user\.id\s*\)/);
+
+  expect(detail).toContain(".eq('user_id', user?.id || '')");
+  expect(detail).toContain(".eq('technician_id', techData.id)");
+  expect(detail).toContain('technician_id: technician.id');
+  expect(detail).not.toMatch(/\.eq\(\s*['"]technician_id['"]\s*,\s*user\.id\s*\)/);
+});
+
+test('InspectionEditor assignment control uses technicians.id', async () => {
+  const editor = read('src/pages/crm/inspections/InspectionEditor.jsx');
+  expect(editor).toContain('value={tech.id}');
+  expect(editor).not.toContain('value={tech.user_id}');
+});
+
+test('active assignment controls never store technicians.user_id as option value', async () => {
+  const activeAssignmentFiles = [
+    'src/pages/crm/Jobs.jsx',
+    'src/pages/crm/Schedule.jsx',
+    'src/pages/crm/appointments/AppointmentScheduler.jsx',
+    'src/pages/crm/inspections/InspectionEditor.jsx',
+  ];
+  const offenders = [];
+  for (const relativePath of activeAssignmentFiles) {
+    const source = read(relativePath);
+    const lines = source.split(/\r?\n/);
+    lines.forEach((line, idx) => {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('//') || trimmed.startsWith('*')) return;
+      if (/SelectItem[^>]*(value=\{tech\.user_id\}|value=\{technician\.user_id\}|value=\{technician\.dispatch_id\})/.test(line)) {
+        offenders.push(`${relativePath}:${idx + 1}`);
+      }
+      if (/dispatch_id\s*:\s*tech\.user_id/.test(line)) {
+        offenders.push(`${relativePath}:${idx + 1}:dispatch_id`);
+      }
+    });
+  }
+  expect(offenders, offenders.join('\n')).toEqual([]);
+});
+
+test('active src does not compare auth.uid/user.id directly to assignment technician_id filters', async () => {
+  const files = walkJsFiles(path.join(srcRoot, 'pages'));
+  const offenders = [];
+  const banned = [
+    /\.eq\(\s*['"]technician_id['"]\s*,\s*user\.id\s*\)/,
+    /\.eq\(\s*['"]technician_id['"]\s*,\s*user\?\.id\s*\)/,
+    /\.eq\(\s*['"]technician_id['"]\s*,\s*authUserId\s*\)/,
+  ];
+  for (const file of files) {
+    const source = fs.readFileSync(file, 'utf8');
+    const relative = path.relative(root, file);
+    // Orphan demo page documents the bad pattern in a comment; ignore comment-only lines.
+    const lines = source.split(/\r?\n/);
+    lines.forEach((line, idx) => {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) return;
+      if (banned.some((re) => re.test(line))) {
+        offenders.push(`${relative}:${idx + 1}`);
+      }
+    });
+  }
+  expect(offenders, offenders.join('\n')).toEqual([]);
+});
+
+test('money-loop / estimate modules are untouched by R1B identity changes', async () => {
+  // Guard that this PR does not expand into pricing/invoice/payment/estimate files.
+  const moneyPaths = [
+    'src/services/paymentService.js',
+    'src/pages/public/PaymentPage.jsx',
+    'src/pages/crm/proposals/ProposalBuilder.jsx',
+  ];
+  for (const relativePath of moneyPaths) {
+    const source = read(relativePath);
+    expect(source).not.toContain("from '@/lib/technicianIdentity'");
+  }
+});

--- a/command-center/tests/smoke/uat-local-schedule-dispatch.spec.js
+++ b/command-center/tests/smoke/uat-local-schedule-dispatch.spec.js
@@ -302,7 +302,7 @@ test.describe.serial('UAT LOCAL schedule dispatch board', () => {
           };
         }, { timeout: 20000 })
         .toEqual({
-          technicianId: technicianUserId,
+          technicianId: technicianRecordId,
           status: 'scheduled',
         });
 
@@ -344,7 +344,7 @@ test.describe.serial('UAT LOCAL schedule dispatch board', () => {
             technicianId: data?.technician_id || null,
           };
         }, { timeout: 20000 })
-        .toEqual({ status: 'scheduled', hasSchedule: true, technicianId: technicianUserId });
+        .toEqual({ status: 'scheduled', hasSchedule: true, technicianId: technicianRecordId });
 
       await expect(
         page
@@ -465,7 +465,7 @@ test.describe.serial('UAT LOCAL schedule dispatch board', () => {
         service_address: '100 Conflict Ave, Titusville, FL 32780',
         payment_status: 'unpaid',
         total_amount: 149,
-        technician_id: technicianUserId,
+        technician_id: technicianRecordId,
         scheduled_start: toIsoAt(1, 9, 0),
         scheduled_end: toIsoAt(1, 11, 0),
         created_at: toIsoAt(-1, 8, 0),
@@ -735,7 +735,7 @@ test.describe.serial('UAT LOCAL schedule dispatch board', () => {
           status: 'scheduled',
           serviceAddress: '930 Alabama St, Titusville, FL 32796',
           hasScheduledStart: true,
-          technicianId: technicianUserId,
+          technicianId: technicianRecordId,
         });
     } finally {
       if (jobIds.length > 0) {


### PR DESCRIPTION
## Summary
- Jobs and Dispatch assignment selectors now write `technicians.id` (roster FK target) instead of `technicians.user_id`.
- Adds shared `technicianIdentity` helper for auth → roster resolution and select/write normalization.
- Adds focused R1B contract tests and updates local schedule UAT expectations to the production FK contract.
- Documents verified production technician contract; no migration and no data repair.

## Test plan
- [x] `npx playwright test tests/smoke/r1b-technician-identity-contract.spec.js`
- [x] R1A + inspection field address regression specs
- [x] `npm run lint` (0 errors)
- [x] `npm run build` + secret-scan
- [x] `npm run review:gate`
- [ ] Required CI checks green
- [ ] Production smoke after merge/deploy (synthetic only)

## Out of scope
- R1C broader guards
- Scheduling UX redesign
- Migrations / production data repair
- Property relationship changes (R1A)

Made with [Cursor](https://cursor.com)