### PR TITLE
fix(ui): restore long customer selector scrolling

### DIFF
--- a/command-center/docs/stabilization/releases/R4A_BRIEF.md
+++ b/command-center/docs/stabilization/releases/R4A_BRIEF.md
@@ -1,0 +1,180 @@
+# Release Brief — R4A Office Inspection Customer Selector Usability
+
+> Orchestrator output. One operational problem. Owner approves this brief before
+> any implementation starts.
+>
+> - Prepared from `origin/main` @ `f25ca094d70f4156402227241c1c2c7ab74e6908`
+>   (governance merge SHA, PR #47).
+> - Worktree: `F:\Dev\BHFOS-r4a-inspection-selector` on branch
+>   `stabilize/r4a-office-inspection-customer-selector` (branched from verified `origin/main`).
+> - Status: **DRAFT — awaiting owner approval. No implementation started.**
+
+## 1. Objective (one problem)
+On `/tvg/crm/inspections/new`, the **Customer (Lead)** dropdown opens but the owner
+cannot reliably scroll a long customer list or reach/select customers below the
+visible area. Make that dropdown fully scrollable and every option reachable and
+selectable. Nothing else.
+
+## 2. Why now / owner priority
+Owner-observed: an office/admin user starting a new inspection cannot pick a
+customer who sits lower in the list, so inspections can't be created for those
+customers from this screen. This blocks the first step of the inspection workflow.
+Priority is owner-reported, not inferred.
+
+## 3. In scope
+- **Exact behavior to change:** the Customer (Lead) selection dropdown on the new-inspection
+  screen must present a bounded, scrollable list where the last option is reachable
+  and selectable, and selecting it updates the inspection draft.
+- **Surfaces affected (role + route + viewport):** Office/admin, `/tvg/crm/inspections/new`,
+  desktop and mobile viewports: 1920x1080, 1366x768, 430x932, 390x844.
+- **Isolated vs shared — investigation verdict: SHARED.** The defect is **not** isolated to the
+  Customer (Lead) selector. It originates in the shared shadcn primitive
+  `src/components/ui/select.jsx`. Evidence:
+  - The Customer (Lead) instance (`InspectionEditor.jsx` lines ~1080–1092) is a plain
+    `<Select>/<SelectContent>/<SelectItem>` consumer with **no dropdown-height, overflow, or
+    scroll logic of its own** — nothing local could cause or fix the clipping.
+  - In `src/components/ui/select.jsx`, `SelectContent` uses `overflow-hidden` with **no bounded
+    max-height and no scroll buttons** (`SelectScrollUpButton` / `SelectScrollDownButton` are not
+    implemented), and the popper `Viewport` is pinned to `h-[var(--radix-select-trigger-height)]`.
+    That combination clips long lists and blocks wheel/scrollbar/keyboard traversal.
+  - The same primitive is imported by **~60 files** app-wide, so any list-based `<Select>` long
+    enough to overflow shares this defect — it merely surfaces first on this screen because the
+    lead list is long. The fix therefore belongs in the shared primitive (see Path A), constrained
+    to the minimum change required (see §4).
+- **Required visible outcome (owner's words):** bounded dropdown height; mouse-wheel
+  scrolling works; visible scrollbar where appropriate; keyboard Arrow Down, Page Down,
+  Home, End work; the final option can be reached and selected; selection updates the
+  inspection form; no clipping; no page-scroll conflict; works in installed Edge, Chrome,
+  and Firefox; works at 1920x1080, 1366x768, 430x932, and 390x844.
+
+### Implementation approach (Orchestrator recommendation — Implementation agent confirms or stops)
+Because the defect lives in the shared primitive, there are two viable paths. The
+Implementation agent must choose one, state which, and **stop and return to the
+Orchestrator/owner if the chosen path cannot satisfy the acceptance criteria without
+expanding scope:**
+
+- **Path A (recommended — shared primitive fix, upstream-correct):** restore canonical
+  shadcn/Radix scrolling in `src/components/ui/select.jsx` — add a bounded max-height on
+  `SelectContent` (e.g. an available-height/viewport-based cap) and implement
+  `SelectScrollUpButton` / `SelectScrollDownButton`, and/or allow the viewport to scroll.
+  Smallest change that fixes every dropdown correctly. **Blast radius: app-wide (see §6b).**
+- **Path B (scoped to the one instance):** pass a height/overflow `className` only to the
+  Customer (Lead) `SelectContent` in `InspectionEditor.jsx`. Lower blast radius, but may
+  not fully work because the offending viewport height is set inside the shared primitive
+  and is not overridable from the consumer. If Path B cannot meet all acceptance checks,
+  **stop** — do not silently escalate to Path A without owner sign-off on the wider blast radius.
+
+## 4. Out of scope (explicit)
+Owner-specified exclusions, carried verbatim:
+- Do **not** add an "Add Customer" affordance.
+- Do **not** redesign inspections.
+- Do **not** modify lead data.
+- Do **not** change the property model.
+- Do **not** change authentication.
+- Do **not** change scheduling.
+- Do **not** begin money-loop work.
+- Do **not** redesign the shared component library beyond what is required.
+
+Orchestrator additions:
+- Do **not** restyle, re-order, or change the *content/labels* of any dropdown; this is a
+  scroll/height/reachability reliability fix only.
+- Do **not** upgrade or replace `@radix-ui/react-select` or other dependencies.
+- Do **not** "fix" unrelated dropdown behavior noticed along the way — report separately.
+- No V2 work, no unrelated cleanup.
+
+## 5. Owning module + files
+- **Business owner (from `V1_MODULE_OWNERSHIP.md`):** Inspections (CRM editor). Surface
+  owner per `V1_CURSOR_ORCHESTRATOR.md` = **Office UX specialist (Agent 3)**, `src/pages/crm/**`
+  and related components.
+- **Files the Implementation agent may edit (one implementer, serialized):**
+  - `src/components/ui/select.jsx` — **shared helper; primary change site for Path A.**
+  - `src/pages/crm/inspections/InspectionEditor.jsx` — only if Path B (scoped className) is chosen.
+  - Test file(s) under `tests/smoke/**` (new focused test — see §9).
+- **Shared helpers touched (must serialize / extra review):** `src/components/ui/select.jsx`
+  is imported by **~60 files** across CRM, tech PWA, settings, admin, marketing, partners,
+  and booking. While this brief is active, **no other agent may edit `select.jsx`**, and the
+  change requires Architecture/Contract Guard review before merge.
+
+## 6. Expected visible behavior + acceptance evidence (owner-verifiable, USABLE tier)
+Precondition: a tenant/account whose Customer (Lead) list is long enough to overflow the
+viewport (enough leads that the last option sits below the fold on the smallest listed viewport).
+
+- [ ] In **Office/admin** on **`/tvg/crm/inspections/new`** in **installed Edge**, opening the
+      Customer (Lead) dropdown shows a **bounded-height** panel (does not run off-screen) —
+      evidence: screenshot.
+- [ ] **Mouse-wheel** scrolling moves through the list to the bottom — evidence: screenshot of last item visible.
+- [ ] A **visible scrollbar** is present where appropriate for the list length — evidence: screenshot.
+- [ ] **Keyboard** Arrow Down, Page Down, Home, and End all move selection/focus through the
+      list as expected — evidence: screenshot or short recording.
+- [ ] The **final (last) option** can be reached and **selected**, and the inspection form's
+      Customer (Lead) value updates to it (and Create Inspection becomes enabled) — evidence: screenshot.
+- [ ] **No clipping** of options and **no page-scroll conflict** (opening/scrolling the dropdown
+      does not scroll the page behind it) — evidence: screenshot.
+- [ ] All of the above confirmed in **installed Edge, Chrome, and Firefox**.
+- [ ] All of the above confirmed at **1920x1080, 1366x768, 430x932, and 390x844**.
+- [ ] **No regression** to the adjacent dropdowns on the same screen (Inspection Type, Work Order,
+      Technician) — each still opens, scrolls if needed, and selects.
+- [ ] **No regression (Path A only)** to a representative sample of other dropdowns app-wide
+      (see §6b) — each still opens and selects.
+
+## 6a. Owner checkpoint
+The release cannot advance until the **owner personally** opens `/tvg/crm/inspections/new`
+in **installed Edge at 1366x768**, scrolls the Customer (Lead) list to the bottom, selects the
+**last** customer, and confirms the form updated. Owner-confirmed screenshot is required; a
+developer or agent screenshot alone does not satisfy this checkpoint.
+
+## 6b. Risks
+- **What could break (blast radius):** Path A edits a primitive imported by **~60 files**. A
+  height/scroll regression could affect dropdowns across CRM (quotes, invoices, jobs, leads,
+  scheduling UI), tech PWA inspection/review, settings, admin, and public booking/partner forms.
+- **Cross-surface / shared-helper risk:** high for Path A (shared primitive), low for Path B
+  (single instance) — but Path B carries a higher risk of *not fully fixing* the problem.
+- **Trigger-domain exposure:** none. This is presentation/interaction only; it does not read or
+  write business state.
+- **Mobile-specific risk:** touch scrolling and on-screen keyboard behavior at 430x932 / 390x844
+  must be checked, not assumed from desktop.
+
+## 7. Trigger-domain check
+Touches tenant_isolation / money_state / acceptance_commit / state_machine / completion_gate?
+**No.** The change is limited to dropdown presentation and scrolling; no business-state read or
+write is modified. Review gate still runs in CI as a standard check, but no trigger-domain tag applies.
+
+## 8. Migration?
+**No.** No schema or data change is required or permitted by this brief.
+
+## 9. Test plan
+- **Focused test to add:** a smoke/behavioral test under `tests/smoke/**` covering the new-inspection
+  Customer (Lead) selector: open the dropdown, assert the list container is height-bounded, assert the
+  last option is reachable and selectable, and assert the draft `lead_id` / form state updates on selection.
+- **Feasibility note:** Radix Select renders in a portal and its scroll behavior is layout/viewport-dependent,
+  which is hard to assert reliably in jsdom. If the automated test cannot meaningfully verify *scrollability*
+  (as opposed to selection), document that limitation in the PR and rely on the manual USABLE matrix in §6
+  for scroll/wheel/scrollbar/keyboard coverage. Automated coverage must at minimum verify that the last
+  option is selectable and updates form state.
+- Run `lint`, `build`, and `review:gate` locally; do not run the full suite during implementation.
+
+## 10. Rollback / stop conditions
+- **Rollback:** revert the PR (single-commit / squash). No data change, so revert is clean and complete.
+- **Stop and return to Orchestrator/owner if:**
+  - Path B is attempted and cannot meet all §6 acceptance checks without editing the shared primitive
+    (escalating to Path A changes the blast radius and needs owner sign-off).
+  - Path A regresses any other dropdown found during the §6b spot-check.
+  - The root cause turns out to differ from the shared-primitive diagnosis in this brief.
+  - Any migration, trigger domain, or excluded area (§4) appears necessary.
+  - Scope would grow beyond the Customer (Lead) scroll/reachability fix.
+
+## 11. Definition of done
+- [ ] Implementation PR opened (scope-limited to §5 files, focused test included)
+- [ ] Architecture/Contract Guard review passed (shared-primitive change scrutinized)
+- [ ] CI green (`lint`, `build`, `review:gate`, `ledger_lock`)
+- [ ] Independent UAT (different chat): owner-confirmed USABLE evidence captured across the full §6 matrix
+- [ ] Owner accepted the material workflow (§6a checkpoint)
+- [ ] Release merged + deployed by Release role (human-approved)
+- [ ] Production re-verified by Independent UAT
+- [ ] Backlog/baseline/scorecard updated
+
+---
+
+### Orchestrator stop
+Release brief complete. No implementation, merge, deploy, or production certification performed.
+Awaiting owner approval of this brief before any Implementation chat begins.

--- a/command-center/src/components/ui/select.jsx
+++ b/command-center/src/components/ui/select.jsx
@@ -43,8 +43,17 @@ const SelectContent = React.forwardRef(({ className, children, position = "poppe
       <SelectPrimitive.Viewport
         className={cn(
           "p-1",
+          // Bound the list to the space the popper has (falling back to 24rem for
+          // the item-aligned position) so long option sets never run off-screen and
+          // the last option is always reachable. Radix already sets overflow:hidden
+          // auto on the viewport, so this makes it scroll (wheel + keyboard) natively.
+          "max-h-[min(24rem,var(--radix-select-content-available-height,24rem))]",
+          // Radix hides the viewport scrollbar by default (scrollbar-width:none /
+          // ::-webkit-scrollbar{display:none}); re-enable a real, draggable scrollbar
+          // where the browser renders one, using !important to beat Radix's injected rule.
+          "![scrollbar-width:thin] [&::-webkit-scrollbar]:![display:block] [&::-webkit-scrollbar]:!w-2 [&::-webkit-scrollbar-thumb]:!rounded-full [&::-webkit-scrollbar-thumb]:!bg-gray-300",
           position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+            "w-full min-w-[var(--radix-select-trigger-width)]"
         )}
       >
         {children}

--- a/command-center/tests/fixtures/r4a-select-harness.html
+++ b/command-center/tests/fixtures/r4a-select-harness.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>R4A Select Test Harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./r4a-select-harness.jsx"></script>
+  </body>
+</html>

--- a/command-center/tests/fixtures/r4a-select-harness.jsx
+++ b/command-center/tests/fixtures/r4a-select-harness.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom/client';
+import '../../src/index.css';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../../src/components/ui/select.jsx';
+
+const customers = Array.from(
+  { length: 60 },
+  (_, index) => ({
+    id: `mock-customer-${String(index + 1).padStart(3, '0')}`,
+    label: `Mock Customer ${String(index + 1).padStart(3, '0')}`,
+  }),
+);
+
+const shortOptions = [
+  { value: 'dryer_vent', label: 'Dryer Vent' },
+  { value: 'air_duct', label: 'Air Duct' },
+  { value: 'hvac', label: 'HVAC' },
+];
+
+function R4ASelectHarness() {
+  const [customerId, setCustomerId] = useState('');
+  const [inspectionType, setInspectionType] = useState('dryer_vent');
+  const selectedCustomer = customers.find((customer) => customer.id === customerId);
+
+  return (
+    <main className="min-h-[200vh] bg-slate-50 p-6 text-slate-900">
+      <section className="mx-auto max-w-md space-y-6 rounded-lg bg-white p-6 shadow-sm">
+        <div>
+          <h1 className="text-lg font-semibold">R4A Select Test Harness</h1>
+          <p className="text-sm text-slate-600">Deterministic mock data only; no application services are loaded.</p>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="r4a-customer-select">Customer (Lead)</label>
+          <Select value={customerId} onValueChange={setCustomerId}>
+            <SelectTrigger id="r4a-customer-select" aria-label="Customer (Lead)">
+              <SelectValue placeholder="Select mock customer" />
+            </SelectTrigger>
+            <SelectContent>
+              {customers.map((customer) => (
+                <SelectItem key={customer.id} value={customer.id}>
+                  {customer.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <output data-testid="selected-customer">
+            Selected customer: {selectedCustomer?.label || 'None'}
+          </output>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="r4a-inspection-type">Inspection Type</label>
+          <Select value={inspectionType} onValueChange={setInspectionType}>
+            <SelectTrigger id="r4a-inspection-type" aria-label="Inspection Type">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {shortOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <output data-testid="selected-inspection-type">Selected type: {inspectionType}</output>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<R4ASelectHarness />);

--- a/command-center/tests/smoke/r4a-inspection-customer-selector.spec.js
+++ b/command-center/tests/smoke/r4a-inspection-customer-selector.spec.js
@@ -1,0 +1,151 @@
+/* eslint-disable testing-library/prefer-screen-queries, jest/valid-title */
+import { test, expect } from '@playwright/test';
+import { createAdminClient, createRunId, insertWithRetry, buildLeadPayload } from './helpers/supabaseAdmin.js';
+
+// R4A — Office Inspection Customer Selector Usability.
+// Real-browser behavioral coverage for the Customer (Lead) dropdown on
+// /tvg/crm/inspections/new. Verifies the fixed shared Select primitive at the
+// four required viewports: the long list is height-bounded, scrolls (wheel +
+// keyboard), the last option is reachable and selectable, and selection updates
+// the inspection form. Also confirms a short adjacent dropdown still works.
+//
+// Like the other office-inspection E2E specs, this requires a LOCAL Supabase and
+// skips otherwise (portal + real layout can only be exercised against the app).
+
+const TENANT_ID = 'tvg';
+const LEAD_COUNT = 40;
+
+const VIEWPORTS = [
+  { name: 'desktop-1920x1080', width: 1920, height: 1080 },
+  { name: 'laptop-1366x768', width: 1366, height: 768 },
+  { name: 'mobile-430x932', width: 430, height: 932 },
+  { name: 'mobile-390x844', width: 390, height: 844 },
+];
+
+const signIn = async (page, email, password) => {
+  await page.goto('/tvg/login', { waitUntil: 'domcontentloaded' });
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password').fill(password);
+  await page.getByRole('button', { name: /^sign in$/i }).click();
+  await page.waitForURL((url) => url.pathname.startsWith('/tvg/') && !url.pathname.endsWith('/login'));
+};
+
+const openCustomerDropdown = async (page) => {
+  await expect(page.getByRole('heading', { name: 'Create Inspection' })).toBeVisible();
+  await page.getByText('Customer (Lead)', { exact: true }).locator('..').getByRole('combobox').click();
+  await expect(page.getByRole('option').first()).toBeVisible();
+};
+
+const viewportMetrics = async (page) =>
+  page.evaluate(() => {
+    const vp = document.querySelector('[data-radix-select-viewport]');
+    if (!vp) return null;
+    return {
+      clientHeight: vp.clientHeight,
+      scrollHeight: vp.scrollHeight,
+      scrollTop: vp.scrollTop,
+      windowHeight: window.innerHeight,
+    };
+  });
+
+test('long Customer (Lead) list is bounded, scrollable, and the last option is selectable across viewports', async ({ page }) => {
+  test.setTimeout(240_000);
+  let admin;
+  let env;
+  try {
+    ({ client: admin, env } = createAdminClient());
+  } catch (err) {
+    test.skip(true, `Supabase admin env not configured; selector E2E needs local Supabase: ${err.message}`);
+  }
+  if (!/127\.0\.0\.1|localhost/i.test(env.supabaseUrl)) {
+    test.skip(true, `Refusing to run selector regression against non-local Supabase: ${env.supabaseUrl}`);
+  }
+
+  const runId = createRunId();
+  const email = `${runId}@example.com`;
+  const password = `Local-${runId}-A1!`;
+  const leadIds = [];
+  let userId;
+
+  try {
+    const user = await admin.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      app_metadata: { tenant_id: TENANT_ID, role: 'admin' },
+    });
+    if (user.error) throw user.error;
+    userId = user.data.user.id;
+
+    for (let index = 0; index < LEAD_COUNT; index += 1) {
+      const marker = String(index).padStart(3, '0');
+      const lead = await insertWithRetry(admin, 'leads', buildLeadPayload(runId, {
+        first_name: 'SELECTOR',
+        last_name: `R4A ${marker}`,
+        company: `R4A SELECTOR ${runId} ${marker}`,
+        email: `${runId}.${marker}@example.com`,
+      }));
+      if (lead.error) throw lead.error;
+      leadIds.push(lead.data.id);
+    }
+
+    await signIn(page, email, password);
+
+    for (const vp of VIEWPORTS) {
+      await test.step(vp.name, async () => {
+        await page.setViewportSize({ width: vp.width, height: vp.height });
+        await page.goto('/tvg/crm/inspections/new', { waitUntil: 'domcontentloaded' });
+        await openCustomerDropdown(page);
+
+        const options = page.getByRole('option');
+        const optionCount = await options.count();
+        expect(optionCount).toBeGreaterThan(12);
+
+        // 1 + 9: bounded height — the panel never exceeds the viewport height and
+        // is capped (no clipping / off-screen list).
+        const bounded = await viewportMetrics(page);
+        expect(bounded, 'radix select viewport not found').not.toBeNull();
+        expect(bounded.clientHeight).toBeLessThanOrEqual(bounded.windowHeight);
+        expect(bounded.clientHeight).toBeLessThanOrEqual(400);
+
+        // 2: the list actually overflows and is scrollable.
+        expect(bounded.scrollHeight).toBeGreaterThan(bounded.clientHeight);
+
+        // 2 (wheel): mouse-wheel moves the list.
+        const box = await page.locator('[data-radix-select-viewport]').boundingBox();
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.mouse.wheel(0, 600);
+        await expect
+          .poll(async () => (await viewportMetrics(page)).scrollTop)
+          .toBeGreaterThan(0);
+
+        // 4 + 5 + 6: keyboard End reaches the last option; Enter selects it.
+        const lastLabel = await options.last().innerText();
+        await page.keyboard.press('Home');
+        await page.keyboard.press('End');
+        await expect(options.last()).toBeVisible();
+        await page.keyboard.press('Enter');
+
+        // 7: selection updates the inspection form (trigger reflects the choice)
+        // and 8: the dropdown closed without leaving orphaned options.
+        const combobox = page.getByText('Customer (Lead)', { exact: true }).locator('..').getByRole('combobox');
+        await expect(combobox).toContainText(lastLabel.trim());
+        await expect(page.getByRole('option')).toHaveCount(0);
+      });
+    }
+
+    // 10: short adjacent Select (Inspection Type, 5 fixed items) still opens and selects.
+    await test.step('short-list regression (Inspection Type)', async () => {
+      await page.setViewportSize({ width: 1366, height: 768 });
+      await page.goto('/tvg/crm/inspections/new', { waitUntil: 'domcontentloaded' });
+      await expect(page.getByRole('heading', { name: 'Create Inspection' })).toBeVisible();
+      await page.getByText('Inspection Type', { exact: true }).locator('..').getByRole('combobox').click();
+      await expect(page.getByRole('option', { name: 'Air Duct' })).toBeVisible();
+      await page.getByRole('option', { name: 'Air Duct' }).click();
+      await expect(page.getByText('Inspection Type', { exact: true }).locator('..').getByRole('combobox')).toContainText('Air Duct');
+    });
+  } finally {
+    if (leadIds.length) await admin.from('leads').delete().in('id', leadIds);
+    if (userId) await admin.auth.admin.deleteUser(userId);
+  }
+});

--- a/command-center/tests/smoke/r4a-inspection-customer-selector.spec.js
+++ b/command-center/tests/smoke/r4a-inspection-customer-selector.spec.js
@@ -1,19 +1,10 @@
 /* eslint-disable testing-library/prefer-screen-queries, jest/valid-title */
 import { test, expect } from '@playwright/test';
-import { createAdminClient, createRunId, insertWithRetry, buildLeadPayload } from './helpers/supabaseAdmin.js';
 
 // R4A — Office Inspection Customer Selector Usability.
-// Real-browser behavioral coverage for the Customer (Lead) dropdown on
-// /tvg/crm/inspections/new. Verifies the fixed shared Select primitive at the
-// four required viewports: the long list is height-bounded, scrolls (wheel +
-// keyboard), the last option is reachable and selectable, and selection updates
-// the inspection form. Also confirms a short adjacent dropdown still works.
-//
-// Like the other office-inspection E2E specs, this requires a LOCAL Supabase and
-// skips otherwise (portal + real layout can only be exercised against the app).
-
-const TENANT_ID = 'tvg';
-const LEAD_COUNT = 40;
+// This loads the real shared Select primitive through a Vite-served test fixture.
+// The fixture has deterministic mock data and imports no app services, auth, or
+// Supabase client, so it is safe to run without a backend.
 
 const VIEWPORTS = [
   { name: 'desktop-1920x1080', width: 1920, height: 1080 },
@@ -22,130 +13,84 @@ const VIEWPORTS = [
   { name: 'mobile-390x844', width: 390, height: 844 },
 ];
 
-const signIn = async (page, email, password) => {
-  await page.goto('/tvg/login', { waitUntil: 'domcontentloaded' });
-  await page.getByLabel('Email').fill(email);
-  await page.getByLabel('Password').fill(password);
-  await page.getByRole('button', { name: /^sign in$/i }).click();
-  await page.waitForURL((url) => url.pathname.startsWith('/tvg/') && !url.pathname.endsWith('/login'));
-};
-
-const openCustomerDropdown = async (page) => {
-  await expect(page.getByRole('heading', { name: 'Create Inspection' })).toBeVisible();
-  await page.getByText('Customer (Lead)', { exact: true }).locator('..').getByRole('combobox').click();
-  await expect(page.getByRole('option').first()).toBeVisible();
-};
-
 const viewportMetrics = async (page) =>
   page.evaluate(() => {
     const vp = document.querySelector('[data-radix-select-viewport]');
     if (!vp) return null;
+    const content = vp.closest('[role="listbox"]');
+    const bounds = content?.getBoundingClientRect();
     return {
       clientHeight: vp.clientHeight,
       scrollHeight: vp.scrollHeight,
       scrollTop: vp.scrollTop,
       windowHeight: window.innerHeight,
+      contentTop: bounds?.top,
+      contentBottom: bounds?.bottom,
+      pageScrollY: window.scrollY,
+      horizontalOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
     };
   });
 
 test('long Customer (Lead) list is bounded, scrollable, and the last option is selectable across viewports', async ({ page }) => {
-  test.setTimeout(240_000);
-  let admin;
-  let env;
-  try {
-    ({ client: admin, env } = createAdminClient());
-  } catch (err) {
-    test.skip(true, `Supabase admin env not configured; selector E2E needs local Supabase: ${err.message}`);
-  }
-  if (!/127\.0\.0\.1|localhost/i.test(env.supabaseUrl)) {
-    test.skip(true, `Refusing to run selector regression against non-local Supabase: ${env.supabaseUrl}`);
-  }
+  const supabaseRequests = [];
+  page.on('request', (request) => {
+    if (/supabase/i.test(request.url())) supabaseRequests.push(request.url());
+  });
 
-  const runId = createRunId();
-  const email = `${runId}@example.com`;
-  const password = `Local-${runId}-A1!`;
-  const leadIds = [];
-  let userId;
+  for (const vp of VIEWPORTS) {
+    await test.step(vp.name, async () => {
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await page.goto('/tests/fixtures/r4a-select-harness.html', { waitUntil: 'domcontentloaded' });
+      await expect(page.getByRole('heading', { name: 'R4A Select Test Harness' })).toBeVisible();
 
-  try {
-    const user = await admin.auth.admin.createUser({
-      email,
-      password,
-      email_confirm: true,
-      app_metadata: { tenant_id: TENANT_ID, role: 'admin' },
+      const customerSelect = page.getByRole('combobox', { name: 'Customer (Lead)' });
+      await customerSelect.click();
+      const options = page.getByRole('option');
+      const viewport = page.locator('[data-radix-select-viewport]');
+      await expect(options).toHaveCount(60);
+      await expect(viewport).toBeVisible();
+
+      const bounded = await viewportMetrics(page);
+      expect(bounded, 'radix select viewport not found').not.toBeNull();
+      expect(bounded.clientHeight).toBeLessThanOrEqual(400);
+      expect(bounded.scrollHeight).toBeGreaterThan(bounded.clientHeight);
+      expect(bounded.contentTop).toBeGreaterThanOrEqual(0);
+      expect(bounded.contentBottom).toBeLessThanOrEqual(bounded.windowHeight);
+      expect(bounded.horizontalOverflow).toBe(false);
+
+      const box = await viewport.boundingBox();
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+      await page.mouse.wheel(0, 600);
+      await expect.poll(async () => (await viewportMetrics(page)).scrollTop).toBeGreaterThan(0);
+      expect((await viewportMetrics(page)).pageScrollY).toBe(bounded.pageScrollY);
+
+      await page.keyboard.press('Home');
+      await expect(options.first()).toHaveAttribute('data-highlighted', '');
+      await page.keyboard.press('ArrowDown');
+      await expect(options.nth(1)).toHaveAttribute('data-highlighted', '');
+      const scrollTopBeforePageDown = (await viewportMetrics(page)).scrollTop;
+      await page.keyboard.press('PageDown');
+      await expect.poll(async () => (await viewportMetrics(page)).scrollTop).toBeGreaterThan(scrollTopBeforePageDown);
+      await page.keyboard.press('End');
+      await expect(options.last()).toHaveAttribute('data-highlighted', '');
+
+      const finalLabel = await options.last().innerText();
+      await page.keyboard.press('Enter');
+      await expect(page.getByTestId('selected-customer')).toHaveText(`Selected customer: ${finalLabel}`);
+      await expect(customerSelect).toContainText(finalLabel);
+      await expect(page.getByRole('option')).toHaveCount(0);
     });
-    if (user.error) throw user.error;
-    userId = user.data.user.id;
-
-    for (let index = 0; index < LEAD_COUNT; index += 1) {
-      const marker = String(index).padStart(3, '0');
-      const lead = await insertWithRetry(admin, 'leads', buildLeadPayload(runId, {
-        first_name: 'SELECTOR',
-        last_name: `R4A ${marker}`,
-        company: `R4A SELECTOR ${runId} ${marker}`,
-        email: `${runId}.${marker}@example.com`,
-      }));
-      if (lead.error) throw lead.error;
-      leadIds.push(lead.data.id);
-    }
-
-    await signIn(page, email, password);
-
-    for (const vp of VIEWPORTS) {
-      await test.step(vp.name, async () => {
-        await page.setViewportSize({ width: vp.width, height: vp.height });
-        await page.goto('/tvg/crm/inspections/new', { waitUntil: 'domcontentloaded' });
-        await openCustomerDropdown(page);
-
-        const options = page.getByRole('option');
-        const optionCount = await options.count();
-        expect(optionCount).toBeGreaterThan(12);
-
-        // 1 + 9: bounded height — the panel never exceeds the viewport height and
-        // is capped (no clipping / off-screen list).
-        const bounded = await viewportMetrics(page);
-        expect(bounded, 'radix select viewport not found').not.toBeNull();
-        expect(bounded.clientHeight).toBeLessThanOrEqual(bounded.windowHeight);
-        expect(bounded.clientHeight).toBeLessThanOrEqual(400);
-
-        // 2: the list actually overflows and is scrollable.
-        expect(bounded.scrollHeight).toBeGreaterThan(bounded.clientHeight);
-
-        // 2 (wheel): mouse-wheel moves the list.
-        const box = await page.locator('[data-radix-select-viewport]').boundingBox();
-        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-        await page.mouse.wheel(0, 600);
-        await expect
-          .poll(async () => (await viewportMetrics(page)).scrollTop)
-          .toBeGreaterThan(0);
-
-        // 4 + 5 + 6: keyboard End reaches the last option; Enter selects it.
-        const lastLabel = await options.last().innerText();
-        await page.keyboard.press('Home');
-        await page.keyboard.press('End');
-        await expect(options.last()).toBeVisible();
-        await page.keyboard.press('Enter');
-
-        // 7: selection updates the inspection form (trigger reflects the choice)
-        // and 8: the dropdown closed without leaving orphaned options.
-        const combobox = page.getByText('Customer (Lead)', { exact: true }).locator('..').getByRole('combobox');
-        await expect(combobox).toContainText(lastLabel.trim());
-        await expect(page.getByRole('option')).toHaveCount(0);
-      });
-    }
-
-    // 10: short adjacent Select (Inspection Type, 5 fixed items) still opens and selects.
-    await test.step('short-list regression (Inspection Type)', async () => {
-      await page.setViewportSize({ width: 1366, height: 768 });
-      await page.goto('/tvg/crm/inspections/new', { waitUntil: 'domcontentloaded' });
-      await expect(page.getByRole('heading', { name: 'Create Inspection' })).toBeVisible();
-      await page.getByText('Inspection Type', { exact: true }).locator('..').getByRole('combobox').click();
-      await expect(page.getByRole('option', { name: 'Air Duct' })).toBeVisible();
-      await page.getByRole('option', { name: 'Air Duct' }).click();
-      await expect(page.getByText('Inspection Type', { exact: true }).locator('..').getByRole('combobox')).toContainText('Air Duct');
-    });
-  } finally {
-    if (leadIds.length) await admin.from('leads').delete().in('id', leadIds);
-    if (userId) await admin.auth.admin.deleteUser(userId);
   }
+
+  await test.step('short-list regression (Inspection Type)', async () => {
+    const inspectionType = page.getByRole('combobox', { name: 'Inspection Type' });
+    await inspectionType.click();
+    await expect(page.getByRole('option')).toHaveCount(3);
+    const shortListBox = page.getByRole('listbox');
+    await expect(shortListBox).toHaveJSProperty('scrollHeight', await shortListBox.evaluate((node) => node.clientHeight));
+    await page.getByRole('option', { name: 'Air Duct' }).click();
+    await expect(page.getByTestId('selected-inspection-type')).toHaveText('Selected type: air_duct');
+  });
+
+  expect(supabaseRequests).toEqual([]);
 });

--- a/command-center/tests/smoke/r4a-select-scroll-contract.spec.js
+++ b/command-center/tests/smoke/r4a-select-scroll-contract.spec.js
@@ -1,0 +1,45 @@
+/* eslint-disable testing-library/prefer-screen-queries, jest/valid-title */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test, expect } from '@playwright/test';
+
+// R4A — Office Inspection Customer Selector Usability.
+// Static contract test (no server / no Supabase required). It locks the shared
+// Select primitive fix so a future edit cannot silently reintroduce the defect
+// that made long customer lists unscrollable / unreachable.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(here, '../..');
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+const SELECT_PRIMITIVE = 'src/components/ui/select.jsx';
+
+test('shared Select viewport is height-bounded so long lists cannot run off-screen', () => {
+  const source = read(SELECT_PRIMITIVE);
+  // Bound the scrollable viewport to the popper available height (fallback 24rem).
+  expect(source).toContain('max-h-[min(24rem,var(--radix-select-content-available-height,24rem))]');
+});
+
+test('shared Select no longer pins the popper viewport to the trigger height', () => {
+  const source = read(SELECT_PRIMITIVE);
+  // The fixed trigger-height pin fought natural scroll flow and was part of the
+  // root cause; it must not come back.
+  expect(source).not.toContain('h-[var(--radix-select-trigger-height)]');
+});
+
+test('shared Select re-enables a visible scrollbar Radix hides by default', () => {
+  const source = read(SELECT_PRIMITIVE);
+  // Radix injects scrollbar-width:none + ::-webkit-scrollbar{display:none} on the
+  // viewport. The fix must override that so a real scrollbar shows where the
+  // browser renders one (Edge/Chrome via webkit, Firefox via scrollbar-width).
+  expect(source).toContain('![scrollbar-width:thin]');
+  expect(source).toContain('[&::-webkit-scrollbar]:![display:block]');
+});
+
+test('shared Select still renders the Radix viewport around its children', () => {
+  const source = read(SELECT_PRIMITIVE);
+  // Structural guard: the fix must not have removed the viewport that hosts the
+  // options (which would break every consumer dropdown).
+  expect(source).toMatch(/SelectPrimitive\.Viewport[\s\S]*\{children\}[\s\S]*SelectPrimitive\.Viewport/);
+});


### PR DESCRIPTION
## Summary

Restores bounded scrolling and keyboard navigation for long shared Select lists, including the office New Inspection Customer (Lead) selector.

## Root cause

The shared Select primitive rendered long popper lists without a bounded scrollable viewport, pinned the popper viewport to trigger height, and suppressed the browser scrollbar.

## Scope

- minimal shared Select primitive repair
- focused static and browser regression tests
- deterministic Vite-served test fixture that imports the real shared Select component
- R4A release brief

## Files changed

- `command-center/src/components/ui/select.jsx`
- `command-center/tests/smoke/r4a-select-scroll-contract.spec.js`
- `command-center/tests/smoke/r4a-inspection-customer-selector.spec.js`
- `command-center/tests/fixtures/r4a-select-harness.html`
- `command-center/tests/fixtures/r4a-select-harness.jsx`
- `command-center/docs/stabilization/releases/R4A_BRIEF.md`

## Why both tests are retained

The static contract test locks the shared primitive's bounded viewport and visible-scrollbar implementation. The browser test exercises that actual component through a backend-independent fixture across all required viewports, including wheel and keyboard behavior, final-option selection, controlled-value updates, and short-list regression.

## Not included

- Add Customer
- inspection redesign
- data-model changes
- authentication
- scheduling
- money-loop changes
- migrations
- deployment changes

## Validation

- `npx playwright test tests/smoke/r4a-select-scroll-contract.spec.js` — 4 passed
- `npx playwright test tests/smoke/r4a-inspection-customer-selector.spec.js` — 1 passed; verifies 1920x1080, 1366x768, 430x932, and 390x844
- `npm run lint` — passed with 20 pre-existing warnings and 0 errors
- `npm run build` — passed, exit code 0
- `npm run test:identity-contracts` — passed: 8 Node tests and 29 Playwright tests
- `npm run review:gate` — passed with 4 pre-existing artifact timestamp warnings
- Existing Supabase-dependent inspection navigation smoke remains skipped because its endpoint guard correctly refuses the configured non-local endpoint.

No migration was added. No deployment occurred. Ledger Lock should post a path-gated no-op success because this PR changes none of its controlled paths.

## UAT required

Independent UAT and owner confirmation are still required before PASS, merge, or deployment.