### PR TITLE
docs(governance): add V1 agent operating model

### DIFF
--- a/command-center/.cursor/rules/v1-operating-model.mdc
+++ b/command-center/.cursor/rules/v1-operating-model.mdc
@@ -1,0 +1,49 @@
+---
+description: V1 agent operating model — control chain, separation of duties, evidence tiers
+alwaysApply: true
+---
+
+# V1 Operating Model (read before starting any release)
+
+This is the spine. The full definitions live in (do not duplicate them):
+- Roles + authority: `docs/governance/AI_ROLES.md`
+- Where humans must approve: `docs/governance/APPROVAL_THRESHOLDS.md`
+- Orchestration / worktree / merge / deploy rules: `docs/stabilization/V1_CURSOR_ORCHESTRATOR.md`
+- One owner per business state: `docs/stabilization/V1_MODULE_OWNERSHIP.md`
+- Machine gate: `review-policy.json` + `tools/review-gate.mjs` (`npm run review:gate`)
+
+## Control chain (no single agent owns the whole chain)
+Owner picks priority → Orchestrator writes a Release Brief → Implementation builds
+→ Architecture/Contract Guard reviews contracts → CI → Independent UAT verifies
+behavior with owner checkpoints → **Owner accepts** → Release merges & deploys
+→ Independent UAT verifies production → release closes.
+
+## Separation of duties (the control that was missing)
+- One operational problem per release; one implementation agent per overlapping fileset.
+- The chat/agent that **implements** a change must NOT be the one that **certifies**
+  it usable, **merges** it, or **deploys** it.
+- Start a **fresh chat** for each role. Do not switch hats inside one implementation
+  chat to approve, merge, deploy, or certify your own work.
+- Merge, deploy, and any consequential action are **human-approved only**
+  (you, the owner = Human Decider — see `docs/governance/APPROVAL_THRESHOLDS.md`).
+
+## Evidence tiers (never conflate)
+Label every claim as one of: **SOURCE-ONLY** (in code) / **DEPLOYED** (in the live
+bundle) / **REACHABLE** (route loads) / **USABLE** (the action was completed in the
+real role + browser/device with a visible result). Only **USABLE**, confirmed by the
+owner or independently observed, may be called **PASS**.
+Forbidden without evidence: "healthy", "fully verified", "should work", "deployed successfully".
+
+## Per-release non-negotiables
+1. One operational problem per PR; no unrelated cleanup; no V2 work in V1.
+2. Inspect before editing; reuse existing services/helpers before adding new ones.
+3. Branch from verified `origin/main`; never use the dirty worktree `F:\Dev\BHFOS`.
+4. No migration without explicit written owner approval.
+5. No production access during implementation; no deploy from a dev worktree.
+6. Every behavior change gets a focused test or a documented reason it cannot.
+7. Trigger domains (tenant_isolation, money_state, acceptance_commit, state_machine,
+   completion_gate) require the review gate + owner approval before release.
+
+## Scope stop
+If the root cause or required architecture differs materially from the approved
+Release Brief, stop and return to the Orchestrator/owner. Do not expand scope silently.

--- a/command-center/docs/stabilization/AGENT_ROLE_PROMPTS.md
+++ b/command-center/docs/stabilization/AGENT_ROLE_PROMPTS.md
@@ -1,0 +1,76 @@
+# Agent Role Prompts (Cursor)
+
+How to run the V1 operating model in Cursor. These are **roles you invoke by
+starting a fresh chat and pasting the matching prompt** — not always-on bots.
+Cursor "agents" are chats/subagents; separation of duties = separate chats.
+
+Canonical definitions: `docs/governance/AI_ROLES.md`,
+`docs/stabilization/V1_CURSOR_ORCHESTRATOR.md`, `.cursor/rules/v1-operating-model.mdc`.
+
+**Golden rule:** the chat that implements does not certify, merge, or deploy its
+own work. Use a different chat for UAT and for Release.
+
+---
+
+## Orchestrator (you + a planning chat)
+```
+Act as V1 Orchestrator. Read .cursor/rules/v1-operating-model.mdc,
+docs/stabilization/V1_CURSOR_ORCHESTRATOR.md, V1_STABILIZATION_BACKLOG.md,
+and V1_MODULE_OWNERSHIP.md.
+Propose ONE operational problem for the next release and produce a Release Brief
+from docs/stabilization/RELEASE_BRIEF_TEMPLATE.md.
+Do not implement. Do not expand scope. Stop for my approval of the brief.
+```
+
+## Implementation (fresh chat, clean worktree)
+```
+Act as Implementation agent for the APPROVED Release Brief: <paste/point to R<N>_BRIEF.md>.
+Follow .cursor/rules/v1-operating-model.mdc.
+Branch from verified origin/main in a clean worktree. Inspect before editing.
+Edit only the files named in the brief. Reuse existing services/helpers.
+Add focused tests. Open a scope-limited PR.
+Do NOT merge, deploy, run migrations without written approval, or certify usability.
+If root cause differs from the brief, STOP and report.
+```
+
+## Architecture / Contract Guard (fresh chat, review-only)
+```
+Act as Architecture/Contract Guard. Review this PR (read-only) against
+docs/governance/ENTITY_OWNERSHIP_AND_MUTATION_RULES.md, V1_MODULE_OWNERSHIP.md,
+technician identity + property/lead ownership contracts, and any migration.
+Flag duplicate business authority, ownership regressions, and trigger-domain risk.
+Recommend only; do not edit product code or approve release.
+```
+
+## Independent UAT (fresh chat, no code edits)
+```
+Act as Independent UAT coordinator/recorder. Read .cursor/rules/v1-operating-model.mdc.
+Verify the Release Brief acceptance criteria at USABLE tier only:
+exact role + route + browser/device + visible result + owner confirmation + screenshot.
+Coordinate owner checkpoints and pause for real results. Review console/network.
+Use verdicts PASS/FAIL/PARTIAL/BLOCKED/UNVERIFIED/NOT APPLICABLE.
+Record results with docs/UAT_PASS_FAIL_TEMPLATE.md. Do NOT edit application code.
+Reject any PASS not backed by owner-observed evidence.
+```
+
+## Release (fresh chat, human-approved)
+```
+Act as Release agent. Only after owner acceptance:
+verify PR scope + green required checks, confirm exact merge SHA,
+build from a clean worktree at that SHA, deploy only the approved project,
+verify served asset hashes, record migrations/edge-function versions,
+run synthetic production smoke (no customer contact, no live charges).
+Stop if the deployed artifact cannot be tied to source. Do not judge UX.
+```
+
+---
+
+## Minimum viable path (solo founder, low overhead)
+You do not need five long chats for a one-line fix. Minimum that preserves the control:
+1. Orchestrator: a 1-paragraph brief (problem + acceptance + out-of-scope).
+2. Implementation: fresh chat, build + PR.
+3. UAT: **a different chat** confirms USABLE with your screenshot.
+4. You accept; Release merges/deploys.
+
+The one rule you never skip even when rushing: **the builder does not approve or
+deploy its own change.**

--- a/command-center/docs/stabilization/RELEASE_BRIEF_TEMPLATE.md
+++ b/command-center/docs/stabilization/RELEASE_BRIEF_TEMPLATE.md
@@ -1,0 +1,65 @@
+# Release Brief — R&lt;N&gt; &lt;short theme&gt;
+
+> Orchestrator output. One operational problem. Owner approves this brief before
+> any implementation starts. Copy this file to
+> `docs/stabilization/releases/R<N>_BRIEF.md` and fill it in.
+
+## 1. Objective (one problem)
+State the single operational problem in one or two sentences. No bundled work.
+
+## 2. Why now / owner priority
+Who is blocked, and what breaks without it. (Owner-observed > inferred.)
+
+## 3. In scope
+- Exact behavior to change:
+- Surfaces affected (role + route + viewport): e.g. Office `/tvg/crm/inspections/new`, desktop
+
+## 4. Out of scope (explicit)
+List related things deliberately NOT touched this release (prevents scope creep).
+
+## 5. Owning module + files
+- Business owner (from `V1_MODULE_OWNERSHIP.md`):
+- Files the Implementation agent may edit:
+- Shared helpers touched (must serialize / extra review):
+
+## 6. Expected visible behavior + acceptance evidence (owner-verifiable)
+Written as USABLE-tier checks: exact role + exact route + exact browser/device +
+expected visible result. Name the evidence to capture (screenshot / console / network).
+- [ ] In &lt;role&gt; on &lt;route&gt; in &lt;browser/device&gt;, &lt;action&gt; produces &lt;visible result&gt; — evidence: &lt;screenshot ref&gt;
+- [ ] No regression to &lt;named working flow&gt;
+
+## 6a. Owner checkpoint
+State the exact point where the owner must personally verify and confirm before the
+release can advance (e.g. "owner confirms last customer selectable in Chrome").
+
+## 6b. Risks
+- What could break (blast radius):
+- Trigger-domain exposure:
+- Shared-helper / cross-surface risk:
+
+## 7. Trigger-domain check
+Does this touch tenant_isolation / money_state / acceptance_commit / state_machine /
+completion_gate? **Yes/No.** If yes: review gate + owner approval required; name the domain tag(s).
+
+## 8. Migration?
+**No** by default. If yes: justify, and note it needs explicit written owner approval.
+
+## 9. Test plan
+- Focused test(s) to add/update:
+- If a behavior change cannot be tested, document why here.
+
+## 10. Rollback / stop conditions
+- How to revert safely (revert PR / previous asset / no data change):
+- Stop conditions (halt and return to Orchestrator/owner): root cause differs from
+  this brief, scope would grow, a migration becomes necessary, or a trigger domain
+  is touched unexpectedly.
+
+## 11. Definition of done
+- [ ] Implementation PR opened (scope-limited, tests included)
+- [ ] Architecture/Contract Guard review passed
+- [ ] CI green (`lint`, `build`, `review:gate`, `ledger_lock`)
+- [ ] Independent UAT: owner-confirmed USABLE evidence captured
+- [ ] Owner accepted material workflow
+- [ ] Release merged + deployed by Release role (human-approved)
+- [ ] Production re-verified by Independent UAT
+- [ ] Backlog/baseline/scorecard updated


### PR DESCRIPTION
## Summary

Adds a lightweight V1 agent operating model that reuses the existing governance
canon and closes the main acceptance gap found during stabilization.

## Included

- always-on Cursor operating rule
- per-release brief template
- copy-paste role prompts for separate Cursor chats
- evidence tiers separating source, deployment, reachability, and actual usability
- minimum viable path for solo-founder operation

## Not included

- application code
- migrations
- CI changes
- deployment changes
- branch-protection changes
- new governance authority

## Existing authority reused

- AI_ROLES.md
- APPROVAL_THRESHOLDS.md
- V1_CURSOR_ORCHESTRATOR.md
- UAT_PASS_FAIL_TEMPLATE.md (command-center/docs/UAT_PASS_FAIL_TEMPLATE.md)
- review:gate
- ledger_lock

## Follow-up

GitHub branch protection is still required to technically prevent builder
self-merge. That will be handled separately.

Do not merge automatically.