### PR TITLE
fix(scheduling): R3 tech schedule + linked appointment lock

### DIFF
--- a/command-center/docs/stabilization/R3_SCHEDULING_OPERATIONS_PLAN.md
+++ b/command-center/docs/stabilization/R3_SCHEDULING_OPERATIONS_PLAN.md
@@ -1,0 +1,51 @@
+# R3 — Scheduling for Operations Plan
+
+**Branch:** `stabilize/r3-scheduling-operations`  
+**Worktree:** `F:\Dev\BHFOS-stabilize-r3-scheduling`  
+**Base:** `origin/main` @ `de304c15bb8b6636c8fa8b8477785190c49929c2` (R2 tip)
+
+## Goal
+
+Technicians can see and navigate their schedule from the phone. When a work order is linked to a calendar appointment, office users edit schedule on Calendar — not by dual-writing job times.
+
+## Includes
+
+| ID | Intent |
+| --- | --- |
+| B-005 | Mount read-only Tech Schedule with multi-day navigation |
+| B-016 | Jobs + Dispatch schedule fields read-only when `appointments.job_id` links the job |
+
+## Excludes
+
+- Dispatch AI / route optimization  
+- Work order board rewrite  
+- Migrations  
+- Forcing new appointment↔job links (link must already exist via Packet 008 `job_id`)
+
+## Surfaces
+
+| Surface | Change |
+| --- | --- |
+| `TechRoutes` / `TechLayout` | `/tech/schedule` route + bottom nav |
+| `TechSchedule` | Tenant filter, roster identity, day scroller, View Details → job |
+| `Jobs.jsx` | Linked appointment lookup; lock schedule fields; Calendar CTA |
+| `Schedule.jsx` (Dispatch) | Same lock for datetime / tech / address |
+| `jobAppointmentSchedule.js` | Shared linked-appointment helpers |
+
+## Acceptance
+
+- Tech opens Schedule and can move across days  
+- Linked job schedule fields are not editable on Jobs/Dispatch  
+- Unlinked jobs keep current schedule editing behavior  
+
+## Validation
+
+```bash
+npm run test:scheduling-contracts
+npm run lint
+npm run build:local
+```
+
+## Production verification (after deploy)
+
+Synthetic tech login → open Schedule → change day. Optional: linked appointment job shows locked schedule on Jobs/Dispatch.

--- a/command-center/docs/stabilization/V1_RELEASE_PLAN.md
+++ b/command-center/docs/stabilization/V1_RELEASE_PLAN.md
@@ -66,6 +66,8 @@ Priority order (unless new P0 outage):
 | Production verification | Synthetic appointment + tech login |
 | Stop conditions | Rewrites work order board |
 
+**Status:** In progress on `stabilize/r3-scheduling-operations` — see `R3_SCHEDULING_OPERATIONS_PLAN.md`.
+
 ---
 
 ## Release R4 — Estimate → job reliability

--- a/command-center/docs/stabilization/V1_STABILIZATION_BACKLOG.md
+++ b/command-center/docs/stabilization/V1_STABILIZATION_BACKLOG.md
@@ -94,7 +94,7 @@ Disposition meanings:
 | Smallest fix | Mount read-only tech schedule **or** improve queue date navigation — no CRM rewrite |
 | Test | Mobile tech route smoke |
 | Release | R3 |
-| Disposition | **Fix in V1** |
+| Disposition | **Fixed in V1** (`/tech/schedule` mounted; multi-day read-only schedule) |
 
 ### B-006 — Lead / customer / property intake ambiguity
 
@@ -235,7 +235,7 @@ Disposition meanings:
 | Evidence | Packet 008 sync trigger; both surfaces editable historically |
 | Smallest fix | UI: edit appointments only; jobs schedule read-only when linked |
 | Release | R3 |
-| Disposition | **Fix in V1** |
+| Disposition | **Fixed in V1** (Jobs + Dispatch lock schedule when `appointments.job_id` set; note: app still rarely sets `job_id`) |
 
 ### B-017 — Tracked `tmp/` tenant / ledger artifacts noise
 

--- a/command-center/docs/stabilization/V1_WORKFLOW_SCORECARD.md
+++ b/command-center/docs/stabilization/V1_WORKFLOW_SCORECARD.md
@@ -113,7 +113,7 @@ Scores are evidence-based. Where production proof is thin, scores stay conservat
 | Test coverage | 2 | Local schedule/dispatch UAT |
 | Production confidence | 2 | Phone scheduling friction called out by founder objectives |
 
-**Status: NEEDS WORK** — weakest mobile surface → R3.
+**Status: IN PROGRESS (R3)** — tech Schedule route mounted; linked appointment locks job schedule edits.
 
 ---
 

--- a/command-center/package.json
+++ b/command-center/package.json
@@ -17,6 +17,8 @@
     "test:identity-contracts": "npm run guard:identity && npm run test:identity-helpers && playwright test tests/smoke/r1a-property-relationship-safety.spec.js tests/smoke/r1b-technician-identity-contract.spec.js tests/smoke/r1c-identity-relationship-guards.spec.js tests/smoke/inspection-field-address-schema.spec.js",
     "test:intake-helpers": "node --test tests/unit/r2-lead-intake-contract.test.mjs",
     "test:intake-contracts": "npm run test:intake-helpers && playwright test tests/smoke/r2-intake-clarity.spec.js tests/smoke/inspection-field-address-schema.spec.js",
+    "test:scheduling-helpers": "node --test tests/unit/r3-job-appointment-schedule.test.mjs",
+    "test:scheduling-contracts": "npm run test:scheduling-helpers && playwright test tests/smoke/r3-scheduling-operations.spec.js",
     "verify:live-secrets": "node tools/scan-live-for-secrets.mjs https://app.bhfos.com",
     "validate:document-system": "node scripts/validate-document-system.mjs",
     "check:customer-doc-encoding": "node scripts/check-customer-doc-encoding.mjs",

--- a/command-center/src/components/tech/TechLayout.jsx
+++ b/command-center/src/components/tech/TechLayout.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { Link, Outlet, useLocation, useParams } from 'react-router-dom';
-import { ClipboardList, Home, LogOut } from 'lucide-react';
+import { CalendarDays, ClipboardList, Home, LogOut } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
@@ -9,6 +9,7 @@ import { tenantPath } from '@/lib/tenantUtils';
 
 const navItems = [
   { id: 'queue', label: 'Queue', icon: ClipboardList, path: '/tech/queue' },
+  { id: 'schedule', label: 'Schedule', icon: CalendarDays, path: '/tech/schedule' },
   { id: 'home', label: 'CRM', icon: Home, path: '/crm/dashboard' },
 ];
 
@@ -20,6 +21,7 @@ export default function TechLayout() {
   const pageLabel = useMemo(() => {
     const path = String(location.pathname || '').toLowerCase();
     if (path.includes('/tech/queue')) return 'Queue';
+    if (path.includes('/tech/schedule')) return 'Schedule';
     if (path.includes('/tech/jobs/')) return 'Job';
     if (path.includes('/tech/inspections/')) return 'Inspection';
     return 'Tech';
@@ -47,10 +49,16 @@ export default function TechLayout() {
       </main>
 
       <nav className="fixed inset-x-0 bottom-0 z-30 border-t border-slate-200 bg-white/95 backdrop-blur">
-        <div className="mx-auto grid max-w-3xl grid-cols-2 gap-2 px-3 py-2">
+        <div className="mx-auto grid max-w-3xl grid-cols-3 gap-2 px-3 py-2">
           {navItems.map((item) => {
             const href = tenantPath(item.path, tenantId);
-            const isActive = String(location.pathname || '').toLowerCase().includes(item.path);
+            const pathLower = String(location.pathname || '').toLowerCase();
+            const isActive =
+              item.id === 'schedule'
+                ? pathLower.includes('/tech/schedule')
+                : item.id === 'queue'
+                  ? pathLower.includes('/tech/queue')
+                  : pathLower.includes(item.path);
             return (
               <Link
                 key={item.id}

--- a/command-center/src/lib/jobAppointmentSchedule.js
+++ b/command-center/src/lib/jobAppointmentSchedule.js
@@ -1,0 +1,76 @@
+/**
+ * R3 — Appointment is the schedule source of truth when linked to a job.
+ *
+ * Link direction: appointments.job_id → jobs.id (Packet 008).
+ * When a link exists, CRM job/dispatch UIs must not edit scheduled_* (or
+ * mirroring tech/address) on the job; edit the appointment on Calendar instead.
+ */
+
+const asText = (value) => (typeof value === 'string' ? value.trim() : '');
+
+export const JOB_SCHEDULE_LINKED_MESSAGE =
+  'This work order is linked to a calendar appointment. Change the date, time, technician, or service address on Calendar — not on the work order.';
+
+export const LINKED_APPOINTMENT_SELECT =
+  'id, job_id, scheduled_start, scheduled_end, technician_id, service_address, status, lead_id';
+
+/**
+ * Fetch the appointment row linked to a job, if any.
+ */
+export const fetchLinkedAppointmentForJob = async (client, { tenantId, jobId } = {}) => {
+  const id = asText(jobId);
+  if (!client || !id) return null;
+
+  let query = client
+    .from('appointments')
+    .select(LINKED_APPOINTMENT_SELECT)
+    .eq('job_id', id)
+    .maybeSingle();
+
+  if (tenantId) {
+    query = client
+      .from('appointments')
+      .select(LINKED_APPOINTMENT_SELECT)
+      .eq('tenant_id', tenantId)
+      .eq('job_id', id)
+      .maybeSingle();
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    // Missing column / relation should not crash office screens.
+    if (
+      error.code === '42703' ||
+      error.code === '42P01' ||
+      /column .* does not exist|could not find the/i.test(error.message || '')
+    ) {
+      return null;
+    }
+    throw error;
+  }
+  return data || null;
+};
+
+export const isJobScheduleLockedByAppointment = (appointment) => Boolean(appointment?.id);
+
+/** Compare ISO timestamps within 60s (trigger sync / UI rounding). */
+export const scheduleTimesMatch = (leftIso, rightIso, toleranceMs = 60_000) => {
+  if (!leftIso || !rightIso) return false;
+  const left = new Date(leftIso).getTime();
+  const right = new Date(rightIso).getTime();
+  if (!Number.isFinite(left) || !Number.isFinite(right)) return false;
+  return Math.abs(left - right) <= toleranceMs;
+};
+
+/**
+ * When schedule is locked, drop schedule-driving fields from a job update payload.
+ * Leaves payment_terms and other non-schedule fields intact.
+ */
+export const omitLockedScheduleFields = (payload = {}) => {
+  const next = { ...payload };
+  delete next.scheduled_start;
+  delete next.scheduled_end;
+  delete next.technician_id;
+  delete next.service_address;
+  return next;
+};

--- a/command-center/src/pages/crm/Jobs.jsx
+++ b/command-center/src/pages/crm/Jobs.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { Helmet } from 'react-helmet';
 import { useSearchParams } from 'react-router-dom';
 import { supabase } from '@/lib/customSupabaseClient';
-import { getTenantId } from '@/lib/tenantUtils';
+import { getTenantId, tenantPath } from '@/lib/tenantUtils';
 import {
   normalizeJobStatus,
   normalizePaymentStatus,
@@ -33,6 +33,12 @@ import {
   resolveTechnicianSelectValue,
   TECHNICIAN_ROSTER_SELECT,
 } from '@/lib/technicianIdentity';
+import {
+  JOB_SCHEDULE_LINKED_MESSAGE,
+  fetchLinkedAppointmentForJob,
+  isJobScheduleLockedByAppointment,
+  omitLockedScheduleFields,
+} from '@/lib/jobAppointmentSchedule';
 import {
   PAYMENT_TERM_OPTIONS,
   formatOperationalStageLabel,
@@ -87,8 +93,12 @@ const Jobs = () => {
   const [recordTechnicianId, setRecordTechnicianId] = useState('unassigned');
   const [recordServiceAddress, setRecordServiceAddress] = useState('');
   const [recordPaymentTerms, setRecordPaymentTerms] = useState('NET_7');
+  const [recordLinkedAppointment, setRecordLinkedAppointment] = useState(null);
+  const [scheduleLinkedAppointment, setScheduleLinkedAppointment] = useState(null);
 
   const tenantId = getTenantId();
+  const recordScheduleLocked = isJobScheduleLockedByAppointment(recordLinkedAppointment);
+  const scheduleLocked = isJobScheduleLockedByAppointment(scheduleLinkedAppointment);
   const asText = (value) => (typeof value === 'string' ? value.trim() : '');
   const asTracking = (value) => asText(value).toUpperCase();
   const formatPhoneDisplay = (value) => {
@@ -491,7 +501,7 @@ const Jobs = () => {
     setPaymentModalOpen(true);
   };
 
-  const openRecordModal = (job) => {
+  const openRecordModal = async (job) => {
     setRecordJob(job);
     setRecordStart(toDatetimeLocal(job?.scheduled_start));
     setRecordTechnicianId(resolveTechnicianSelection(job?.technician_id));
@@ -499,7 +509,20 @@ const Jobs = () => {
     setRecordPaymentTerms(
       normalizeWorkOrderPaymentTerms(job?.payment_terms) || 'NET_7',
     );
+    setRecordLinkedAppointment(null);
     setRecordModalOpen(true);
+    try {
+      const linked = await fetchLinkedAppointmentForJob(supabase, {
+        tenantId,
+        jobId: job?.id,
+      });
+      setRecordLinkedAppointment(linked);
+      if (linked?.scheduled_start) {
+        setRecordStart(toDatetimeLocal(linked.scheduled_start));
+      }
+    } catch (error) {
+      console.warn('Linked appointment lookup skipped:', error?.message || error);
+    }
   };
 
   const getScheduledDurationMinutes = (job) => {
@@ -514,14 +537,18 @@ const Jobs = () => {
     if (!recordJob?.id) return;
 
     const trimmedAddress = recordServiceAddress.trim();
-    const payload = {
+    let payload = {
       service_address: trimmedAddress || null,
       technician_id: recordTechnicianId === 'unassigned' ? null : recordTechnicianId,
       payment_terms: recordPaymentTerms,
       updated_at: new Date().toISOString(),
     };
 
-    if (recordStart) {
+    if (recordScheduleLocked) {
+      payload = omitLockedScheduleFields(payload);
+      payload.payment_terms = recordPaymentTerms;
+      payload.updated_at = new Date().toISOString();
+    } else if (recordStart) {
       const start = new Date(recordStart);
       if (Number.isNaN(start.getTime())) {
         toast({ variant: 'destructive', title: 'Invalid date', description: 'Please enter a valid scheduled start.' });
@@ -569,7 +596,7 @@ const Jobs = () => {
     }
   };
 
-  const openScheduleModal = (job) => {
+  const openScheduleModal = async (job) => {
     setRecordModalOpen(false);
     setScheduleJob(job);
     setScheduleStart(toDatetimeLocal(job.scheduled_start));
@@ -583,10 +610,45 @@ const Jobs = () => {
     }
     setScheduleAddress(job.service_address || '');
     setScheduleTechnicianId(resolveTechnicianSelection(job.technician_id));
+    setScheduleLinkedAppointment(null);
     setScheduleModalOpen(true);
+    try {
+      const linked = await fetchLinkedAppointmentForJob(supabase, {
+        tenantId,
+        jobId: job?.id,
+      });
+      setScheduleLinkedAppointment(linked);
+      if (linked?.scheduled_start) {
+        setScheduleStart(toDatetimeLocal(linked.scheduled_start));
+        if (linked.scheduled_end) {
+          const start = new Date(linked.scheduled_start).getTime();
+          const end = new Date(linked.scheduled_end).getTime();
+          if (Number.isFinite(start) && Number.isFinite(end) && end > start) {
+            setScheduleDuration(String(Math.max(30, Math.round((end - start) / 60000))));
+          }
+        }
+        if (linked.technician_id) {
+          setScheduleTechnicianId(resolveTechnicianSelection(linked.technician_id));
+        }
+        if (linked.service_address) {
+          setScheduleAddress(linked.service_address);
+        }
+      }
+    } catch (error) {
+      console.warn('Linked appointment lookup skipped:', error?.message || error);
+    }
   };
 
   const handleScheduleSubmit = async () => {
+    if (scheduleLocked) {
+      toast({
+        variant: 'destructive',
+        title: 'Edit on Calendar',
+        description: JOB_SCHEDULE_LINKED_MESSAGE,
+      });
+      return;
+    }
+
     if (!scheduleJob || !scheduleStart) {
       toast({ variant: 'destructive', title: 'Missing schedule', description: 'Start date/time is required.' });
       return;
@@ -971,13 +1033,23 @@ const Jobs = () => {
                   </div>
                 </div>
 
+                {recordScheduleLocked ? (
+                  <div className="md:col-span-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                    <p className="font-medium">Schedule locked to Calendar</p>
+                    <p className="mt-1 text-amber-800">{JOB_SCHEDULE_LINKED_MESSAGE}</p>
+                    <Button asChild variant="outline" size="sm" className="mt-2">
+                      <Link to={tenantPath('/crm/calendar', tenantId)}>Open Calendar</Link>
+                    </Button>
+                  </div>
+                ) : null}
+
                 <div className="space-y-2">
                   <Label>Scheduled Start</Label>
                   <Input
                     type="datetime-local"
                     value={recordStart}
                     onChange={(e) => setRecordStart(e.target.value)}
-                    disabled={processingId === recordJob.id}
+                    disabled={processingId === recordJob.id || recordScheduleLocked}
                   />
                 </div>
 
@@ -986,7 +1058,7 @@ const Jobs = () => {
                   <Select
                     value={recordTechnicianId}
                     onValueChange={setRecordTechnicianId}
-                    disabled={processingId === recordJob.id}
+                    disabled={processingId === recordJob.id || recordScheduleLocked}
                   >
                     <SelectTrigger>
                       <SelectValue placeholder="Unassigned" />
@@ -1010,7 +1082,7 @@ const Jobs = () => {
                     onChange={(e) => setRecordServiceAddress(e.target.value)}
                     onAddressSelect={(addressData) => setRecordServiceAddress(formatSelectedAddress(addressData))}
                     placeholder="Street, City, State ZIP"
-                    disabled={processingId === recordJob.id}
+                    disabled={processingId === recordJob.id || recordScheduleLocked}
                   />
                 </div>
 
@@ -1131,12 +1203,22 @@ const Jobs = () => {
               <div className="text-slate-600">{scheduleJob?.leads?.first_name} {scheduleJob?.leads?.last_name}</div>
               <div className="text-slate-500">{formatPhoneDisplay(scheduleJob?.leads?.phone)}</div>
             </div>
+            {scheduleLocked ? (
+              <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                <p className="font-medium">Schedule locked to Calendar</p>
+                <p className="mt-1 text-amber-800">{JOB_SCHEDULE_LINKED_MESSAGE}</p>
+                <Button asChild variant="outline" size="sm" className="mt-2">
+                  <Link to={tenantPath('/crm/calendar', tenantId)}>Open Calendar</Link>
+                </Button>
+              </div>
+            ) : null}
             <div className="space-y-2">
               <Label>Start Date & Time</Label>
               <Input
                 type="datetime-local"
                 value={scheduleStart}
                 onChange={(e) => setScheduleStart(e.target.value)}
+                disabled={scheduleLocked}
               />
             </div>
             <div className="space-y-2">
@@ -1147,11 +1229,12 @@ const Jobs = () => {
                 step="15"
                 value={scheduleDuration}
                 onChange={(e) => setScheduleDuration(e.target.value)}
+                disabled={scheduleLocked}
               />
             </div>
             <div className="space-y-2">
               <Label>Technician (optional)</Label>
-                  <Select value={scheduleTechnicianId} onValueChange={setScheduleTechnicianId}>
+                  <Select value={scheduleTechnicianId} onValueChange={setScheduleTechnicianId} disabled={scheduleLocked}>
                 <SelectTrigger>
                   <SelectValue placeholder="Unassigned" />
                 </SelectTrigger>
@@ -1173,6 +1256,7 @@ const Jobs = () => {
                 onChange={(e) => setScheduleAddress(e.target.value)}
                 onAddressSelect={(addressData) => setScheduleAddress(formatSelectedAddress(addressData))}
                 placeholder="Street, City, State ZIP"
+                disabled={scheduleLocked}
               />
             </div>
           </div>
@@ -1180,7 +1264,10 @@ const Jobs = () => {
             <Button variant="outline" onClick={() => setScheduleModalOpen(false)}>
               Cancel
             </Button>
-            <Button onClick={handleScheduleSubmit} disabled={!scheduleStart || processingId === scheduleJob?.id}>
+            <Button
+              onClick={handleScheduleSubmit}
+              disabled={scheduleLocked || !scheduleStart || processingId === scheduleJob?.id}
+            >
               {processingId === scheduleJob?.id ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : null}
               Confirm Schedule
             </Button>

--- a/command-center/src/pages/crm/Schedule.jsx
+++ b/command-center/src/pages/crm/Schedule.jsx
@@ -46,7 +46,13 @@ import { cn } from '@/lib/utils';
 import {
   formatOperationalStageLabel,
 } from '@/lib/workOrderOperational';
-import { getTenantId } from '@/lib/tenantUtils';
+import { getTenantId, tenantPath } from '@/lib/tenantUtils';
+import {
+  JOB_SCHEDULE_LINKED_MESSAGE,
+  fetchLinkedAppointmentForJob,
+  isJobScheduleLockedByAppointment,
+  omitLockedScheduleFields,
+} from '@/lib/jobAppointmentSchedule';
 import { jobService } from '@/services/jobService';
 import { workOrderBoardService } from '@/services/workOrderBoardService';
 
@@ -682,6 +688,9 @@ export default function Schedule() {
   const [dispatchService, setDispatchService] = useState('');
   const [dispatchStatus, setDispatchStatus] = useState('unscheduled');
   const [dispatchErrors, setDispatchErrors] = useState({});
+  const [linkedAppointment, setLinkedAppointment] = useState(null);
+
+  const scheduleLocked = isJobScheduleLockedByAppointment(linkedAppointment);
 
   const hydrateBoard = async ({ showPageSpinner = false } = {}) => {
     if (!tenantId) return;
@@ -832,6 +841,7 @@ export default function Schedule() {
       setDispatchService('');
       setDispatchStatus('unscheduled');
       setDispatchErrors({});
+      setLinkedAppointment(null);
       return;
     }
 
@@ -842,6 +852,7 @@ export default function Schedule() {
     setDispatchService(selectedJobDispatchService);
     setDispatchStatus(selectedJobDispatchStatus);
     setDispatchErrors({});
+    setLinkedAppointment(null);
   }, [
     selectedJobResetKey,
     selectedJobDispatchAddress,
@@ -851,6 +862,49 @@ export default function Schedule() {
     selectedJobDispatchStatus,
     selectedJobDispatchTechnicianId,
   ]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadLinked = async () => {
+      if (!selectedJob?.id) {
+        setLinkedAppointment(null);
+        return;
+      }
+      try {
+        const linked = await fetchLinkedAppointmentForJob(supabase, {
+          tenantId,
+          jobId: selectedJob.id,
+        });
+        if (cancelled) return;
+        setLinkedAppointment(linked);
+        if (linked?.scheduled_start) {
+          setDispatchStart(toDatetimeLocal(linked.scheduled_start));
+          if (linked.scheduled_end) {
+            const start = new Date(linked.scheduled_start).getTime();
+            const end = new Date(linked.scheduled_end).getTime();
+            if (Number.isFinite(start) && Number.isFinite(end) && end > start) {
+              setDispatchDuration(String(Math.max(30, Math.round((end - start) / 60000))));
+            }
+          }
+          if (linked.technician_id) {
+            setDispatchTechnicianId(resolveTechnicianSelection(technicians, linked.technician_id));
+          }
+          if (linked.service_address) {
+            setDispatchAddress(linked.service_address);
+          }
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.warn('Linked appointment lookup skipped:', error?.message || error);
+          setLinkedAppointment(null);
+        }
+      }
+    };
+    loadLinked();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedJob?.id, tenantId, technicians]);
 
   const handlePrimaryAction = async () => {
     if (!selectedJob || !selectedPrimaryAction) return;
@@ -931,35 +985,41 @@ export default function Schedule() {
     const trimmedService = dispatchService.trim();
     const nextStatus = normalizeStatus(dispatchStatus || selectedJob.status);
     const mustHaveStart =
-      ['unscheduled', 'pending_schedule'].includes(selectedJob.dispatch_status) || Boolean(dispatchStart);
+      !scheduleLocked &&
+      (['unscheduled', 'pending_schedule'].includes(selectedJob.dispatch_status) || Boolean(dispatchStart));
     const addressValidation = getDispatchAddressValidation(trimmedAddress);
     const nextErrors = {};
 
-    if (!trimmedAddress) {
-      nextErrors.address = 'Street, city, and state are required before dispatch.';
-    } else if (!addressValidation.hasDispatchableAddress) {
-      nextErrors.address = 'Enter a dispatchable address with street, city, and state.';
+    if (!scheduleLocked) {
+      if (!trimmedAddress) {
+        nextErrors.address = 'Street, city, and state are required before dispatch.';
+      } else if (!addressValidation.hasDispatchableAddress) {
+        nextErrors.address = 'Enter a dispatchable address with street, city, and state.';
+      }
     }
 
     if (!trimmedService) {
       nextErrors.service = 'Set the service or scope before saving dispatch.';
     }
 
-    if (selectedPrimaryAction?.key === 'assign_technician' && dispatchTechnicianId === 'unassigned') {
-      nextErrors.technician = technicians.length
-        ? 'Choose a technician before assigning this work order.'
-        : 'No active technicians are available to assign.';
-    } else if (selectedPrimaryAction?.key === 'assign_technician' && technicians.length === 0) {
-      nextErrors.technician = 'No active technicians are available to assign.';
-    }
-
-    if (mustHaveStart && !dispatchStart) {
-      nextErrors.start = 'Select the service date and time before saving dispatch.';
-    }
-
     const duration = Number(dispatchDuration);
-    if (!Number.isFinite(duration) || duration <= 0) {
-      nextErrors.duration = 'Dispatch duration must be greater than 0 minutes.';
+
+    if (!scheduleLocked) {
+      if (selectedPrimaryAction?.key === 'assign_technician' && dispatchTechnicianId === 'unassigned') {
+        nextErrors.technician = technicians.length
+          ? 'Choose a technician before assigning this work order.'
+          : 'No active technicians are available to assign.';
+      } else if (selectedPrimaryAction?.key === 'assign_technician' && technicians.length === 0) {
+        nextErrors.technician = 'No active technicians are available to assign.';
+      }
+
+      if (mustHaveStart && !dispatchStart) {
+        nextErrors.start = 'Select the service date and time before saving dispatch.';
+      }
+
+      if (!Number.isFinite(duration) || duration <= 0) {
+        nextErrors.duration = 'Dispatch duration must be greater than 0 minutes.';
+      }
     }
 
     setDispatchErrors(nextErrors);
@@ -1009,14 +1069,19 @@ export default function Schedule() {
       return;
     }
 
-    const payload = {
+    let payload = {
       service_address: trimmedAddress,
       technician_id: dispatchTechnicianId === 'unassigned' ? null : dispatchTechnicianId,
       status: nextStatus,
       updated_at: new Date().toISOString(),
     };
 
-    if (dispatchStart) {
+    if (scheduleLocked) {
+      // Appointment owns schedule fields — only allow status/service updates here.
+      payload = omitLockedScheduleFields(payload);
+      payload.status = nextStatus;
+      payload.updated_at = new Date().toISOString();
+    } else if (dispatchStart) {
       const start = new Date(dispatchStart);
       if (Number.isNaN(start.getTime())) {
         toast({
@@ -1331,6 +1396,16 @@ export default function Schedule() {
                           Dispatch Setup
                         </div>
 
+                        {scheduleLocked ? (
+                          <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                            <p className="font-medium">Schedule locked to Calendar</p>
+                            <p className="mt-1 text-amber-800">{JOB_SCHEDULE_LINKED_MESSAGE}</p>
+                            <Button asChild variant="outline" size="sm" className="mt-2">
+                              <Link to={tenantPath('/crm/calendar', tenantId)}>Open Calendar</Link>
+                            </Button>
+                          </div>
+                        ) : null}
+
                         <div className="space-y-2">
                           <Label htmlFor="dispatch-service-input">Service / Scope</Label>
                             <Input
@@ -1380,7 +1455,7 @@ export default function Schedule() {
                               setDispatchStart(event.target.value);
                               setDispatchErrors((prev) => ({ ...prev, start: null }));
                             }}
-                            disabled={processingId === selectedJob.id}
+                            disabled={processingId === selectedJob.id || scheduleLocked}
                           />
                           {dispatchErrors.start ? (
                             <p className="text-sm text-red-600">{dispatchErrors.start}</p>
@@ -1401,7 +1476,7 @@ export default function Schedule() {
                                 setDispatchDuration(event.target.value);
                                 setDispatchErrors((prev) => ({ ...prev, duration: null }));
                               }}
-                              disabled={processingId === selectedJob.id}
+                              disabled={processingId === selectedJob.id || scheduleLocked}
                             />
                             {dispatchErrors.duration ? (
                               <p className="text-sm text-red-600">{dispatchErrors.duration}</p>
@@ -1416,7 +1491,7 @@ export default function Schedule() {
                                 setDispatchTechnicianId(value);
                                 setDispatchErrors((prev) => ({ ...prev, technician: null }));
                               }}
-                              disabled={processingId === selectedJob.id}
+                              disabled={processingId === selectedJob.id || scheduleLocked}
                             >
                               <SelectTrigger id="dispatch-technician-select" aria-label="Dispatch Technician">
                                 <SelectValue placeholder="Unassigned" />
@@ -1455,7 +1530,7 @@ export default function Schedule() {
                             }}
                             className={dispatchErrors.address ? 'border-red-300 focus-visible:ring-red-300' : ''}
                             placeholder="Street, City, State ZIP"
-                            disabled={processingId === selectedJob.id}
+                            disabled={processingId === selectedJob.id || scheduleLocked}
                           />
                           {dispatchErrors.address ? (
                             <p className="text-sm text-red-600">{dispatchErrors.address}</p>

--- a/command-center/src/pages/tech/TechRoutes.jsx
+++ b/command-center/src/pages/tech/TechRoutes.jsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import TechLayout from '@/components/tech/TechLayout';
 
 import TechQueue from '@/pages/tech/TechQueue';
+import TechSchedule from '@/pages/tech/TechSchedule';
 import TechJobDetail from '@/pages/tech/TechJobDetail';
 import TechInspectionSession from '@/pages/tech/TechInspectionSession';
 import TechInspectionReview from '@/pages/tech/TechInspectionReview';
@@ -13,6 +14,7 @@ export default function TechRoutes() {
       <Route element={<TechLayout />}>
         <Route index element={<Navigate to="queue" replace />} />
         <Route path="queue" element={<TechQueue />} />
+        <Route path="schedule" element={<TechSchedule />} />
         <Route path="jobs/:jobId" element={<TechJobDetail />} />
         <Route path="inspections/:inspectionId" element={<TechInspectionSession />} />
         <Route path="inspections/:inspectionId/review" element={<TechInspectionReview />} />

--- a/command-center/src/pages/tech/TechSchedule.jsx
+++ b/command-center/src/pages/tech/TechSchedule.jsx
@@ -1,157 +1,217 @@
-import React, { useState, useEffect } from 'react';
-import { supabase } from '@/lib/customSupabaseClient';
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { format, addDays, startOfDay, endOfDay } from 'date-fns';
-import { MapPin, Clock, Calendar as CalendarIcon, Phone, User, ArrowRight } from 'lucide-react';
+import { MapPin, Clock, Calendar as CalendarIcon, Phone, ArrowRight } from 'lucide-react';
+
+import { supabase } from '@/lib/customSupabaseClient';
+import { getTenantId, tenantPath } from '@/lib/tenantUtils';
+import { resolveLoggedInTechnicianRosterId } from '@/lib/technicianIdentity';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { useToast } from '@/components/ui/use-toast';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { useTrainingMode } from '@/contexts/TrainingModeContext';
 
+/**
+ * Read-only multi-day schedule for field techs (R3 / B-005).
+ * Office Calendar remains the place to change appointment times.
+ */
 const TechSchedule = () => {
-    const { user } = useSupabaseAuth();
-    const { isTrainingMode } = useTrainingMode();
-    const [jobs, setJobs] = useState([]);
-    const [loading, setLoading] = useState(true);
-    const [selectedDate, setSelectedDate] = useState(new Date());
+  const tenantId = getTenantId();
+  const { user } = useSupabaseAuth();
+  const { isTrainingMode } = useTrainingMode();
+  const [jobs, setJobs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [technicianId, setTechnicianId] = useState(null);
 
-    useEffect(() => {
-        const fetchJobs = async () => {
-            if (!user) return;
-            setLoading(true);
+  useEffect(() => {
+    const fetchJobs = async () => {
+      if (!user?.id) return;
+      setLoading(true);
 
-            // Fetch tech profile first
-            const { data: techData } = await supabase
-                .from('technicians')
-                .select('id, user_id')
-                .eq('user_id', user.id)
-                .single();
+      const { data: techRows, error: techError } = await supabase
+        .from('technicians')
+        .select('id, user_id, full_name, is_active')
+        .eq('user_id', user.id);
 
-            if (!techData) {
-                setLoading(false);
-                return;
-            }
+      if (techError) {
+        console.error(techError);
+        setJobs([]);
+        setTechnicianId(null);
+        setLoading(false);
+        return;
+      }
 
-            const start = startOfDay(selectedDate).toISOString();
-            const end = endOfDay(selectedDate).toISOString();
+      const rosterId = resolveLoggedInTechnicianRosterId({
+        technicians: techRows || [],
+        authUserId: user.id,
+      });
+      setTechnicianId(rosterId);
 
-            // Construct Query with Mode Filter
-            let query = supabase
-                .from('jobs')
-                .select(`
-                    *,
-                    leads ( first_name, last_name, phone, address, property_formatted_address )
-                `)
-                .eq('technician_id', techData.id)
-                .gte('scheduled_start', start)
-                .lte('scheduled_start', end)
-                .order('scheduled_start', { ascending: true });
+      if (!rosterId) {
+        setJobs([]);
+        setLoading(false);
+        return;
+      }
 
-            // MODE FILTER
-            if (isTrainingMode) {
-                query = query.eq('is_test_data', true);
-            } else {
-                query = query.or('is_test_data.is.false,is_test_data.is.null');
-            }
+      const start = startOfDay(selectedDate).toISOString();
+      const end = endOfDay(selectedDate).toISOString();
 
-            const { data, error } = await query;
-            if (error) console.error(error);
-            setJobs(data || []);
-            setLoading(false);
-        };
+      let query = supabase
+        .from('jobs')
+        .select(
+          `
+          id,
+          tenant_id,
+          status,
+          scheduled_start,
+          scheduled_end,
+          service_address,
+          work_order_number,
+          leads ( first_name, last_name, company, phone, address, property_formatted_address )
+        `,
+        )
+        .eq('tenant_id', tenantId)
+        .eq('technician_id', rosterId)
+        .gte('scheduled_start', start)
+        .lte('scheduled_start', end)
+        .order('scheduled_start', { ascending: true });
 
-        fetchJobs();
-    }, [user, selectedDate, isTrainingMode]);
+      if (isTrainingMode) {
+        query = query.eq('is_test_data', true);
+      } else {
+        query = query.or('is_test_data.is.false,is_test_data.is.null');
+      }
 
+      const { data, error } = await query;
+      if (error) console.error(error);
+      setJobs(data || []);
+      setLoading(false);
+    };
+
+    fetchJobs();
+  }, [user, selectedDate, isTrainingMode, tenantId]);
+
+  const customerName = (job) => {
+    const lead = job?.leads;
     return (
-        <div className="min-h-screen bg-slate-50 pb-20">
-            {/* Header */}
-            <div className="bg-white border-b sticky top-0 z-10">
-                <div className="px-4 py-3 flex justify-between items-center">
-                    <h1 className="text-lg font-bold text-slate-900">My Schedule</h1>
-                </div>
-                
-                {/* Date Scroller */}
-                <div className="flex overflow-x-auto py-2 px-4 gap-2 border-t bg-slate-50/50">
-                    {[-1, 0, 1, 2, 3].map(days => {
-                        const date = addDays(new Date(), days);
-                        const isSelected = date.toDateString() === selectedDate.toDateString();
-                        return (
-                            <button
-                                key={days}
-                                onClick={() => setSelectedDate(date)}
-                                className={`flex flex-col items-center min-w-[4.5rem] p-2 rounded-lg border text-sm transition-all ${
-                                    isSelected 
-                                        ? 'bg-blue-600 text-white border-blue-600 shadow-md' 
-                                        : 'bg-white text-slate-600 border-slate-200'
-                                }`}
-                            >
-                                <span className="font-bold">{format(date, 'EEE')}</span>
-                                <span className="text-xs opacity-90">{format(date, 'MMM d')}</span>
-                            </button>
-                        );
-                    })}
-                </div>
-            </div>
-
-            {/* Work Order List */}
-            <div className="p-4 space-y-4">
-                {loading ? (
-                    <div className="text-center py-10 text-slate-400">Loading schedule...</div>
-                ) : jobs.length === 0 ? (
-                    <div className="text-center py-10">
-                        <div className="bg-white p-6 rounded-full inline-block mb-4 shadow-sm">
-                            <CalendarIcon className="h-8 w-8 text-slate-300" />
-                        </div>
-                        <h3 className="text-slate-900 font-medium">No Work Orders Scheduled</h3>
-                        <p className="text-slate-500 text-sm mt-1">You're clear for {format(selectedDate, 'MMMM do')}.</p>
-                        {isTrainingMode && <p className="text-amber-600 text-xs mt-2 font-medium">Tip: Switch to Live Mode to see real work orders.</p>}
-                    </div>
-                ) : (
-                    jobs.map(job => (
-                        <Card key={job.id} className="overflow-hidden border-l-4 border-l-blue-500 shadow-sm">
-                            <CardContent className="p-4">
-                                <div className="flex justify-between items-start mb-3">
-                                    <div className="flex items-center text-blue-700 font-bold">
-                                        <Clock className="h-4 w-4 mr-1.5" />
-                                        {format(new Date(job.scheduled_start), 'h:mm a')}
-                                    </div>
-                                    <Badge variant="outline" className="bg-slate-50">{job.status}</Badge>
-                                </div>
-                                
-                                <h3 className="text-lg font-bold text-slate-900 mb-1">
-                                    {job.leads?.first_name} {job.leads?.last_name}
-                                </h3>
-                                
-                                <div className="space-y-2 text-sm text-slate-600 mb-4">
-                                    <div className="flex items-start">
-                                        <MapPin className="h-4 w-4 mr-2 mt-0.5 text-slate-400 shrink-0" />
-                                        <span>
-                                            {job.service_address
-                                              || job.leads?.property_formatted_address
-                                              || job.leads?.address
-                                              || 'No address on file'}
-                                        </span>
-                                    </div>
-                                    <div className="flex items-center">
-                                        <Phone className="h-4 w-4 mr-2 text-slate-400" />
-                                        <a href={`tel:${job.leads?.phone}`} className="underline decoration-slate-300">
-                                            {job.leads?.phone}
-                                        </a>
-                                    </div>
-                                </div>
-
-                                <Button className="w-full bg-blue-600 hover:bg-blue-700">
-                                    View Details <ArrowRight className="ml-2 h-4 w-4" />
-                                </Button>
-                            </CardContent>
-                        </Card>
-                    ))
-                )}
-            </div>
-        </div>
+      [lead?.first_name, lead?.last_name].filter(Boolean).join(' ').trim() ||
+      lead?.company ||
+      'Customer'
     );
+  };
+
+  return (
+    <div className="pb-4">
+      <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
+        <div className="px-4 py-3 flex justify-between items-center border-b">
+          <div>
+            <h1 className="text-lg font-bold text-slate-900">My Schedule</h1>
+            <p className="text-xs text-slate-500">Read-only. Office changes times on Calendar.</p>
+          </div>
+        </div>
+
+        <div className="flex overflow-x-auto py-2 px-4 gap-2 bg-slate-50/50">
+          {[-1, 0, 1, 2, 3].map((days) => {
+            const date = addDays(new Date(), days);
+            const isSelected = date.toDateString() === selectedDate.toDateString();
+            return (
+              <button
+                key={days}
+                type="button"
+                onClick={() => setSelectedDate(date)}
+                className={`flex flex-col items-center min-w-[4.5rem] min-h-11 p-2 rounded-lg border text-sm transition-all ${
+                  isSelected
+                    ? 'bg-blue-600 text-white border-blue-600 shadow-md'
+                    : 'bg-white text-slate-600 border-slate-200'
+                }`}
+              >
+                <span className="font-bold">{format(date, 'EEE')}</span>
+                <span className="text-xs opacity-90">{format(date, 'MMM d')}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-4">
+        {!technicianId && !loading ? (
+          <div className="text-center py-10 text-slate-500 text-sm">
+            No technician profile is linked to this login. Ask the office to connect your account.
+          </div>
+        ) : null}
+
+        {loading ? (
+          <div className="text-center py-10 text-slate-400">Loading schedule...</div>
+        ) : jobs.length === 0 && technicianId ? (
+          <div className="text-center py-10">
+            <div className="bg-white p-6 rounded-full inline-block mb-4 shadow-sm border">
+              <CalendarIcon className="h-8 w-8 text-slate-300" />
+            </div>
+            <h3 className="text-slate-900 font-medium">No Work Orders Scheduled</h3>
+            <p className="text-slate-500 text-sm mt-1">
+              You&apos;re clear for {format(selectedDate, 'MMMM do')}.
+            </p>
+            {isTrainingMode ? (
+              <p className="text-amber-600 text-xs mt-2 font-medium">
+                Tip: Switch to Live Mode to see real work orders.
+              </p>
+            ) : null}
+          </div>
+        ) : (
+          jobs.map((job) => (
+            <Card key={job.id} className="overflow-hidden border-l-4 border-l-blue-500 shadow-sm">
+              <CardContent className="p-4">
+                <div className="flex justify-between items-start mb-3">
+                  <div className="flex items-center text-blue-700 font-bold">
+                    <Clock className="h-4 w-4 mr-1.5" />
+                    {job.scheduled_start
+                      ? format(new Date(job.scheduled_start), 'h:mm a')
+                      : 'Unscheduled'}
+                  </div>
+                  <Badge variant="outline" className="bg-slate-50">
+                    {job.status}
+                  </Badge>
+                </div>
+
+                <h3 className="text-lg font-bold text-slate-900 mb-1">{customerName(job)}</h3>
+                {job.work_order_number ? (
+                  <p className="text-xs text-slate-500 mb-2">WO {job.work_order_number}</p>
+                ) : null}
+
+                <div className="space-y-2 text-sm text-slate-600 mb-4">
+                  <div className="flex items-start">
+                    <MapPin className="h-4 w-4 mr-2 mt-0.5 text-slate-400 shrink-0" />
+                    <span>
+                      {job.service_address ||
+                        job.leads?.property_formatted_address ||
+                        job.leads?.address ||
+                        'No address on file'}
+                    </span>
+                  </div>
+                  {job.leads?.phone ? (
+                    <div className="flex items-center">
+                      <Phone className="h-4 w-4 mr-2 text-slate-400" />
+                      <a href={`tel:${job.leads.phone}`} className="underline decoration-slate-300">
+                        {job.leads.phone}
+                      </a>
+                    </div>
+                  ) : null}
+                </div>
+
+                <Button asChild className="w-full min-h-11 bg-blue-600 hover:bg-blue-700">
+                  <Link to={tenantPath(`/tech/jobs/${job.id}`, tenantId)}>
+                    View Details <ArrowRight className="ml-2 h-4 w-4" />
+                  </Link>
+                </Button>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default TechSchedule;

--- a/command-center/tests/smoke/r3-scheduling-operations.spec.js
+++ b/command-center/tests/smoke/r3-scheduling-operations.spec.js
@@ -1,0 +1,63 @@
+/* eslint-disable testing-library/prefer-screen-queries, jest/valid-title */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test, expect } from '@playwright/test';
+import {
+  JOB_SCHEDULE_LINKED_MESSAGE,
+  isJobScheduleLockedByAppointment,
+  omitLockedScheduleFields,
+} from '../../src/lib/jobAppointmentSchedule.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(here, '../..');
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+test('tech schedule is mounted and reachable from tech nav', async () => {
+  const routes = read('src/pages/tech/TechRoutes.jsx');
+  const layout = read('src/components/tech/TechLayout.jsx');
+  const schedule = read('src/pages/tech/TechSchedule.jsx');
+
+  expect(routes).toContain("path=\"schedule\"");
+  expect(routes).toContain('TechSchedule');
+  expect(layout).toContain('/tech/schedule');
+  expect(layout).toMatch(/label:\s*'Schedule'/);
+  expect(schedule).toContain('eq(\'tenant_id\'');
+  expect(schedule).toContain('resolveLoggedInTechnicianRosterId');
+  expect(schedule).toContain('/tech/jobs/');
+  expect(schedule).toMatch(/Read-only|read-only/i);
+  expect(schedule).toContain('selectedDate');
+});
+
+test('CRM job and dispatch schedule edits lock when appointment is linked', async () => {
+  const jobs = read('src/pages/crm/Jobs.jsx');
+  const dispatch = read('src/pages/crm/Schedule.jsx');
+  const helper = read('src/lib/jobAppointmentSchedule.js');
+
+  expect(helper).toContain('fetchLinkedAppointmentForJob');
+  expect(helper).toContain('omitLockedScheduleFields');
+  expect(JOB_SCHEDULE_LINKED_MESSAGE).toMatch(/Calendar/);
+
+  expect(jobs).toContain('fetchLinkedAppointmentForJob');
+  expect(jobs).toContain('JOB_SCHEDULE_LINKED_MESSAGE');
+  expect(jobs).toContain('recordScheduleLocked');
+  expect(jobs).toContain('scheduleLocked');
+  expect(jobs).toContain('omitLockedScheduleFields');
+
+  expect(dispatch).toContain('fetchLinkedAppointmentForJob');
+  expect(dispatch).toContain('scheduleLocked');
+  expect(dispatch).toContain('omitLockedScheduleFields');
+  expect(dispatch).toContain('JOB_SCHEDULE_LINKED_MESSAGE');
+
+  expect(isJobScheduleLockedByAppointment({ id: 'a1' })).toBe(true);
+  expect(omitLockedScheduleFields({ scheduled_start: 'x', status: 'scheduled' })).not.toHaveProperty(
+    'scheduled_start',
+  );
+});
+
+test('R3 does not rewrite work order board service', async () => {
+  // Guardrail: board service should not appear in this release's ownership changes.
+  // We only assert Jobs/Schedule/Tech files reference the helper, not a board rewrite.
+  const board = read('src/services/workOrderBoardService.js');
+  expect(board).not.toContain('jobAppointmentSchedule');
+});

--- a/command-center/tests/unit/r3-job-appointment-schedule.test.mjs
+++ b/command-center/tests/unit/r3-job-appointment-schedule.test.mjs
@@ -1,0 +1,49 @@
+/**
+ * R3 job↔appointment schedule contract tests.
+ * Run: node --test tests/unit/r3-job-appointment-schedule.test.mjs
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  JOB_SCHEDULE_LINKED_MESSAGE,
+  isJobScheduleLockedByAppointment,
+  omitLockedScheduleFields,
+  scheduleTimesMatch,
+} from '../../src/lib/jobAppointmentSchedule.js';
+
+describe('R3 job appointment schedule helpers', () => {
+  it('locks schedule when an appointment id is present', () => {
+    assert.equal(isJobScheduleLockedByAppointment(null), false);
+    assert.equal(isJobScheduleLockedByAppointment({}), false);
+    assert.equal(isJobScheduleLockedByAppointment({ id: 'appt-1' }), true);
+    assert.match(JOB_SCHEDULE_LINKED_MESSAGE, /Calendar/i);
+  });
+
+  it('omits schedule-driving fields from job payloads', () => {
+    const next = omitLockedScheduleFields({
+      scheduled_start: '2026-07-16T14:00:00.000Z',
+      scheduled_end: '2026-07-16T16:00:00.000Z',
+      technician_id: 'tech-1',
+      service_address: '1 Main',
+      status: 'scheduled',
+      payment_terms: 'NET_7',
+    });
+    assert.equal(next.scheduled_start, undefined);
+    assert.equal(next.scheduled_end, undefined);
+    assert.equal(next.technician_id, undefined);
+    assert.equal(next.service_address, undefined);
+    assert.equal(next.status, 'scheduled');
+    assert.equal(next.payment_terms, 'NET_7');
+  });
+
+  it('matches linked appointment and job times within tolerance', () => {
+    assert.equal(
+      scheduleTimesMatch('2026-07-16T14:00:00.000Z', '2026-07-16T14:00:30.000Z'),
+      true,
+    );
+    assert.equal(
+      scheduleTimesMatch('2026-07-16T14:00:00.000Z', '2026-07-16T15:00:00.000Z'),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Mount read-only `/tech/schedule` with multi-day navigation and bottom-nav entry (B-005)
- When `appointments.job_id` links a work order, Jobs + Dispatch schedule fields become read-only with a Calendar CTA (B-016)
- Shared `jobAppointmentSchedule` helper + focused unit/smoke tests
- No migration; work order board service not rewritten

## Test plan
- [x] `npm run test:scheduling-helpers`
- [x] Playwright `r3-scheduling-operations` + R1B identity smoke
- [x] lint / build:local / review:gate
- [ ] After merge/deploy: tech login → Schedule day scroller; optional linked-job lock check

## Notes
- App still rarely sets `appointments.job_id`; lock applies when the link exists (Packet 008)
- Calendar remains the edit surface for linked schedules

Made with [Cursor](https://cursor.com)