### PR TITLE
fix(auth): stop OAuth callback bounce to select-tenant

### DIFF
--- a/command-center/src/App.jsx
+++ b/command-center/src/App.jsx
@@ -7,6 +7,12 @@ import SelectTenant from '@/pages/SelectTenant';
 import { Loader2 } from 'lucide-react';
 import TenantGuard from '@/components/TenantGuard';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
+import {
+  OAUTH_CALLBACK_MAX_WAIT_MS,
+  readOAuthErrorFromUrl,
+  resolveOAuthCallbackNavigation,
+  urlHasOAuthCallbackParams,
+} from '@/lib/oauthCallbackGate';
 
 import Login from '@/pages/Login';
 import Contact from '@/pages/Contact';
@@ -125,17 +131,19 @@ const RootGate = () => {
   const navigate = useNavigate();
   const { session, loading } = useSupabaseAuth();
   const [showTimeoutUI, setShowTimeoutUI] = useState(false);
+  const [oauthWaitStartedAt, setOauthWaitStartedAt] = useState(null);
+  const [oauthWaitTick, setOauthWaitTick] = useState(0);
+  const [oauthFailMessage, setOauthFailMessage] = useState(null);
 
-  const hasOAuthParams = useMemo(() => {
-    const params = new URLSearchParams(location.search);
-    return (
-      params.has('code') ||
-      params.has('access_token') ||
-      params.has('refresh_token') ||
-      params.has('error') ||
-      params.has('error_description')
-    );
-  }, [location.search]);
+  const hasOAuthParams = useMemo(
+    () => urlHasOAuthCallbackParams(location.search, location.hash),
+    [location.search, location.hash]
+  );
+
+  const { oauthError, oauthErrorDescription } = useMemo(
+    () => readOAuthErrorFromUrl(location.search, location.hash),
+    [location.search, location.hash]
+  );
 
   useEffect(() => {
     if (!loading) {
@@ -149,6 +157,21 @@ const RootGate = () => {
 
     return () => clearTimeout(timer);
   }, [loading]);
+
+  // Keep waiting while PKCE exchange can still complete — do not drop ?code=.
+  useEffect(() => {
+    if (!hasOAuthParams || session || oauthError) {
+      setOauthWaitStartedAt(null);
+      return undefined;
+    }
+    if (oauthWaitStartedAt == null) {
+      setOauthWaitStartedAt(Date.now());
+    }
+    const timer = setInterval(() => {
+      setOauthWaitTick((tick) => tick + 1);
+    }, 500);
+    return () => clearInterval(timer);
+  }, [hasOAuthParams, session, oauthError, oauthWaitStartedAt]);
 
   useEffect(() => {
     if (loading) return;
@@ -169,27 +192,51 @@ const RootGate = () => {
       }
     };
 
-    if (hasOAuthParams) {
-      // OAuth redirect landed here (origin-only). Wait for Supabase to hydrate a session,
-      // then forward to the intended post-login route.
-      if (session) {
-        const redirect = safeGetRedirect();
-        safeClearRedirect();
-        navigate(redirect || `/${getTenantFromStorage()}/crm`, { replace: true });
-      } else {
-        // Auth failed or was cancelled; return to tenant selection.
-        navigate('/select-tenant', { replace: true });
-      }
+    const waitedMs =
+      hasOAuthParams && oauthWaitStartedAt != null
+        ? Date.now() - oauthWaitStartedAt
+        : 0;
+
+    const decision = resolveOAuthCallbackNavigation({
+      hasOAuthParams,
+      session,
+      oauthError,
+      oauthErrorDescription,
+      waitedMs,
+      maxWaitMs: OAUTH_CALLBACK_MAX_WAIT_MS,
+      postLoginRedirect: safeGetRedirect(),
+      tenantFallback: getTenantFromStorage(),
+    });
+
+    if (decision.action === 'wait') {
+      setOauthFailMessage(null);
       return;
     }
 
-    // Normal root visits: if we have a session, go to the last tenant CRM; otherwise select-tenant.
-    if (session) {
-      navigate(`/${getTenantFromStorage()}/crm`, { replace: true });
-    } else {
-      navigate('/select-tenant', { replace: true });
+    if (decision.action === 'fail') {
+      // Stay on this screen so we do not silently dump the user on select-tenant.
+      // Offer an explicit path back to login (email/password still works on phone).
+      setOauthFailMessage(decision.message || 'Sign-in did not complete.');
+      return;
     }
-  }, [hasOAuthParams, loading, navigate, session]);
+
+    if (decision.action === 'navigate' && decision.to) {
+      if (decision.clearPostLoginRedirect) {
+        safeClearRedirect();
+      }
+      setOauthFailMessage(null);
+      navigate(decision.to, { replace: decision.replace !== false });
+    }
+  }, [
+    hasOAuthParams,
+    loading,
+    navigate,
+    session,
+    oauthError,
+    oauthErrorDescription,
+    oauthWaitStartedAt,
+    oauthWaitTick,
+  ]);
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-slate-50">
@@ -197,7 +244,19 @@ const RootGate = () => {
       <p className="text-slate-500 text-sm">
         {hasOAuthParams ? 'Completing sign-in…' : 'Loading…'}
       </p>
-      {showTimeoutUI && (
+      {oauthFailMessage && (
+        <div className="mt-4 flex max-w-sm flex-col items-center gap-2 px-4 text-center">
+          <p className="text-xs text-red-600">{oauthFailMessage}</p>
+          <button
+            type="button"
+            className="text-xs font-medium text-blue-700 underline underline-offset-2"
+            onClick={() => navigate(`/${getTenantFromStorage()}/login`, { replace: true })}
+          >
+            Back to Login
+          </button>
+        </div>
+      )}
+      {showTimeoutUI && !oauthFailMessage && (
         <div className="mt-4 flex flex-col items-center gap-2 px-4 text-center">
           <p className="text-xs text-slate-500">Still loading your session.</p>
           <div className="flex items-center gap-3">

--- a/command-center/src/lib/oauthCallbackGate.js
+++ b/command-center/src/lib/oauthCallbackGate.js
@@ -1,0 +1,99 @@
+/**
+ * RootGate OAuth return routing.
+ *
+ * Do not navigate away while an OAuth `code` (or token) is still present and
+ * the session is not ready yet. Leaving `/?code=...` for `/select-tenant`
+ * drops the PKCE callback query and can abort a slow exchange — observed on
+ * iOS Safari as a failed "Continue with Google" that lands on select-tenant.
+ */
+
+export const OAUTH_CALLBACK_MAX_WAIT_MS = 12000;
+
+/**
+ * @param {object} input
+ * @param {boolean} input.hasOAuthParams
+ * @param {object|null|undefined} input.session
+ * @param {string|null|undefined} input.oauthError
+ * @param {string|null|undefined} input.oauthErrorDescription
+ * @param {number} input.waitedMs
+ * @param {number} [input.maxWaitMs]
+ * @param {string|null|undefined} input.postLoginRedirect
+ * @param {string} [input.tenantFallback]
+ * @returns {{ action: 'wait'|'navigate'|'fail', to?: string, replace?: boolean, clearPostLoginRedirect?: boolean, message?: string }}
+ */
+export function resolveOAuthCallbackNavigation({
+  hasOAuthParams,
+  session,
+  oauthError = null,
+  oauthErrorDescription = null,
+  waitedMs = 0,
+  maxWaitMs = OAUTH_CALLBACK_MAX_WAIT_MS,
+  postLoginRedirect = null,
+  tenantFallback = 'tvg',
+}) {
+  const tenant = String(tenantFallback || 'tvg').toLowerCase();
+
+  if (!hasOAuthParams) {
+    if (session) {
+      return { action: 'navigate', to: `/${tenant}/crm`, replace: true };
+    }
+    return { action: 'navigate', to: '/select-tenant', replace: true };
+  }
+
+  if (session) {
+    return {
+      action: 'navigate',
+      to: postLoginRedirect || `/${tenant}/crm`,
+      replace: true,
+      clearPostLoginRedirect: true,
+    };
+  }
+
+  if (oauthError) {
+    return {
+      action: 'fail',
+      message:
+        oauthErrorDescription ||
+        oauthError ||
+        'Sign-in was cancelled or failed.',
+      to: `/${tenant}/login`,
+      replace: true,
+    };
+  }
+
+  if (waitedMs < maxWaitMs) {
+    return { action: 'wait' };
+  }
+
+  return {
+    action: 'fail',
+    message: 'Sign-in did not complete. Please try again with Continue with Google, or use email and password.',
+    to: `/${tenant}/login`,
+    replace: true,
+  };
+}
+
+/**
+ * True when the current URL still carries an OAuth callback payload.
+ * Checks query string and hash (implicit/token style).
+ */
+export function urlHasOAuthCallbackParams(search = '', hash = '') {
+  const query = new URLSearchParams(typeof search === 'string' ? search : '');
+  const hashQuery = new URLSearchParams(
+    typeof hash === 'string' ? hash.replace(/^#/, '') : ''
+  );
+
+  const keys = ['code', 'access_token', 'refresh_token', 'error', 'error_description'];
+  return keys.some((key) => query.has(key) || hashQuery.has(key));
+}
+
+export function readOAuthErrorFromUrl(search = '', hash = '') {
+  const query = new URLSearchParams(typeof search === 'string' ? search : '');
+  const hashQuery = new URLSearchParams(
+    typeof hash === 'string' ? hash.replace(/^#/, '') : ''
+  );
+  const oauthError = query.get('error') || hashQuery.get('error');
+  const oauthErrorDescription =
+    query.get('error_description') || hashQuery.get('error_description');
+  return { oauthError, oauthErrorDescription };
+}

--- a/command-center/tests/unit/oauth-callback-gate.test.mjs
+++ b/command-center/tests/unit/oauth-callback-gate.test.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  OAUTH_CALLBACK_MAX_WAIT_MS,
+  readOAuthErrorFromUrl,
+  resolveOAuthCallbackNavigation,
+  urlHasOAuthCallbackParams,
+} from '../../src/lib/oauthCallbackGate.js';
+
+test('urlHasOAuthCallbackParams detects query code and hash tokens', () => {
+  assert.equal(urlHasOAuthCallbackParams('?code=abc', ''), true);
+  assert.equal(urlHasOAuthCallbackParams('', '#access_token=xyz'), true);
+  assert.equal(urlHasOAuthCallbackParams('?foo=1', '#bar=2'), false);
+});
+
+test('readOAuthErrorFromUrl reads error from query', () => {
+  const { oauthError, oauthErrorDescription } = readOAuthErrorFromUrl(
+    '?error=access_denied&error_description=User%20cancelled',
+    ''
+  );
+  assert.equal(oauthError, 'access_denied');
+  assert.equal(oauthErrorDescription, 'User cancelled');
+});
+
+test('OAuth success navigates to post-login redirect and clears flag', () => {
+  const decision = resolveOAuthCallbackNavigation({
+    hasOAuthParams: true,
+    session: { access_token: 't' },
+    postLoginRedirect: '/tvg/crm',
+    waitedMs: 0,
+  });
+  assert.equal(decision.action, 'navigate');
+  assert.equal(decision.to, '/tvg/crm');
+  assert.equal(decision.clearPostLoginRedirect, true);
+});
+
+test('OAuth code with no session yet must WAIT (do not bounce to select-tenant)', () => {
+  const decision = resolveOAuthCallbackNavigation({
+    hasOAuthParams: true,
+    session: null,
+    waitedMs: 1000,
+    maxWaitMs: OAUTH_CALLBACK_MAX_WAIT_MS,
+  });
+  assert.equal(decision.action, 'wait');
+  assert.notEqual(decision.to, '/select-tenant');
+});
+
+test('regression: prior bug immediately sent null session + OAuth params to select-tenant', () => {
+  // The old RootGate did: if (hasOAuthParams && !session) navigate('/select-tenant')
+  // which drops ?code= and aborts Safari PKCE. New gate must wait instead.
+  const early = resolveOAuthCallbackNavigation({
+    hasOAuthParams: true,
+    session: null,
+    waitedMs: 0,
+  });
+  assert.equal(early.action, 'wait');
+});
+
+test('OAuth provider error fails with message (not silent select-tenant)', () => {
+  const decision = resolveOAuthCallbackNavigation({
+    hasOAuthParams: true,
+    session: null,
+    oauthError: 'access_denied',
+    oauthErrorDescription: 'User cancelled',
+    waitedMs: 0,
+  });
+  assert.equal(decision.action, 'fail');
+  assert.match(decision.message, /cancelled|access_denied|User cancelled/i);
+  assert.notEqual(decision.to, '/select-tenant');
+});
+
+test('OAuth wait timeout fails to login path, not select-tenant', () => {
+  const decision = resolveOAuthCallbackNavigation({
+    hasOAuthParams: true,
+    session: null,
+    waitedMs: OAUTH_CALLBACK_MAX_WAIT_MS + 1,
+  });
+  assert.equal(decision.action, 'fail');
+  assert.equal(decision.to, '/tvg/login');
+  assert.notEqual(decision.to, '/select-tenant');
+});
+
+test('non-OAuth root without session still goes to select-tenant', () => {
+  const decision = resolveOAuthCallbackNavigation({
+    hasOAuthParams: false,
+    session: null,
+  });
+  assert.equal(decision.action, 'navigate');
+  assert.equal(decision.to, '/select-tenant');
+});


### PR DESCRIPTION
## Summary
- iOS Safari Google OAuth was landing on `/select-tenant` because RootGate navigated away while `?code=` was still exchanging (PKCE).
- Wait for session hydration (or show a clear failure + Back to Login) instead of immediately bouncing.
- Add unit coverage for the callback routing gate.

## Test plan
- [x] `node --test tests/unit/oauth-callback-gate.test.mjs` (8/8)
- [ ] CI lint/build
- [ ] After deploy: Safari Private → Continue with Google → should land on `/tvg/crm`, not `/select-tenant`
- [ ] Edge/Chrome Google login still works
- [ ] Phone email/password login still works
