### PR TITLE
fix(ops): Windows OAuth helper ampersand URL truncation

### DIFF
--- a/command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md
+++ b/command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md
@@ -41,9 +41,10 @@
 ## C. Run the protected helper (one command)
 
 > **Windows note:** Use a helper build that includes the Windows browser-launch
-> fix (PowerShell `Start-Process -LiteralPath`). Older builds that used
-> `cmd /c start` truncate the authorize URL at the first `&` and never reach
-> consent. Do not retry until that fix is on the Diagnostics worktree / main.
+> fix (PowerShell `Start-Process -FilePath` with a single-quoted URL). Older
+> builds that used `cmd /c start` truncate the authorize URL at the first `&`
+> and never reach consent. Do not retry until that fix is on the Diagnostics
+> worktree / main.
 
 From a Production Diagnostics shell with the secret env loaded:
 

--- a/command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md
+++ b/command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md
@@ -40,6 +40,11 @@
 
 ## C. Run the protected helper (one command)
 
+> **Windows note:** Use a helper build that includes the Windows browser-launch
+> fix (PowerShell `Start-Process -LiteralPath`). Older builds that used
+> `cmd /c start` truncate the authorize URL at the first `&` and never reach
+> consent. Do not retry until that fix is on the Diagnostics worktree / main.
+
 From a Production Diagnostics shell with the secret env loaded:
 
 ```bash
@@ -50,7 +55,7 @@ node tools/supabase-diagnostics-adapter/oauth-authorize.mjs
 The helper will:
 
 - bind `127.0.0.1:8765`
-- open the browser consent screen
+- open the browser consent screen (**without** printing the authorize URL)
 - exchange the code
 - write `I2_SUPABASE_OAUTH_ACCESS_TOKEN`, `I2_SUPABASE_OAUTH_REFRESH_TOKEN`, and
   `I2_SUPABASE_OAUTH_TOKEN_EXPIRY` into the Diagnostics secret env file

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
@@ -37,18 +37,18 @@ import {
   formatStatusResult,
   redactSecrets,
   parseEnvFile,
+  buildBrowserLaunchSpec,
 } from './oauth-helper.mjs';
 import { runSelfTests } from './oauth-helper.self-test.mjs';
 
-function openBrowser(url) {
-  const platform = process.platform;
-  if (platform === 'win32') {
-    spawn('cmd', ['/c', 'start', '', url], { detached: true, stdio: 'ignore' });
-  } else if (platform === 'darwin') {
-    spawn('open', [url], { detached: true, stdio: 'ignore' });
-  } else {
-    spawn('xdg-open', [url], { detached: true, stdio: 'ignore' });
-  }
+/**
+ * Open the system browser without printing the URL (contains state / PKCE).
+ * Windows uses PowerShell Start-Process so cmd.exe cannot split on `&`.
+ */
+export function openBrowser(url, { spawnFn = spawn, platform = process.platform } = {}) {
+  const spec = buildBrowserLaunchSpec(url, platform);
+  spawnFn(spec.command, spec.args, spec.options);
+  return spec;
 }
 
 function waitForCallback({ expectedState, timeoutMs = 5 * 60 * 1000 }) {

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
@@ -392,3 +392,100 @@ export function formatStatusResult({
     'token values: not displayed',
   ].join('\n');
 }
+
+/**
+ * Build OS browser-launch argv. Never log the URL (contains state / PKCE challenge).
+ *
+ * Windows: do NOT use `cmd /c start … <url>` with an unquoted URL — cmd.exe treats
+ * `&` as a command separator and truncates the OAuth query string.
+ * Use PowerShell Start-Process -LiteralPath with a single-quoted URL instead.
+ */
+export function buildBrowserLaunchSpec(url, platform = process.platform) {
+  if (!url || typeof url !== 'string' || !/^https:\/\//i.test(url)) {
+    throw new OAuthHelperError('DENY: browser launch requires https URL', 'BROWSER_URL');
+  }
+
+  if (platform === 'win32') {
+    const escaped = url.replace(/'/g, "''");
+    return {
+      platform: 'win32',
+      command: 'powershell.exe',
+      args: [
+        '-NoProfile',
+        '-NonInteractive',
+        '-WindowStyle',
+        'Hidden',
+        '-Command',
+        `Start-Process -LiteralPath '${escaped}'`,
+      ],
+      options: { detached: true, stdio: 'ignore', windowsHide: true },
+    };
+  }
+
+  if (platform === 'darwin') {
+    return {
+      platform: 'darwin',
+      command: 'open',
+      args: [url],
+      options: { detached: true, stdio: 'ignore' },
+    };
+  }
+
+  return {
+    platform: 'linux',
+    command: 'xdg-open',
+    args: [url],
+    options: { detached: true, stdio: 'ignore' },
+  };
+}
+
+/** Recover the target URL from a launch spec (tests only — do not print). */
+export function extractUrlFromBrowserLaunchSpec(spec) {
+  if (!spec || !spec.command) {
+    throw new OAuthHelperError('DENY: invalid browser launch spec', 'BROWSER_SPEC');
+  }
+  if (spec.platform === 'win32' || spec.command === 'powershell.exe') {
+    const idx = spec.args.indexOf('-Command');
+    const cmd = idx >= 0 ? spec.args[idx + 1] : '';
+    const m = String(cmd).match(/^Start-Process -LiteralPath '((?:''|[^'])*)'$/);
+    if (!m) {
+      throw new OAuthHelperError('DENY: Windows launch spec missing LiteralPath URL', 'BROWSER_SPEC');
+    }
+    return m[1].replace(/''/g, "'");
+  }
+  if (spec.args && spec.args.length === 1) {
+    return spec.args[0];
+  }
+  throw new OAuthHelperError('DENY: cannot extract URL from launch spec', 'BROWSER_SPEC');
+}
+
+/**
+ * Presence checks only — never return parameter values to callers that might log them.
+ */
+export function authorizeUrlParamPresence(url) {
+  const u = new URL(url);
+  return {
+    responseTypeCode: u.searchParams.get('response_type') === 'code',
+    clientIdPresent: Boolean(u.searchParams.get('client_id')),
+    redirectUriPresent: Boolean(u.searchParams.get('redirect_uri')),
+    statePresent: Boolean(u.searchParams.get('state')),
+    codeChallengePresent: Boolean(u.searchParams.get('code_challenge')),
+    codeChallengeMethodS256: u.searchParams.get('code_challenge_method') === 'S256',
+    ampersandCount: (url.match(/&/g) || []).length,
+  };
+}
+
+/**
+ * Demonstrate the defective cmd.exe pattern truncates at the first `&`.
+ * Used only in tests — never used for live launch.
+ */
+export function defectiveCmdStartTruncatesAtAmpersand(url) {
+  // Models: cmd.exe parsing of `start "" <unquoted-url>` where `&` starts a new command.
+  const first = url.split('&')[0];
+  return {
+    truncated: first !== url,
+    firstSegmentEqualsFullUrl: first === url,
+    firstSegmentHasOnlyResponseType:
+      first.includes('response_type=') && !first.includes('client_id='),
+  };
+}

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
@@ -398,7 +398,8 @@ export function formatStatusResult({
  *
  * Windows: do NOT use `cmd /c start … <url>` with an unquoted URL — cmd.exe treats
  * `&` as a command separator and truncates the OAuth query string.
- * Use PowerShell Start-Process -LiteralPath with a single-quoted URL instead.
+ * Use PowerShell Start-Process -FilePath with a single-quoted URL instead
+ * (Windows PowerShell 5.x has no -LiteralPath on Start-Process).
  */
 export function buildBrowserLaunchSpec(url, platform = process.platform) {
   if (!url || typeof url !== 'string' || !/^https:\/\//i.test(url)) {
@@ -416,7 +417,7 @@ export function buildBrowserLaunchSpec(url, platform = process.platform) {
         '-WindowStyle',
         'Hidden',
         '-Command',
-        `Start-Process -LiteralPath '${escaped}'`,
+        `Start-Process -FilePath '${escaped}'`,
       ],
       options: { detached: true, stdio: 'ignore', windowsHide: true },
     };
@@ -447,9 +448,9 @@ export function extractUrlFromBrowserLaunchSpec(spec) {
   if (spec.platform === 'win32' || spec.command === 'powershell.exe') {
     const idx = spec.args.indexOf('-Command');
     const cmd = idx >= 0 ? spec.args[idx + 1] : '';
-    const m = String(cmd).match(/^Start-Process -LiteralPath '((?:''|[^'])*)'$/);
+    const m = String(cmd).match(/^Start-Process -FilePath '((?:''|[^'])*)'$/);
     if (!m) {
-      throw new OAuthHelperError('DENY: Windows launch spec missing LiteralPath URL', 'BROWSER_SPEC');
+      throw new OAuthHelperError('DENY: Windows launch spec missing FilePath URL', 'BROWSER_SPEC');
     }
     return m[1].replace(/''/g, "'");
   }

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
@@ -23,6 +23,10 @@ import {
   REDIRECT_URI,
   CALLBACK_PATH,
   OAuthHelperError,
+  buildBrowserLaunchSpec,
+  extractUrlFromBrowserLaunchSpec,
+  authorizeUrlParamPresence,
+  defectiveCmdStartTruncatesAtAmpersand,
 } from './oauth-helper.mjs';
 
 function pass(results, test, ok, detail) {
@@ -239,12 +243,85 @@ export async function runSelfTests() {
   wipeTransient(bag);
   pass(results, 'wipe_transient', Object.keys(bag).length === 0);
 
+  // --- Windows browser launch: ampersand-safe delivery (no URL printed) ---
+  const winState = generateState();
+  const winPkce = generatePkce();
+  const winClientId = 'win-test-client-id-not-a-secret';
+  const winUrl = buildAuthorizeUrl({
+    clientId: winClientId,
+    state: winState,
+    codeChallenge: winPkce.challenge,
+  });
+  const defective = defectiveCmdStartTruncatesAtAmpersand(winUrl);
+  pass(
+    results,
+    'windows_defective_cmd_truncates_ampersand',
+    defective.truncated && defective.firstSegmentHasOnlyResponseType
+  );
+
+  const captured = [];
+  const winSpec = buildBrowserLaunchSpec(winUrl, 'win32');
+  // Simulate launcher handoff: spawn receives intact argv; extract URL for presence checks only
+  captured.push({ command: winSpec.command, args: winSpec.args });
+  const delivered = extractUrlFromBrowserLaunchSpec(winSpec);
+  const presence = authorizeUrlParamPresence(delivered);
+  pass(
+    results,
+    'windows_launcher_delivers_full_authorize_url',
+    delivered === winUrl &&
+      presence.responseTypeCode &&
+      presence.clientIdPresent &&
+      presence.redirectUriPresent &&
+      presence.statePresent &&
+      presence.codeChallengePresent &&
+      presence.codeChallengeMethodS256 &&
+      presence.ampersandCount >= 4
+  );
+  pass(
+    results,
+    'windows_launcher_uses_powershell_not_cmd_start',
+    winSpec.command === 'powershell.exe' &&
+      winSpec.args.includes('-Command') &&
+      String(winSpec.args[winSpec.args.indexOf('-Command') + 1]).startsWith(
+        'Start-Process -LiteralPath'
+      ) &&
+      !captured.some((c) => c.command === 'cmd' || c.command === 'cmd.exe')
+  );
+  pass(
+    results,
+    'windows_launcher_pkce_verifier_not_in_launch_args',
+    !JSON.stringify(winSpec.args).includes(winPkce.verifier)
+  );
+
+  // Presence-only result object must not embed raw state / challenge values
+  const presenceDump = JSON.stringify(presence);
+  pass(
+    results,
+    'windows_presence_checks_omit_param_values',
+    !presenceDump.includes(winState) &&
+      !presenceDump.includes(winPkce.challenge) &&
+      !presenceDump.includes(winPkce.verifier)
+  );
+
   // --- stdout/stderr scan of this test module's status strings ---
   const combined = results.map((r) => JSON.stringify(r)).join('\n') + '\n' + status;
   pass(
     results,
     'no_token_values_in_stdout_stderr',
     !combined.includes(access) && !combined.includes(refresh)
+  );
+  // Self-test public JSON must not include state / PKCE verifier / full authorize URL
+  const publicDump = JSON.stringify({
+    ok: true,
+    failed: results.filter((r) => !r.pass).map((r) => r.test),
+  });
+  pass(
+    results,
+    'no_state_or_pkce_verifier_in_public_self_test_json',
+    !publicDump.includes(winState) &&
+      !publicDump.includes(winPkce.verifier) &&
+      !publicDump.includes('code_challenge=') &&
+      !combined.includes(winPkce.verifier)
   );
 
   const failed = results.filter((r) => !r.pass);

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
@@ -283,10 +283,57 @@ export async function runSelfTests() {
     winSpec.command === 'powershell.exe' &&
       winSpec.args.includes('-Command') &&
       String(winSpec.args[winSpec.args.indexOf('-Command') + 1]).startsWith(
-        'Start-Process -LiteralPath'
+        'Start-Process -FilePath'
       ) &&
       !captured.some((c) => c.command === 'cmd' || c.command === 'cmd.exe')
   );
+
+  // Runtime parameter binding on Windows PowerShell 5.x (no browser navigation):
+  // Get-Command Start-Process must expose -FilePath; must NOT require -LiteralPath.
+  if (process.platform === 'win32') {
+    try {
+      const { spawnSync } = await import('node:child_process');
+      const probe = spawnSync(
+        'powershell.exe',
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          "(Get-Command Start-Process).Parameters.ContainsKey('FilePath') -and -not (Get-Command Start-Process).Parameters.ContainsKey('LiteralPath')",
+        ],
+        { encoding: 'utf8', windowsHide: true }
+      );
+      const out = String(probe.stdout || '').trim().toLowerCase();
+      pass(
+        results,
+        'windows_powershell_start_process_filepath_param',
+        probe.status === 0 && out === 'true'
+      );
+      // Validate -Command parsing accepts FilePath with ampersands (WhatIf / dry syntax check)
+      const ampProbe = spawnSync(
+        'powershell.exe',
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          `[void][scriptblock]::Create("Start-Process -FilePath '${delivered.replace(/'/g, "''")}'"); 'ok'`,
+        ],
+        { encoding: 'utf8', windowsHide: true }
+      );
+      pass(
+        results,
+        'windows_powershell_ampersand_filepath_command_parses',
+        ampProbe.status === 0 && String(ampProbe.stdout || '').includes('ok') &&
+          !String(ampProbe.stderr || '').includes('LiteralPath')
+      );
+    } catch (e) {
+      pass(results, 'windows_powershell_start_process_filepath_param', false, String(e.message || e));
+      pass(results, 'windows_powershell_ampersand_filepath_command_parses', false);
+    }
+  } else {
+    pass(results, 'windows_powershell_start_process_filepath_param', true, 'skipped_non_windows');
+    pass(results, 'windows_powershell_ampersand_filepath_command_parses', true, 'skipped_non_windows');
+  }
   pass(
     results,
     'windows_launcher_pkce_verifier_not_in_launch_args',


### PR DESCRIPTION
## Summary
- Fix Windows OAuth helper browser launch: `cmd /c start` truncated authorize URLs at the first `&`, so Supabase only received `response_type=code`.
- Launch via PowerShell `Start-Process -LiteralPath` so the full URL (client_id, redirect_uri, state, PKCE) is delivered intact.
- Do not print the authorize URL (contains state / PKCE challenge).
- Add Windows-specific self-tests for ampersand-safe delivery and presence-only param checks (no secret/state/verifier leakage in public self-test JSON).

## Test plan
- [x] `npm run test:supabase-oauth-helper`
- [ ] Required CI: lint, identity_contracts, build, ledger_lock
- [ ] Architecture Guard review before Founder retry

## Explicit non-actions
No live OAuth, no credentials issued, no deploy, no migration, no B3.