### PR TITLE
fix(ops): HTTPS OAuth callback + Edge-direct Windows launch

### DIFF
--- a/command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md
+++ b/command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md
@@ -19,9 +19,14 @@
 4. Set:
    - **Name:** `BHFOS I2 Diagnostics`
    - **Website** (if asked): `https://github.com/faydog127/BHFOS`
-   - **Redirect URI:** `http://127.0.0.1:8765/oauth/callback`
+   - **Redirect URI:** `https://127.0.0.1:8765/oauth/callback`
+     (Platform OAuth Apps reject `http://` — HTTPS is required even for loopback.)
    - **Scopes:** **Projects → Read** only (nothing else)
 5. Confirm / create.
+
+If the app was already created with the old `http://` redirect, edit the OAuth app
+and set Redirect URI to exactly `https://127.0.0.1:8765/oauth/callback` before
+running the helper again.
 
 ---
 
@@ -40,11 +45,10 @@
 
 ## C. Run the protected helper (one command)
 
-> **Windows note:** Use a helper build that includes the Windows browser-launch
-> fix (PowerShell `Start-Process -FilePath` with a single-quoted URL). Older
-> builds that used `cmd /c start` truncate the authorize URL at the first `&`
-> and never reach consent. Do not retry until that fix is on the Diagnostics
-> worktree / main.
+> **Windows note:** Use a helper build that launches Edge/Chrome with the authorize
+> URL as a single argv element (not `cmd /c start`). Older builds truncate at `&`.
+> The callback listener is **HTTPS** on `127.0.0.1:8765` using a local self-signed
+> certificate under `%LOCALAPPDATA%\BHFOS\production-diagnostics\certs\` (not in git).
 
 From a Production Diagnostics shell with the secret env loaded:
 
@@ -55,7 +59,7 @@ node tools/supabase-diagnostics-adapter/oauth-authorize.mjs
 
 The helper will:
 
-- bind `127.0.0.1:8765`
+- bind `https://127.0.0.1:8765/oauth/callback`
 - open the browser consent screen (**without** printing the authorize URL)
 - exchange the code
 - write `I2_SUPABASE_OAUTH_ACCESS_TOKEN`, `I2_SUPABASE_OAUTH_REFRESH_TOKEN`, and
@@ -67,8 +71,11 @@ The helper will:
 ## D. Approve the browser consent screen
 
 When the browser opens, approve as the Founder for the organization that owns
-`wwyxohjnyqnegzbxtuxs`. Then confirm the helper printed status lines including
-`OAuth authorization: completed` and `token values: not displayed`.
+`wwyxohjnyqnegzbxtuxs`. If Edge shows a certificate warning for `127.0.0.1` after
+consent (local callback TLS), choose **Continue** / proceed to the loopback host —
+that page only confirms receipt; it never displays tokens. Then confirm the helper
+printed status lines including `OAuth authorization: completed` and
+`token values: not displayed`.
 
 ---
 

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
@@ -15,9 +15,13 @@
  *   SUPABASE_DIAGNOSTICS_PROJECT_REF=wwyxohjnyqnegzbxtuxs
  */
 
-import http from 'node:http';
-import { spawn } from 'node:child_process';
+import https from 'node:https';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { spawn, spawnSync } from 'node:child_process';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 import {
   CALLBACK_HOST,
   CALLBACK_PORT,
@@ -42,8 +46,63 @@ import {
 import { runSelfTests } from './oauth-helper.self-test.mjs';
 
 /**
+ * Local TLS material for https://127.0.0.1:8765 only (never committed).
+ * Platform OAuth Apps reject http redirect_uri.
+ */
+export function ensureLocalCallbackTlsMaterial(
+  baseDir = path.join(process.env.LOCALAPPDATA || '', 'BHFOS', 'production-diagnostics', 'certs')
+) {
+  if (!process.env.LOCALAPPDATA) {
+    throw new Error('DENY: LOCALAPPDATA required for local OAuth callback TLS material');
+  }
+  fs.mkdirSync(baseDir, { recursive: true });
+  const pfxPath = path.join(baseDir, 'oauth-callback.pfx');
+  const passPath = path.join(baseDir, 'oauth-callback.pfx.pass');
+
+  if (!fs.existsSync(pfxPath) || !fs.existsSync(passPath)) {
+    const passphrase = cryptoRandomPassphrase();
+    const ps = `
+$ErrorActionPreference = 'Stop'
+$dir = ${JSON.stringify(baseDir)}
+$pfx = ${JSON.stringify(pfxPath)}
+$passFile = ${JSON.stringify(passPath)}
+$plain = ${JSON.stringify(passphrase)}
+$secure = ConvertTo-SecureString -String $plain -Force -AsPlainText
+$cert = New-SelfSignedCertificate -Subject 'CN=127.0.0.1' -DnsName @('127.0.0.1') -CertStoreLocation 'Cert:\\CurrentUser\\My' -KeyExportPolicy Exportable -NotAfter (Get-Date).AddYears(2) -KeyAlgorithm RSA -KeyLength 2048 -FriendlyName 'BHFOS-I2-OAuth-Callback' -HashAlgorithm SHA256
+Export-PfxCertificate -Cert $cert -FilePath $pfx -Password $secure | Out-Null
+Set-Content -LiteralPath $passFile -Value $plain -NoNewline -Encoding ascii
+Remove-Item -LiteralPath ("Cert:\\CurrentUser\\My\\" + $cert.Thumbprint) -Force -ErrorAction SilentlyContinue
+Write-Output 'ok'
+`;
+    const probe = spawnSync(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', ps],
+      { encoding: 'utf8', windowsHide: true }
+    );
+    if (probe.status !== 0 || !String(probe.stdout || '').includes('ok')) {
+      const err = String(probe.stderr || probe.stdout || 'cert generation failed');
+      throw new Error(`DENY: unable to create local OAuth callback TLS material (${err.slice(0, 200)})`);
+    }
+  }
+
+  const passphrase = fs.readFileSync(passPath, 'utf8').trim();
+  if (!passphrase) {
+    throw new Error('DENY: local OAuth callback TLS passphrase missing');
+  }
+  return {
+    pfx: fs.readFileSync(pfxPath),
+    passphrase,
+  };
+}
+
+function cryptoRandomPassphrase() {
+  return crypto.randomBytes(24).toString('base64url');
+}
+
+/**
  * Open the system browser without printing the URL (contains state / PKCE).
- * Windows uses PowerShell Start-Process so cmd.exe cannot split on `&`.
+ * Windows spawns Edge/Chrome (or explorer.exe fallback) with the URL as one argv
+ * element so cmd.exe cannot split on `&`.
  */
 export function openBrowser(url, { spawnFn = spawn, platform = process.platform } = {}) {
   const spec = buildBrowserLaunchSpec(url, platform);
@@ -51,46 +110,48 @@ export function openBrowser(url, { spawnFn = spawn, platform = process.platform 
   return spec;
 }
 
-function waitForCallback({ expectedState, timeoutMs = 5 * 60 * 1000 }) {
+function waitForCallback({ expectedState, timeoutMs = 5 * 60 * 1000, tls }) {
   return new Promise((resolve, reject) => {
     let settled = false;
-    const server = http.createServer((req, res) => {
-      const finish = (status, body, result, err) => {
-        res.writeHead(status, { 'Content-Type': 'text/plain; charset=utf-8' });
-        res.end(body);
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        server.close(() => {
-          if (err) reject(err);
-          else resolve(result);
-        });
-      };
+    const server = https.createServer(
+      { pfx: tls.pfx, passphrase: tls.passphrase },
+      (req, res) => {
+        const finish = (status, body, result, err) => {
+          res.writeHead(status, { 'Content-Type': 'text/plain; charset=utf-8' });
+          res.end(body);
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          server.close(() => {
+            if (err) reject(err);
+            else resolve(result);
+          });
+        };
 
-      try {
-        const { code } = validateCallbackRequest({
-          method: req.method,
-          hostHeader: req.headers.host,
-          urlPathWithQuery: req.url || '/',
-          expectedState,
-        });
-        finish(
-          200,
-          'Authorization received. You may close this window. Tokens are not displayed.',
-          { code }
-        );
-      } catch (e) {
-        const msg = e && e.message ? e.message : 'DENY: callback rejected';
-        // Wrong path / state: keep listening unless fatal host issues — for path mismatch
-        // respond 404 and continue waiting; for state mismatch fail closed.
-        if (e && e.code === 'CALLBACK_PATH') {
-          res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
-          res.end('Not found');
-          return;
+        try {
+          const { code } = validateCallbackRequest({
+            method: req.method,
+            hostHeader: req.headers.host,
+            urlPathWithQuery: req.url || '/',
+            expectedState,
+          });
+          finish(
+            200,
+            'Authorization received. You may close this window. Tokens are not displayed.',
+            { code }
+          );
+        } catch (e) {
+          // Wrong path / state: keep listening unless fatal host issues — for path mismatch
+          // respond 404 and continue waiting; for state mismatch fail closed.
+          if (e && e.code === 'CALLBACK_PATH') {
+            res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+            res.end('Not found');
+            return;
+          }
+          finish(400, 'Authorization failed. You may close this window.', null, e);
         }
-        finish(400, 'Authorization failed. You may close this window.', null, e);
       }
-    });
+    );
 
     server.on('error', (err) => {
       if (!settled) {
@@ -107,7 +168,7 @@ function waitForCallback({ expectedState, timeoutMs = 5 * 60 * 1000 }) {
     }, timeoutMs);
 
     server.listen(CALLBACK_PORT, CALLBACK_HOST, () => {
-      // Bound exclusively to 127.0.0.1:8765
+      // Bound exclusively to 127.0.0.1:8765 (HTTPS)
     });
   });
 }
@@ -168,10 +229,12 @@ async function authorizeMain() {
       throw new Error('DENY: redirect_uri mismatch in authorize URL');
     }
 
-    console.log(`Callback listener: http://${CALLBACK_HOST}:${CALLBACK_PORT}${CALLBACK_PATH}`);
+    const tls = ensureLocalCallbackTlsMaterial();
+    console.log(`Callback listener: ${REDIRECT_URI}`);
     console.log('Opening browser for Founder consent (Projects Read only)…');
+    console.log('status: if Edge warns about the local certificate, continue to 127.0.0.1 (callback only)');
 
-    const callbackPromise = waitForCallback({ expectedState: transient.state });
+    const callbackPromise = waitForCallback({ expectedState: transient.state, tls });
     openBrowser(authorizeUrl);
 
     const { code } = await callbackPromise;
@@ -269,4 +332,9 @@ Requires:
   await authorizeMain();
 }
 
-main();
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+if (isMain) {
+  main();
+}

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
@@ -12,7 +12,9 @@ export const PRODUCTION_PROJECT_REF = 'wwyxohjnyqnegzbxtuxs';
 export const CALLBACK_HOST = '127.0.0.1';
 export const CALLBACK_PORT = 8765;
 export const CALLBACK_PATH = '/oauth/callback';
-export const REDIRECT_URI = `http://${CALLBACK_HOST}:${CALLBACK_PORT}${CALLBACK_PATH}`;
+/** Platform OAuth Apps require HTTPS redirect_uri (http://127.0.0.1 is rejected). */
+export const CALLBACK_SCHEME = 'https';
+export const REDIRECT_URI = `${CALLBACK_SCHEME}://${CALLBACK_HOST}:${CALLBACK_PORT}${CALLBACK_PATH}`;
 export const AUTHORIZE_URL = 'https://api.supabase.com/v1/oauth/authorize';
 export const TOKEN_URL = 'https://api.supabase.com/v1/oauth/token';
 export const ALLOWED_SCOPES = new Set(['projects:read']);
@@ -394,12 +396,32 @@ export function formatStatusResult({
 }
 
 /**
+ * Prefer a real browser executable on Windows so the authorize URL is a single
+ * argv element (ampersands preserved) and the tab opens in that browser.
+ */
+export function resolveWindowsBrowserExecutable(
+  env = process.env,
+  existsSyncFn = fs.existsSync
+) {
+  const candidates = [
+    path.join(env['ProgramFiles(x86)'] || '', 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
+    path.join(env.ProgramFiles || '', 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
+    path.join(env.ProgramFiles || '', 'Google', 'Chrome', 'Application', 'chrome.exe'),
+    path.join(env.LOCALAPPDATA || '', 'Google', 'Chrome', 'Application', 'chrome.exe'),
+  ];
+  for (const candidate of candidates) {
+    if (candidate && existsSyncFn(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
  * Build OS browser-launch argv. Never log the URL (contains state / PKCE challenge).
  *
  * Windows: do NOT use `cmd /c start … <url>` with an unquoted URL — cmd.exe treats
  * `&` as a command separator and truncates the OAuth query string.
- * Use PowerShell Start-Process -FilePath with a single-quoted URL instead
- * (Windows PowerShell 5.x has no -LiteralPath on Start-Process).
+ * Prefer spawning Edge/Chrome with the URL as one argv element. Fall back to
+ * explorer.exe (still a single argv URL — never cmd.exe).
  */
 export function buildBrowserLaunchSpec(url, platform = process.platform) {
   if (!url || typeof url !== 'string' || !/^https:\/\//i.test(url)) {
@@ -407,18 +429,11 @@ export function buildBrowserLaunchSpec(url, platform = process.platform) {
   }
 
   if (platform === 'win32') {
-    const escaped = url.replace(/'/g, "''");
+    const browser = resolveWindowsBrowserExecutable();
     return {
       platform: 'win32',
-      command: 'powershell.exe',
-      args: [
-        '-NoProfile',
-        '-NonInteractive',
-        '-WindowStyle',
-        'Hidden',
-        '-Command',
-        `Start-Process -FilePath '${escaped}'`,
-      ],
+      command: browser || 'explorer.exe',
+      args: [url],
       options: { detached: true, stdio: 'ignore', windowsHide: true },
     };
   }
@@ -445,14 +460,21 @@ export function extractUrlFromBrowserLaunchSpec(spec) {
   if (!spec || !spec.command) {
     throw new OAuthHelperError('DENY: invalid browser launch spec', 'BROWSER_SPEC');
   }
-  if (spec.platform === 'win32' || spec.command === 'powershell.exe') {
-    const idx = spec.args.indexOf('-Command');
-    const cmd = idx >= 0 ? spec.args[idx + 1] : '';
-    const m = String(cmd).match(/^Start-Process -FilePath '((?:''|[^'])*)'$/);
-    if (!m) {
-      throw new OAuthHelperError('DENY: Windows launch spec missing FilePath URL', 'BROWSER_SPEC');
+  if (spec.platform === 'win32') {
+    if (spec.args && spec.args.length === 1 && /^https:\/\//i.test(spec.args[0])) {
+      return spec.args[0];
     }
-    return m[1].replace(/''/g, "'");
+    // Legacy PowerShell Start-Process -FilePath form (pre-Edge-direct launch)
+    if (spec.command === 'powershell.exe') {
+      const idx = spec.args.indexOf('-Command');
+      const cmd = idx >= 0 ? spec.args[idx + 1] : '';
+      const m = String(cmd).match(/^Start-Process -FilePath '((?:''|[^'])*)'$/);
+      if (!m) {
+        throw new OAuthHelperError('DENY: Windows launch spec missing FilePath URL', 'BROWSER_SPEC');
+      }
+      return m[1].replace(/''/g, "'");
+    }
+    throw new OAuthHelperError('DENY: Windows launch spec missing https URL argv', 'BROWSER_SPEC');
   }
   if (spec.args && spec.args.length === 1) {
     return spec.args[0];

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
@@ -277,62 +277,35 @@ export async function runSelfTests() {
       presence.codeChallengeMethodS256 &&
       presence.ampersandCount >= 4
   );
-  pass(
-    results,
-    'windows_launcher_uses_powershell_not_cmd_start',
-    winSpec.command === 'powershell.exe' &&
-      winSpec.args.includes('-Command') &&
-      String(winSpec.args[winSpec.args.indexOf('-Command') + 1]).startsWith(
-        'Start-Process -FilePath'
-      ) &&
-      !captured.some((c) => c.command === 'cmd' || c.command === 'cmd.exe')
-  );
+  const winCmd = String(winSpec.command || '').toLowerCase();
+  const usesDirectBrowserArgv =
+    winSpec.args.length === 1 &&
+    winSpec.args[0] === winUrl &&
+    (winCmd.endsWith('msedge.exe') ||
+      winCmd.endsWith('chrome.exe') ||
+      winCmd === 'explorer.exe') &&
+    !captured.some((c) => c.command === 'cmd' || c.command === 'cmd.exe' || c.command === 'powershell.exe');
+  pass(results, 'windows_launcher_uses_direct_browser_not_cmd_start', usesDirectBrowserArgv);
 
-  // Runtime parameter binding on Windows PowerShell 5.x (no browser navigation):
-  // Get-Command Start-Process must expose -FilePath; must NOT require -LiteralPath.
+  // Runtime: resolved Windows browser path must exist when present (no navigation).
   if (process.platform === 'win32') {
     try {
-      const { spawnSync } = await import('node:child_process');
-      const probe = spawnSync(
-        'powershell.exe',
-        [
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          "(Get-Command Start-Process).Parameters.ContainsKey('FilePath') -and -not (Get-Command Start-Process).Parameters.ContainsKey('LiteralPath')",
-        ],
-        { encoding: 'utf8', windowsHide: true }
-      );
-      const out = String(probe.stdout || '').trim().toLowerCase();
+      const { existsSync } = await import('node:fs');
+      const resolvedIsFile =
+        winCmd === 'explorer.exe' || (winSpec.command && existsSync(winSpec.command));
+      pass(results, 'windows_launcher_browser_executable_resolves', resolvedIsFile);
       pass(
         results,
-        'windows_powershell_start_process_filepath_param',
-        probe.status === 0 && out === 'true'
-      );
-      // Validate -Command parsing accepts FilePath with ampersands (WhatIf / dry syntax check)
-      const ampProbe = spawnSync(
-        'powershell.exe',
-        [
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          `[void][scriptblock]::Create("Start-Process -FilePath '${delivered.replace(/'/g, "''")}'"); 'ok'`,
-        ],
-        { encoding: 'utf8', windowsHide: true }
-      );
-      pass(
-        results,
-        'windows_powershell_ampersand_filepath_command_parses',
-        ampProbe.status === 0 && String(ampProbe.stdout || '').includes('ok') &&
-          !String(ampProbe.stderr || '').includes('LiteralPath')
+        'windows_launcher_ampersand_url_is_single_argv',
+        winSpec.args.length === 1 && presence.ampersandCount >= 4
       );
     } catch (e) {
-      pass(results, 'windows_powershell_start_process_filepath_param', false, String(e.message || e));
-      pass(results, 'windows_powershell_ampersand_filepath_command_parses', false);
+      pass(results, 'windows_launcher_browser_executable_resolves', false, String(e.message || e));
+      pass(results, 'windows_launcher_ampersand_url_is_single_argv', false);
     }
   } else {
-    pass(results, 'windows_powershell_start_process_filepath_param', true, 'skipped_non_windows');
-    pass(results, 'windows_powershell_ampersand_filepath_command_parses', true, 'skipped_non_windows');
+    pass(results, 'windows_launcher_browser_executable_resolves', true, 'skipped_non_windows');
+    pass(results, 'windows_launcher_ampersand_url_is_single_argv', true, 'skipped_non_windows');
   }
   pass(
     results,


### PR DESCRIPTION
﻿## Summary
- Switch Diagnostics Supabase OAuth callback to `https://127.0.0.1:8765/oauth/callback` with local self-signed TLS material under `%LOCALAPPDATA%\BHFOS\production-diagnostics\certs\` (not committed).
- Launch Windows browser via Edge/Chrome executable with the authorize URL as a single argv element (ampersand-safe; no `cmd /c start`).
- Update Founder steps to match Platform OAuth HTTPS redirect requirements and local cert continue guidance.
- Update OAuth helper self-tests for the new launch/callback contract.

## Governance exception context
- A Founder OAuth run completed against **uncommitted** Diagnostics worktree copies of these fixes.
- That token set is **QUARANTINED** and must not be used for B3 or live diagnostics.
- After merge: update Diagnostics worktree + protected launcher to the merge SHA, re-run OAuth from a clean worktree, and replace quarantined tokens.
- **B3 remains unauthorized** until that clean rerun succeeds.

## Test plan
- [x] `npm run test:supabase-oauth-helper` (local)
- [ ] CI: lint
- [ ] CI: identity_contracts
- [ ] CI: build
- [ ] CI: ledger_lock
- [ ] Architecture Guard review → `APPROVE_FOR_FINAL_DECISION_PACKET` on exact head
- [ ] Release Agent merge only after Founder exact-head authorization
- [ ] Post-merge: clean Diagnostics worktree + launcher SHA update + OAuth rerun (replace quarantined tokens)

## Scope / non-actions
- No deployment, migration, production mutation, Hostinger access, or live diagnostics (B3).
- No Founder OAuth in this PR CI path.
