### PR TITLE
fix(intake): R2 intake clarity — required fields and loud failures

### DIFF
--- a/command-center/docs/stabilization/R2_INTAKE_CLARITY_PLAN.md
+++ b/command-center/docs/stabilization/R2_INTAKE_CLARITY_PLAN.md
@@ -1,0 +1,72 @@
+# R2 — Intake Clarity Plan
+
+**Branch:** `stabilize/r2-intake-clarity`  
+**Worktree:** `F:\Dev\BHFOS-stabilize-r2-intake`  
+**Base:** `origin/main` @ `fca55c14c14d320c48b91742bfd368690b79c3ab` (R1C tip)
+
+## Goal
+
+Reliable lead/customer creation with clear required fields and loud failures.
+
+## Includes
+
+| ID | Intent |
+| --- | --- |
+| B-006 | Single intake checklist: name + phone + address; stop inventing property rows |
+| B-015 | Explicit required-column contract; fail loud (no silent create-time column strip) |
+| B-018 | **Accepted / deferred** — Contacts sidebar not required for this release |
+
+## Excludes
+
+- Property table / FK redesign
+- Billing, quotes, ProposalBuilder create fallbacks
+- New CRM modules
+- Migrations
+
+## Contract (V1)
+
+New leads require:
+
+1. **Name** — first name, last name, or company  
+2. **Phone** — valid 10-digit US number  
+3. **Service address** — freeform string (or structured street/city/state/ZIP in field)
+
+Persist address on the lead only:
+
+- `leads.address`
+- `leads.property_formatted_address` (same value)
+- **Do not** set `property_id` or insert into `properties`
+
+Shared module: `src/lib/leadIntakeContract.js`
+
+## Surfaces
+
+| Surface | Change |
+| --- | --- |
+| CRM `Leads.jsx` Add Lead | Address field + contract validation; no column-strip retry on create |
+| `appointmentService.createCustomer` | Contract payload; loud DB errors |
+| Field `InspectionFieldCustomerStep` | Phone required; single insert with address |
+| Appointment scheduler Add Customer | Phone + address required (same contract) |
+
+## Acceptance
+
+- Create lead from CRM and field with address  
+- Missing required field blocked with plain language  
+- Create-time missing-column errors surface plainly (no silent field drop)
+
+## Stop conditions
+
+- Touches billing or quote triggers  
+- Proposes property schema migration  
+
+## Validation
+
+```bash
+npm run test:intake-contracts
+npm run lint
+npm run build:local
+```
+
+## Production verification (after deploy)
+
+Synthetic lead create (CRM + field or scheduler) then delete; confirm address on lead and no new `properties` row.

--- a/command-center/docs/stabilization/V1_RELEASE_PLAN.md
+++ b/command-center/docs/stabilization/V1_RELEASE_PLAN.md
@@ -49,6 +49,8 @@ Priority order (unless new P0 outage):
 | Production verification | Synthetic lead create/delete |
 | Stop conditions | Touches billing or quote triggers |
 
+**Status:** In progress on `stabilize/r2-intake-clarity` — see `R2_INTAKE_CLARITY_PLAN.md`. B-018 accepted/deferred.
+
 ---
 
 ## Release R3 — Scheduling for operations (incl. phone)

--- a/command-center/docs/stabilization/V1_STABILIZATION_BACKLOG.md
+++ b/command-center/docs/stabilization/V1_STABILIZATION_BACKLOG.md
@@ -107,7 +107,7 @@ Disposition meanings:
 | Smallest fix | Document + enforce single intake checklist: required phone/name/address fields; stop inventing property rows |
 | Test | Field customer step + CRM lead create smoke |
 | Release | R2 |
-| Disposition | **Fix in V1** (process + UI clarity; not schema redesign) |
+| Disposition | **Fixed in V1** (`leadIntakeContract.js`; CRM / field / scheduler / `createCustomer`) |
 
 ### B-007 — Quote-accept → job reliability / duplicate events
 
@@ -224,7 +224,7 @@ Disposition meanings:
 | Evidence | `Leads.jsx` / `appointmentService` retry without missing columns |
 | Smallest fix | Explicit required-column contract; fail loud in UI |
 | Release | R2 |
-| Disposition | **Fix in V1** |
+| Disposition | **Fixed in V1** (create paths fail loud via `describeLeadIntakeDbError`; no silent strip) |
 
 ### B-016 — Appointment ↔ job schedule dual write confusion
 
@@ -257,7 +257,7 @@ Disposition meanings:
 | Evidence | Routed but absent from `BHFSidebar` |
 | Smallest fix | Add nav item **or** merge into Leads UX — choose one |
 | Release | R2 |
-| Disposition | **Accept in V1** unless intake release needs it |
+| Disposition | **Accepted in V1** (deferred; not required for intake clarity) |
 
 ### B-019 — Follow-up task surface weak
 

--- a/command-center/docs/stabilization/V1_WORKFLOW_SCORECARD.md
+++ b/command-center/docs/stabilization/V1_WORKFLOW_SCORECARD.md
@@ -38,7 +38,7 @@ Scores are evidence-based. Where production proof is thin, scores stay conservat
 | Test coverage | 2 | Older UAT; not CI-gated |
 | Production confidence | 3 | Daily use assumed; not re-proven in this package |
 
-**Status: NEEDS WORK** — clarify required fields (R2).
+**Status: IN PROGRESS (R2)** — shared intake contract (name/phone/address); loud create failures.
 
 ---
 

--- a/command-center/package.json
+++ b/command-center/package.json
@@ -15,6 +15,8 @@
     "guard:identity": "node tools/identity-relationship-guards.mjs",
     "test:identity-helpers": "node --test tests/unit/r1c-helper-contracts.test.mjs",
     "test:identity-contracts": "npm run guard:identity && npm run test:identity-helpers && playwright test tests/smoke/r1a-property-relationship-safety.spec.js tests/smoke/r1b-technician-identity-contract.spec.js tests/smoke/r1c-identity-relationship-guards.spec.js tests/smoke/inspection-field-address-schema.spec.js",
+    "test:intake-helpers": "node --test tests/unit/r2-lead-intake-contract.test.mjs",
+    "test:intake-contracts": "npm run test:intake-helpers && playwright test tests/smoke/r2-intake-clarity.spec.js tests/smoke/inspection-field-address-schema.spec.js",
     "verify:live-secrets": "node tools/scan-live-for-secrets.mjs https://app.bhfos.com",
     "validate:document-system": "node scripts/validate-document-system.mjs",
     "check:customer-doc-encoding": "node scripts/check-customer-doc-encoding.mjs",

--- a/command-center/src/components/tech/InspectionFieldCustomerStep.jsx
+++ b/command-center/src/components/tech/InspectionFieldCustomerStep.jsx
@@ -11,6 +11,11 @@ import {
   normalizeLeadRecord,
   resolveServiceAddress,
 } from '@/lib/inspectionFieldAddress';
+import {
+  assertLeadIntakeValid,
+  describeLeadIntakeDbError,
+  formatLeadIntakeErrors,
+} from '@/lib/leadIntakeContract';
 import { useToast } from '@/components/ui/use-toast';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -255,22 +260,30 @@ export default function InspectionFieldCustomerStep({
 
   const createAndLink = async ({ force = false } = {}) => {
     if (locked) return;
-    if (!asText(form.first_name) && !asText(form.last_name) && !asText(form.company)) {
-      toast({
-        variant: 'destructive',
-        title: 'Name required',
-        description: 'Add a first name, last name, or company.',
-      });
-      return;
-    }
+
+    // Field reports need a complete structured address (street + city + state + ZIP).
     if (!asText(form.address1) || !asText(form.city) || !asText(form.state) || !asText(form.zip)) {
       toast({
         variant: 'destructive',
-        title: 'Service address required',
-        description: 'Address, city, state, and ZIP are required for the report.',
+        title: 'Missing required info',
+        description: 'Enter street, city, state, and ZIP so the service address is saved on the customer.',
       });
       return;
     }
+
+    let validation;
+    try {
+      validation = assertLeadIntakeValid(form);
+    } catch (validationError) {
+      toast({
+        variant: 'destructive',
+        title: 'Missing required info',
+        description: formatLeadIntakeErrors({ errors: validationError.errors }) || validationError.message,
+      });
+      return;
+    }
+
+    const serviceAddress = validation.normalized.address;
 
     setSaving(true);
     try {
@@ -282,41 +295,25 @@ export default function InspectionFieldCustomerStep({
         }
       }
 
+      // Single insert with address on the lead — do not invent properties rows.
       const created = await appointmentService.createCustomer(
         {
-          first_name: asText(form.first_name) || null,
-          last_name: asText(form.last_name) || null,
-          company: asText(form.company) || null,
-          phone: formatPhoneNumber(form.phone) || null,
-          email: asText(form.email) || null,
+          first_name: validation.normalized.first_name,
+          last_name: validation.normalized.last_name,
+          company: validation.normalized.company,
+          phone: validation.normalized.phone,
+          email: validation.normalized.email,
+          address: serviceAddress,
           source: 'field_inspection',
           status: 'new',
         },
         tenantId,
       );
 
-      const serviceAddress = composeAddressFromParts(form);
-
-      // Production public.properties uses bigint ids + address_line_1 and cannot be
-      // linked through leads.property_id (uuid). Persist freeform address on the lead only.
-      const leadPatch = {
-        address: serviceAddress || null,
-        property_formatted_address: serviceAddress || null,
-        updated_at: new Date().toISOString(),
-      };
-
-      const addressUpdate = await supabase
-        .from('leads')
-        .update(leadPatch)
-        .eq('tenant_id', tenantId)
-        .eq('id', created.id);
-      if (addressUpdate.error) {
-        console.warn('Lead address patch skipped:', addressUpdate.error.message);
-      }
-
       const linkedLeadRow = {
         ...created,
-        ...leadPatch,
+        address: created.address || serviceAddress,
+        property_formatted_address: created.property_formatted_address || serviceAddress,
         property: null,
       };
 
@@ -338,7 +335,7 @@ export default function InspectionFieldCustomerStep({
       toast({
         variant: 'destructive',
         title: 'Could not add lead',
-        description: error?.message || 'Lead creation failed.',
+        description: describeLeadIntakeDbError(error),
       });
     } finally {
       setSaving(false);
@@ -507,8 +504,8 @@ export default function InspectionFieldCustomerStep({
             </div>
             <div className="grid gap-3 sm:grid-cols-2">
               <div className="space-y-1">
-                <Label>Phone</Label>
-                <Input className="min-h-11" value={form.phone} onChange={(e) => setForm((p) => ({ ...p, phone: e.target.value }))} disabled={saving} />
+                <Label>Phone (required)</Label>
+                <Input className="min-h-11" value={form.phone} onChange={(e) => setForm((p) => ({ ...p, phone: formatPhoneNumber(e.target.value) }))} disabled={saving} />
               </div>
               <div className="space-y-1">
                 <Label>Email (optional)</Label>

--- a/command-center/src/lib/leadIntakeContract.js
+++ b/command-center/src/lib/leadIntakeContract.js
@@ -1,0 +1,148 @@
+/**
+ * R2 Intake Clarity — single lead/customer create contract.
+ *
+ * Required for new leads: name (first OR last OR company), 10-digit phone, service address.
+ * Address is stored on the lead only (address + property_formatted_address).
+ * Do not invent properties rows; do not silently drop columns on create.
+ */
+
+import { formatPhoneNumber, validatePhone } from './formUtils.js';
+import { composeAddressFromParts } from './inspectionFieldAddress.js';
+
+export const LEAD_INTAKE_REQUIRED_FIELDS = ['name', 'phone', 'address'];
+
+export const LEAD_INTAKE_MESSAGES = {
+  name: 'Add a first name, last name, or company.',
+  phone: 'Enter a valid 10-digit phone number.',
+  address: 'Enter the service address so the job location is saved on the customer.',
+};
+
+const asText = (value) => (typeof value === 'string' ? value.trim() : '');
+
+export const resolveIntakeAddress = (input = {}) => {
+  const freeform = asText(input.address || input.service_address || input.serviceAddress);
+  if (freeform) return freeform;
+
+  const composed = composeAddressFromParts({
+    address1: input.address1 || input.address_line_1 || '',
+    address2: input.address2 || input.address_line_2 || '',
+    city: input.city || '',
+    state: input.state || '',
+    zip: input.zip || input.postal_code || '',
+  });
+  return asText(composed);
+};
+
+export const validateLeadIntake = (input = {}) => {
+  const firstName = asText(input.first_name || input.firstName);
+  const lastName = asText(input.last_name || input.lastName);
+  const company = asText(input.company);
+  const phoneRaw = input.phone || '';
+  const phone = formatPhoneNumber(phoneRaw) || asText(phoneRaw);
+  const email = asText(input.email) || null;
+  const address = resolveIntakeAddress(input);
+
+  const errors = [];
+  if (!firstName && !lastName && !company) {
+    errors.push({ field: 'name', message: LEAD_INTAKE_MESSAGES.name });
+  }
+  if (!validatePhone(phone)) {
+    errors.push({ field: 'phone', message: LEAD_INTAKE_MESSAGES.phone });
+  }
+  if (!address) {
+    errors.push({ field: 'address', message: LEAD_INTAKE_MESSAGES.address });
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    normalized: {
+      first_name: firstName || null,
+      last_name: lastName || null,
+      company: company || null,
+      phone: phone || null,
+      email,
+      address,
+    },
+  };
+};
+
+export const formatLeadIntakeErrors = (validation) =>
+  (validation?.errors || []).map((entry) => entry.message).join(' ');
+
+export const assertLeadIntakeValid = (input = {}) => {
+  const validation = validateLeadIntake(input);
+  if (!validation.ok) {
+    const error = new Error(formatLeadIntakeErrors(validation));
+    error.code = 'LEAD_INTAKE_VALIDATION';
+    error.errors = validation.errors;
+    throw error;
+  }
+  return validation;
+};
+
+/**
+ * Canonical insert shape for new leads. Never sets property_id.
+ */
+export const buildLeadIntakeInsertPayload = (input = {}, options = {}) => {
+  const validation = assertLeadIntakeValid(input);
+  const { normalized } = validation;
+  const nowIso = options.nowIso || new Date().toISOString();
+
+  const payload = {
+    first_name: normalized.first_name,
+    last_name: normalized.last_name,
+    company: normalized.company,
+    phone: normalized.phone,
+    email: normalized.email,
+    address: normalized.address,
+    property_formatted_address: normalized.address,
+    source: options.source || input.source || 'crm',
+    status: options.status || input.status || 'new',
+    pipeline_stage: options.pipeline_stage || input.pipeline_stage || 'new',
+    service: options.service || input.service || null,
+    created_at: nowIso,
+    updated_at: nowIso,
+  };
+
+  if (options.tenantId != null) {
+    payload.tenant_id = options.tenantId;
+  }
+
+  if (options.extras && typeof options.extras === 'object') {
+    Object.assign(payload, options.extras);
+  }
+
+  return payload;
+};
+
+export const isMissingColumnError = (error) =>
+  error?.code === '42703' ||
+  /column .* does not exist/i.test(error?.message || '') ||
+  /could not find the '.*' column/i.test(error?.message || '');
+
+export const getMissingColumnName = (error) => {
+  const message = error?.message || '';
+  const postgresMatch = message.match(/column "([^"]+)"/i);
+  if (postgresMatch) return postgresMatch[1];
+  const cacheMatch = message.match(/could not find the '([^']+)' column/i);
+  return cacheMatch ? cacheMatch[1] : null;
+};
+
+/**
+ * Plain-language DB/schema errors for create paths (no silent column strip).
+ */
+export const describeLeadIntakeDbError = (error) => {
+  if (!error) return 'Could not save the customer.';
+  if (error.code === 'LEAD_INTAKE_VALIDATION') {
+    return error.message || formatLeadIntakeErrors({ errors: error.errors || [] });
+  }
+  if (isMissingColumnError(error)) {
+    const column = getMissingColumnName(error);
+    if (column) {
+      return `Database is missing the "${column}" field needed to save this customer. Contact support — the record was not saved with missing data.`;
+    }
+    return 'Database is missing a required customer field. Contact support — the record was not saved with missing data.';
+  }
+  return error.message || 'Could not save the customer.';
+};

--- a/command-center/src/pages/crm/Leads.jsx
+++ b/command-center/src/pages/crm/Leads.jsx
@@ -62,6 +62,12 @@ import {
 } from 'lucide-react';
 import { format } from 'date-fns';
 import { formatPhoneNumber } from '@/lib/formUtils';
+import {
+  assertLeadIntakeValid,
+  buildLeadIntakeInsertPayload,
+  describeLeadIntakeDbError,
+  formatLeadIntakeErrors,
+} from '@/lib/leadIntakeContract';
 
 const PIPELINE_STAGES = [
   { value: 'new', label: 'New' },
@@ -140,6 +146,7 @@ const Leads = () => {
     lastName: '',
     email: '',
     phone: '',
+    address: '',
     service: '',
     persona: 'homeowner',
     pipelineStage: 'new',
@@ -782,51 +789,70 @@ const Leads = () => {
   const handleAddSave = async () => {
      setIsSaving(true);
      try {
-         const nowIso = new Date().toISOString();
          const pipelineStage = normalizeStageValue(addFormData.pipelineStage || 'new') || 'new';
-         let payload = {
-             first_name: addFormData.firstName,
-             last_name: addFormData.lastName,
-             email: addFormData.email,
+         let validation;
+         try {
+           validation = assertLeadIntakeValid({
+             firstName: addFormData.firstName,
+             lastName: addFormData.lastName,
              phone: addFormData.phone,
+             email: addFormData.email,
+             address: addFormData.address,
+           });
+         } catch (validationError) {
+           toast({
+             variant: 'destructive',
+             title: 'Missing required info',
+             description: formatLeadIntakeErrors({ errors: validationError.errors }) || validationError.message,
+           });
+           return;
+         }
+
+         const payload = buildLeadIntakeInsertPayload(
+           {
+             ...validation.normalized,
              service: addFormData.service,
+             source: 'crm_leads',
+           },
+           {
+             tenantId,
              pipeline_stage: pipelineStage,
              status: mapStageToStatus(pipelineStage),
-             preferred_document_delivery:
-               normalizePreferredDocumentDelivery(addFormData.preferredDocumentDelivery) === 'auto'
-                 ? null
-                 : normalizePreferredDocumentDelivery(addFormData.preferredDocumentDelivery),
-             sms_consent: addFormData.smsConsent === true,
-             sms_opt_out: addFormData.smsOptOut === true,
-             updated_at: nowIso,
-             created_at: nowIso,
-             is_test_data: isTrainingMode,
-             tenant_id: tenantId // Explicitly setting tenant_id
-         };
+             service: addFormData.service || null,
+             source: 'crm_leads',
+             extras: {
+               preferred_document_delivery:
+                 normalizePreferredDocumentDelivery(addFormData.preferredDocumentDelivery) === 'auto'
+                   ? null
+                   : normalizePreferredDocumentDelivery(addFormData.preferredDocumentDelivery),
+               sms_consent: addFormData.smsConsent === true,
+               sms_opt_out: addFormData.smsOptOut === true,
+               is_test_data: isTrainingMode,
+             },
+           },
+         );
 
-         let { error } = await supabase.from('leads').insert(payload);
-         if (error && isMissingColumnError(error)) {
-           payload = { ...payload };
-           const missingColumn = getMissingColumnName(error);
-           if (missingColumn === 'preferred_document_delivery') delete payload.preferred_document_delivery;
-           if (missingColumn === 'sms_consent') delete payload.sms_consent;
-           if (missingColumn === 'sms_opt_out') delete payload.sms_opt_out;
-           if (missingColumn === 'pipeline_stage') {
-             payload.stage = payload.pipeline_stage;
-             delete payload.pipeline_stage;
-           }
-           if (missingColumn === 'tenant_id') {
-             delete payload.tenant_id;
-           }
-           const retry = await supabase.from('leads').insert(payload);
-           error = retry.error;
-         }
+         // R2: no silent column-stripping retries on create — fail loud instead.
+         const { error } = await supabase.from('leads').insert(payload);
          if (error) throw error;
          toast({ title: "Success", description: "Lead created." });
          setIsAddModalOpen(false);
+         setAddFormData((prev) => ({
+           ...prev,
+           firstName: '',
+           lastName: '',
+           email: '',
+           phone: '',
+           address: '',
+           service: '',
+         }));
          fetchLeads();
      } catch(e) {
-         toast({ variant: "destructive", title: "Error", description: e.message });
+         toast({
+           variant: 'destructive',
+           title: 'Could not create lead',
+           description: describeLeadIntakeDbError(e),
+         });
      } finally {
          setIsSaving(false);
      }
@@ -879,6 +905,15 @@ const Leads = () => {
                         </div>
                         <div className="space-y-2"><Label>Email</Label><Input value={addFormData.email} onChange={e => setAddFormData({...addFormData, email: e.target.value})} /></div>
                         <div className="space-y-2"><Label>Phone</Label><Input value={addFormData.phone} onChange={e => setAddFormData({...addFormData, phone: formatPhoneNumber(e.target.value)})} /></div>
+                        <div className="space-y-2">
+                          <Label>Service address</Label>
+                          <Input
+                            value={addFormData.address}
+                            onChange={(e) => setAddFormData({ ...addFormData, address: e.target.value })}
+                            placeholder="Street, city, state, ZIP"
+                          />
+                          <p className="text-xs text-muted-foreground">Required. Saved on the customer record (not a separate property).</p>
+                        </div>
                         <div className="space-y-2">
                              <Label>Document Delivery</Label>
                              <Select value={addFormData.preferredDocumentDelivery} onValueChange={(v) => setAddFormData({...addFormData, preferredDocumentDelivery: v})}>

--- a/command-center/src/pages/crm/appointments/AppointmentScheduler.jsx
+++ b/command-center/src/pages/crm/appointments/AppointmentScheduler.jsx
@@ -7,6 +7,10 @@ import { Calendar as CalendarIcon, Check, ChevronsUpDown, Loader2, Plus, UserPlu
 import { appointmentService } from '@/services/appointmentService';
 import { getTenantId } from '@/lib/tenantUtils';
 import { formatPhoneNumber } from '@/lib/formUtils';
+import {
+  assertLeadIntakeValid,
+  formatLeadIntakeErrors,
+} from '@/lib/leadIntakeContract';
 import { useToast } from '@/components/ui/use-toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -123,6 +127,7 @@ const AppointmentScheduler = () => {
     email: '',
     phone: '',
     company: '',
+    address: '',
   });
   const [formData, setFormData] = useState({
     lead_id: '',
@@ -227,11 +232,13 @@ const AppointmentScheduler = () => {
   }, [customers, prefilledLeadId]);
 
   const handleCreateCustomer = async () => {
-    if (!newCustomer.first_name.trim() && !newCustomer.last_name.trim() && !newCustomer.company.trim()) {
+    try {
+      assertLeadIntakeValid(newCustomer);
+    } catch (validationError) {
       toast({
         variant: 'destructive',
-        title: 'Customer name required',
-        description: 'Add at least a first name, last name, or company before saving.',
+        title: 'Missing required info',
+        description: formatLeadIntakeErrors({ errors: validationError.errors }) || validationError.message,
       });
       return;
     }
@@ -242,13 +249,18 @@ const AppointmentScheduler = () => {
         {
           ...newCustomer,
           phone: formatPhoneNumber(newCustomer.phone),
+          address: newCustomer.address,
           source: 'appointment_scheduler',
         },
         tenantId,
       );
 
       setCustomers((prev) => sortCustomers([created, ...prev.filter((entry) => entry.id !== created.id)]));
-      setFormData((prev) => ({ ...prev, lead_id: created.id }));
+      setFormData((prev) => ({
+        ...prev,
+        lead_id: created.id,
+        service_address: prev.service_address || created.address || newCustomer.address,
+      }));
       setCustomerDialogOpen(false);
       setCustomerPickerOpen(false);
       setNewCustomer({
@@ -257,6 +269,7 @@ const AppointmentScheduler = () => {
         email: '',
         phone: '',
         company: '',
+        address: '',
       });
 
       toast({
@@ -426,6 +439,15 @@ const AppointmentScheduler = () => {
                   }
                 />
               </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="new-customer-address">Service address</Label>
+              <Input
+                id="new-customer-address"
+                value={newCustomer.address}
+                onChange={(event) => setNewCustomer((prev) => ({ ...prev, address: event.target.value }))}
+                placeholder="Street, city, state, ZIP"
+              />
             </div>
           </div>
           <DialogFooter>

--- a/command-center/src/services/appointmentService.js
+++ b/command-center/src/services/appointmentService.js
@@ -1,4 +1,8 @@
 import { supabase } from '@/lib/customSupabaseClient';
+import {
+  buildLeadIntakeInsertPayload,
+  describeLeadIntakeDbError,
+} from '@/lib/leadIntakeContract';
 
 const DEFAULT_OPERATING_HOURS = {
   monday: { isOpen: true, start: '09:00', end: '17:00' },
@@ -27,14 +31,6 @@ const isMissingColumnError = (error) =>
   error?.code === '42703' ||
   /column .* does not exist/i.test(error?.message || '') ||
   /could not find the '.*' column/i.test(error?.message || '');
-
-const getMissingColumnName = (error) => {
-  const message = error?.message || '';
-  const postgresMatch = message.match(/column "([^"]+)"/i);
-  if (postgresMatch) return postgresMatch[1];
-  const cacheMatch = message.match(/could not find the '([^']+)' column/i);
-  return cacheMatch ? cacheMatch[1] : null;
-};
 
 const normalizeSettings = (row) => ({
   ...DEFAULT_BOOKING_SETTINGS,
@@ -198,35 +194,24 @@ export const appointmentService = {
   },
 
   async createCustomer(payload, tenantId) {
-    const insertPayload = {
-      tenant_id: tenantId,
-      first_name: payload.first_name,
-      last_name: payload.last_name,
-      email: payload.email || null,
-      phone: payload.phone || null,
-      company: payload.company || null,
-      service: payload.service || null,
-      source: payload.source || 'appointment_scheduler',
-      status: payload.status || 'new',
-      pipeline_stage: payload.pipeline_stage || 'new',
-      created_at: new Date().toISOString(),
-    };
-
-    let { data, error } = await supabase.from('leads').insert(insertPayload).select().single();
-
-    if (error && isMissingColumnError(error) && getMissingColumnName(error) === 'pipeline_stage') {
-      const fallbackPayload = {
-        ...insertPayload,
-        stage: insertPayload.pipeline_stage,
-      };
-      delete fallbackPayload.pipeline_stage;
-
-      const fallback = await supabase.from('leads').insert(fallbackPayload).select().single();
-      data = fallback.data;
-      error = fallback.error;
+    let insertPayload;
+    try {
+      insertPayload = buildLeadIntakeInsertPayload(payload, {
+        tenantId,
+        source: payload?.source || 'appointment_scheduler',
+        status: payload?.status || 'new',
+        pipeline_stage: payload?.pipeline_stage || 'new',
+        service: payload?.service || null,
+      });
+    } catch (validationError) {
+      throw new Error(describeLeadIntakeDbError(validationError));
     }
 
-    if (error) throw error;
+    const { data, error } = await supabase.from('leads').insert(insertPayload).select().single();
+
+    if (error) {
+      throw new Error(describeLeadIntakeDbError(error));
+    }
     return data;
   },
 

--- a/command-center/tests/smoke/inspection-field-address-schema.spec.js
+++ b/command-center/tests/smoke/inspection-field-address-schema.spec.js
@@ -209,10 +209,10 @@ test('composeAddressFromParts builds freeform text from form input without parsi
 
 test('new-lead flow persists freeform lead address and does not write invalid properties.address1', async () => {
   const customerStep = readSource('src/components/tech/InspectionFieldCustomerStep.jsx');
-  const leadPatchBlock = customerStep.match(/const leadPatch = \{[\s\S]*?\n\s*\};/);
-  expect(leadPatchBlock?.[0] || '').toMatch(/address:\s*serviceAddress/);
-  expect(leadPatchBlock?.[0] || '').not.toMatch(/\baddress1\s*:/);
-  expect(customerStep).not.toMatch(/\.insert\(\{[\s\S]*address1:/);
   expect(customerStep).toContain('appointmentService.createCustomer');
+  expect(customerStep).toContain('assertLeadIntakeValid');
+  expect(customerStep).toMatch(/address:\s*serviceAddress/);
+  expect(customerStep).not.toMatch(/\.from\(\s*['"]properties['"]\s*\)\s*\.insert/);
+  expect(customerStep).not.toMatch(/\.insert\(\{[\s\S]*address1:/);
   expect(customerStep).toMatch(/source:\s*'field_inspection'/);
 });

--- a/command-center/tests/smoke/r2-intake-clarity.spec.js
+++ b/command-center/tests/smoke/r2-intake-clarity.spec.js
@@ -1,0 +1,81 @@
+/* eslint-disable testing-library/prefer-screen-queries, jest/valid-title */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test, expect } from '@playwright/test';
+import {
+  LEAD_INTAKE_MESSAGES,
+  buildLeadIntakeInsertPayload,
+  validateLeadIntake,
+} from '../../src/lib/leadIntakeContract.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(here, '../..');
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+const INTAKE_SURFACES = [
+  'src/lib/leadIntakeContract.js',
+  'src/services/appointmentService.js',
+  'src/pages/crm/Leads.jsx',
+  'src/components/tech/InspectionFieldCustomerStep.jsx',
+  'src/pages/crm/appointments/AppointmentScheduler.jsx',
+];
+
+test('shared intake contract blocks incomplete creates with plain language', async () => {
+  const missing = validateLeadIntake({});
+  expect(missing.ok).toBe(false);
+  expect(missing.errors.map((e) => e.message)).toEqual(
+    expect.arrayContaining([
+      LEAD_INTAKE_MESSAGES.name,
+      LEAD_INTAKE_MESSAGES.phone,
+      LEAD_INTAKE_MESSAGES.address,
+    ]),
+  );
+
+  const ok = validateLeadIntake({
+    first_name: 'Pat',
+    phone: '3215551212',
+    address: '101 Test Airflow Lane, Titusville, FL 32780',
+  });
+  expect(ok.ok).toBe(true);
+
+  const payload = buildLeadIntakeInsertPayload(ok.normalized, { tenantId: 'tvg', source: 'test' });
+  expect(payload.address).toBeTruthy();
+  expect(payload.property_formatted_address).toBe(payload.address);
+  expect(payload).not.toHaveProperty('property_id');
+});
+
+test('CRM, field, and scheduler create paths import the intake contract', async () => {
+  for (const relativePath of INTAKE_SURFACES.slice(1)) {
+    const source = read(relativePath);
+    expect(source, relativePath).toMatch(/leadIntakeContract/);
+  }
+
+  expect(read('src/pages/crm/Leads.jsx')).toContain('assertLeadIntakeValid');
+  expect(read('src/pages/crm/Leads.jsx')).toContain('buildLeadIntakeInsertPayload');
+  expect(read('src/components/tech/InspectionFieldCustomerStep.jsx')).toContain('assertLeadIntakeValid');
+  expect(read('src/pages/crm/appointments/AppointmentScheduler.jsx')).toContain('assertLeadIntakeValid');
+  expect(read('src/services/appointmentService.js')).toContain('buildLeadIntakeInsertPayload');
+});
+
+test('create paths do not silently strip columns on lead insert', async () => {
+  const leads = read('src/pages/crm/Leads.jsx');
+  const handleAddSave = leads.match(/const handleAddSave = async \(\) => \{[\s\S]*?\n  \};/);
+  expect(handleAddSave?.[0] || '', 'handleAddSave missing').toBeTruthy();
+  expect(handleAddSave[0]).not.toMatch(/delete payload\./);
+  expect(handleAddSave[0]).toContain('describeLeadIntakeDbError');
+
+  const service = read('src/services/appointmentService.js');
+  const createCustomer = service.match(/async createCustomer\([\s\S]*?\n  \},/);
+  expect(createCustomer?.[0] || '', 'createCustomer missing').toBeTruthy();
+  expect(createCustomer[0]).not.toMatch(/delete fallbackPayload/);
+  expect(createCustomer[0]).not.toMatch(/delete .*pipeline_stage/);
+  expect(createCustomer[0]).toContain('describeLeadIntakeDbError');
+});
+
+test('intake create paths never invent properties rows', async () => {
+  for (const relativePath of INTAKE_SURFACES) {
+    const source = read(relativePath);
+    expect(source, relativePath).not.toMatch(/\.from\(\s*['"]properties['"]\s*\)\s*\.insert/);
+  }
+});

--- a/command-center/tests/unit/r2-lead-intake-contract.test.mjs
+++ b/command-center/tests/unit/r2-lead-intake-contract.test.mjs
@@ -1,0 +1,86 @@
+/**
+ * R2 lead intake contract tests (Node built-in test runner).
+ * Run: node --test tests/unit/r2-lead-intake-contract.test.mjs
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  LEAD_INTAKE_MESSAGES,
+  assertLeadIntakeValid,
+  buildLeadIntakeInsertPayload,
+  describeLeadIntakeDbError,
+  resolveIntakeAddress,
+  validateLeadIntake,
+} from '../../src/lib/leadIntakeContract.js';
+
+const validInput = {
+  first_name: 'Pat',
+  last_name: 'Homeowner',
+  phone: '(321) 555-1212',
+  address: '101 Test Airflow Lane, Titusville, FL 32780',
+};
+
+describe('R2 lead intake validation', () => {
+  it('requires name, phone, and address with plain-language errors', () => {
+    const empty = validateLeadIntake({});
+    assert.equal(empty.ok, false);
+    assert.deepEqual(
+      empty.errors.map((e) => e.field).sort(),
+      ['address', 'name', 'phone'],
+    );
+    assert.equal(empty.errors.find((e) => e.field === 'name')?.message, LEAD_INTAKE_MESSAGES.name);
+    assert.equal(empty.errors.find((e) => e.field === 'phone')?.message, LEAD_INTAKE_MESSAGES.phone);
+    assert.equal(empty.errors.find((e) => e.field === 'address')?.message, LEAD_INTAKE_MESSAGES.address);
+  });
+
+  it('accepts company-only name and structured address parts', () => {
+    const result = validateLeadIntake({
+      company: 'Vent Co',
+      phone: '3215551212',
+      address1: '55 Brand New Lead Way',
+      city: 'Titusville',
+      state: 'FL',
+      zip: '32780',
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.normalized.company, 'Vent Co');
+    assert.match(result.normalized.address, /55 Brand New Lead Way/);
+    assert.match(result.normalized.phone, /321/);
+  });
+
+  it('buildLeadIntakeInsertPayload writes lead address only (no property_id)', () => {
+    const payload = buildLeadIntakeInsertPayload(validInput, {
+      tenantId: 'tvg',
+      source: 'crm_leads',
+    });
+    assert.equal(payload.tenant_id, 'tvg');
+    assert.equal(payload.address, validInput.address);
+    assert.equal(payload.property_formatted_address, validInput.address);
+    assert.equal(payload.property_id, undefined);
+    assert.equal(payload.source, 'crm_leads');
+  });
+
+  it('assertLeadIntakeValid throws LEAD_INTAKE_VALIDATION', () => {
+    assert.throws(
+      () => assertLeadIntakeValid({ first_name: 'Pat' }),
+      (error) => error.code === 'LEAD_INTAKE_VALIDATION',
+    );
+  });
+
+  it('describeLeadIntakeDbError is loud for missing columns', () => {
+    const message = describeLeadIntakeDbError({
+      code: '42703',
+      message: 'column "property_formatted_address" does not exist',
+    });
+    assert.match(message, /property_formatted_address/);
+    assert.match(message, /not saved with missing data/i);
+  });
+
+  it('resolveIntakeAddress prefers freeform then composed parts', () => {
+    assert.equal(resolveIntakeAddress({ address: '  Freeform  ' }), 'Freeform');
+    assert.match(
+      resolveIntakeAddress({ address1: '1 Main', city: 'Titusville', state: 'FL', zip: '32780' }),
+      /1 Main/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add shared `leadIntakeContract` requiring name, phone, and service address for new leads
- Wire CRM Leads, field customer step, appointment scheduler, and `createCustomer` to the contract
- Persist address on the lead only (no properties invent); remove silent create-time column stripping (B-006, B-015)
- B-018 contacts sidebar accepted/deferred

## Test plan
- [x] `npm run test:intake-helpers` (6 passed)
- [x] Playwright `r2-intake-clarity` + `inspection-field-address-schema` (11 passed)
- [x] `npm run lint` (0 errors)
- [x] `npm run build:local`
- [x] `npm run review:gate` PASSED
- [ ] After merge/deploy: synthetic CRM + field lead create/delete; confirm address on lead

## Notes
- Frontend-only; no migration; no PDF/function deploy
- Stop conditions honored: no billing/quote trigger changes

Made with [Cursor](https://cursor.com)