### PR TITLE
fix(ops): HTTP OAuth loopback + fail-closed browser launch (supersedes #58 HTTPS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,28 @@ jobs:
       - name: Identity helper contract tests
         run: npm run test:identity-helpers
 
+  supabase_oauth_helper:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: command-center
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.1
+          cache: npm
+          cache-dependency-path: command-center/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Supabase OAuth helper self-tests
+        run: npm run test:supabase-oauth-helper
+
   build:
     runs-on: ubuntu-latest
     needs: lint

--- a/command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md
+++ b/command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md
@@ -1,52 +1,62 @@
 # Exact Supabase OAuth App creation — G2.3B-B2D Option A (Founder UI)
 
 > Binding ceiling from Founder **G2.3B-B2D Option A** authorization.
-> **No secret values** belong in this file, chat, or repository.
+> **No secret values** belong in this file, chat, repository files, Cursor, or
+> terminal command history.
 >
-> OAuth code exchange is performed by the **protected local helper** — the Founder
-> does **not** construct URLs, run PKCE, capture codes, or copy tokens.
+> OAuth code exchange is performed by the **protected local helper only** — the
+> Founder does **not** construct URLs, run PKCE, capture codes, or copy tokens.
 
 **Authorized scope only:** Dashboard **Projects** → **Read** (wire `projects:read`).  
-**Project ref (adapter lock):** `wwyxohjnyqnegzbxtuxs`
+**Project ref (adapter lock):** `wwyxohjnyqnegzbxtuxs`  
+**Redirect URI (exact):** `http://127.0.0.1:8765/oauth/callback`
 
 ---
 
-## A. Create the OAuth application (Dashboard only)
+## Quarantined tokens (binding)
+
+Any OAuth access/refresh tokens issued during failed or non-clean attempts
+(including pre-HTTP-harden / HTTPS-callback experiments) are **quarantined**:
+
+- **Invalid for B3** and for any live Diagnostics campaign
+- Must be **replaced** by a clean helper rerun after this HTTP + hardened launcher
+  correction is on the Diagnostics worktree
+- Do **not** reuse quarantined token values
+
+---
+
+## A. Create or update the OAuth application (Dashboard only)
 
 1. Sign in as the **Founder** Supabase account that owns project `wwyxohjnyqnegzbxtuxs`.
 2. Open that project’s **organization** → **Organization Settings → OAuth Apps**.
-3. Click **Add application**.
+3. Create or edit **`BHFOS I2 Diagnostics`**.
 4. Set:
-   - **Name:** `BHFOS I2 Diagnostics`
-   - **Website** (if asked): `https://github.com/faydog127/BHFOS`
-   - **Redirect URI:** `http://127.0.0.1:8765/oauth/callback`
+   - **Redirect URI (exact):** `http://127.0.0.1:8765/oauth/callback`
    - **Scopes:** **Projects → Read** only (nothing else)
-5. Confirm / create.
+5. Confirm / save.
+
+Do **not** register an HTTPS loopback redirect. Do **not** use `localhost` unless
+you intentionally change both the app and the helper together (helper uses
+`127.0.0.1` only).
 
 ---
 
 ## B. Place Client ID / secret in Diagnostics secret store only
 
 1. Create or open the Diagnostics durable env file (gitignored; outside chat/repo).
-2. Set environment variable `I2_DIAGNOSTICS_SECRET_ENV_FILE` to that file’s absolute path
-   (Diagnostics shell / profile only).
-3. Put into that file / Diagnostics env (values never pasted into chat):
+2. Set `I2_DIAGNOSTICS_SECRET_ENV_FILE` to that file’s absolute path (Diagnostics shell only).
+3. Put into that file (values never pasted into chat/Cursor/repo/history):
    - `I2_SUPABASE_OAUTH_CLIENT_ID`
-   - `I2_SUPABASE_OAUTH_CLIENT_SECRET` (only if the Dashboard issued one)
+   - `I2_SUPABASE_OAUTH_CLIENT_SECRET` (only if issued)
    - `SUPABASE_DIAGNOSTICS_PROJECT_REF=wwyxohjnyqnegzbxtuxs`
-4. Optional (only if needed for consent pre-select): `I2_SUPABASE_OAUTH_ORGANIZATION_SLUG`
 
 ---
 
-## C. Run the protected helper (one command)
+## C. Run the protected helper only (one command)
 
-> **Windows note:** Use a helper build that includes the Windows browser-launch
-> fix (PowerShell `Start-Process -FilePath` with a single-quoted URL). Older
-> builds that used `cmd /c start` truncate the authorize URL at the first `&`
-> and never reach consent. Do not retry until that fix is on the Diagnostics
-> worktree / main.
-
-From a Production Diagnostics shell with the secret env loaded:
+Use **only** the protected launcher from an updated Production Diagnostics worktree
+(HTTP callback + approved Edge/Chrome absolute path launch). Do not use ad-hoc
+scripts, browser address-bar OAuth, or quarantined tokens.
 
 ```bash
 cd command-center
@@ -55,25 +65,24 @@ node tools/supabase-diagnostics-adapter/oauth-authorize.mjs
 
 The helper will:
 
-- bind `127.0.0.1:8765`
-- open the browser consent screen (**without** printing the authorize URL)
-- exchange the code
-- write `I2_SUPABASE_OAUTH_ACCESS_TOKEN`, `I2_SUPABASE_OAUTH_REFRESH_TOKEN`, and
-  `I2_SUPABASE_OAUTH_TOKEN_EXPIRY` into the Diagnostics secret env file
-- print **names/status only** (never token values)
+- bind **only** `127.0.0.1:8765` (plain HTTP)
+- open Edge/Chrome via an approved absolute path (URL as one argv; no explorer/cmd/PATH)
+- exchange the code with PKCE
+- write access/refresh/expiry into the Diagnostics secret env file
+- print **names/status only**
 
 ---
 
 ## D. Approve the browser consent screen
 
-When the browser opens, approve as the Founder for the organization that owns
-`wwyxohjnyqnegzbxtuxs`. Then confirm the helper printed status lines including
-`OAuth authorization: completed` and `token values: not displayed`.
+Approve as the Founder for the organization that owns `wwyxohjnyqnegzbxtuxs`.
+Confirm status includes `OAuth authorization: completed` and
+`token values: not displayed`.
 
 ---
 
 ## E. Explicit non-actions
 
-Do **not**: grant any other OAuth scope; manually craft authorize URLs; copy codes
-or tokens; use PAT / Dashboard Read-Only / service-role; paste secrets into chat;
-run B3 under this packet; provision Hostinger.
+Do **not**: grant other OAuth scopes; use HTTPS self-signed callbacks; paste
+secrets into Cursor/chat/repo/history; reuse quarantined tokens; start B3; use
+PAT / Dashboard Read-Only / service-role; provision Hostinger.

--- a/command-center/docs/governance/decisions/G2.3B-B2D_OAUTH_REDIRECT_PLATFORM_VERIFICATION.md
+++ b/command-center/docs/governance/decisions/G2.3B-B2D_OAUTH_REDIRECT_PLATFORM_VERIFICATION.md
@@ -1,0 +1,46 @@
+# G2.3B-B2D — OAuth redirect URI platform verification (SOURCE-ONLY)
+
+> No production OAuth app mutation. No token issuance. No secret values.
+
+## Question
+Does Supabase Management API OAuth require HTTPS for loopback redirect URIs,
+or is plain HTTP loopback accepted?
+
+## Evidence
+
+### A. Official documentation (fetched 2026-07-18)
+`https://supabase.com/docs/guides/integrations/build-a-supabase-oauth-integration`
+
+Authorize URL example in docs uses an **HTTP** redirect URI:
+
+`redirect_uri=http://localhost:54321/functions/v1/connect-supabase/oauth2/callback`
+
+This contradicts the PR #58 claim that platform OAuth Apps reject `http://` redirects.
+
+RFC 8252 recommends loopback **HTTP** for native apps.
+
+### B. Bounded authorize preflight (no valid client; no consent; no tokens)
+Identical fake `client_id` (`00000000-0000-0000-0000-000000000000`) with:
+
+| Candidate redirect_uri | HTTP status | Body (verbatim) |
+| --- | --- | --- |
+| `http://127.0.0.1:8765/oauth/callback` | 422 | `{"message":"Unrecognized client_id"}` |
+| `http://localhost:8765/oauth/callback` | 422 | `{"message":"Unrecognized client_id"}` |
+| `https://127.0.0.1:8765/oauth/callback` | 422 | `{"message":"Unrecognized client_id"}` |
+
+**Interpretation:** Platform validation fails on unrecognized client **before** any
+scheme-based rejection. No response claimed “HTTPS required” or rejected HTTP
+specifically. Therefore an HTTPS requirement must **not** be inferred from a
+generic redirect/client error.
+
+## Confirmed helper redirect URI
+**`http://127.0.0.1:8765/oauth/callback`**
+
+- Preferred over `localhost` (exact IP bind + Host check).
+- OAuth app registration and helper `REDIRECT_URI` must match **exactly**.
+- No self-signed certificate. No certificate click-through.
+
+## Root cause of PR #58 REQUEST_CHANGES
+PR #58 assumed HTTPS was required, introduced self-signed TLS + browser launch
+weaknesses, and lacked required security tests. Preferred design returns to HTTP
+loopback with fail-closed absolute browser paths.

--- a/command-center/tools/supabase-diagnostics-adapter/README.md
+++ b/command-center/tools/supabase-diagnostics-adapter/README.md
@@ -43,6 +43,11 @@ Inventory names (values never in repo):
 
 ### Protected OAuth helper
 
+Plain HTTP loopback: `http://127.0.0.1:8765/oauth/callback` (no self-signed TLS).
+Windows browser launch uses approved Edge/Chrome **absolute** paths only (no
+explorer/cmd/PATH). Quarantined tokens from failed attempts must be replaced
+before B3.
+
 ```bash
 npm run test:supabase-oauth-helper
 node tools/supabase-diagnostics-adapter/oauth-authorize.mjs

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
@@ -38,12 +38,13 @@ import {
   redactSecrets,
   parseEnvFile,
   buildBrowserLaunchSpec,
+  callbackListenArgs,
 } from './oauth-helper.mjs';
 import { runSelfTests } from './oauth-helper.self-test.mjs';
 
 /**
- * Open the system browser without printing the URL (contains state / PKCE).
- * Windows uses PowerShell Start-Process so cmd.exe cannot split on `&`.
+ * Open an approved browser without printing the URL (contains state / PKCE).
+ * Windows: absolute Edge/Chrome path only; URL is one argv item; no explorer/cmd/PATH.
  */
 export function openBrowser(url, { spawnFn = spawn, platform = process.platform } = {}) {
   const spec = buildBrowserLaunchSpec(url, platform);
@@ -106,8 +107,9 @@ function waitForCallback({ expectedState, timeoutMs = 5 * 60 * 1000 }) {
       server.close(() => reject(new Error('DENY: OAuth callback timed out')));
     }, timeoutMs);
 
-    server.listen(CALLBACK_PORT, CALLBACK_HOST, () => {
-      // Bound exclusively to 127.0.0.1:8765
+    const [port, host] = callbackListenArgs();
+    server.listen(port, host, () => {
+      // Bound exclusively to 127.0.0.1:8765 (HTTP loopback)
     });
   });
 }

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
@@ -12,10 +12,29 @@ export const PRODUCTION_PROJECT_REF = 'wwyxohjnyqnegzbxtuxs';
 export const CALLBACK_HOST = '127.0.0.1';
 export const CALLBACK_PORT = 8765;
 export const CALLBACK_PATH = '/oauth/callback';
+/** Plain HTTP loopback — platform docs + preflight do not require HTTPS. */
 export const REDIRECT_URI = `http://${CALLBACK_HOST}:${CALLBACK_PORT}${CALLBACK_PATH}`;
 export const AUTHORIZE_URL = 'https://api.supabase.com/v1/oauth/authorize';
 export const TOKEN_URL = 'https://api.supabase.com/v1/oauth/token';
 export const ALLOWED_SCOPES = new Set(['projects:read']);
+
+/** Listener bind contract — host must be loopback IP only (not 0.0.0.0). */
+export const CALLBACK_BIND = Object.freeze({
+  host: CALLBACK_HOST,
+  port: CALLBACK_PORT,
+  path: CALLBACK_PATH,
+  redirectUri: REDIRECT_URI,
+});
+
+/**
+ * Approved Windows browser absolute paths only.
+ * Do not derive from PATH, PATHEXT, or environment-steered directories.
+ */
+export const APPROVED_WINDOWS_BROWSER_PATHS = Object.freeze([
+  'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+  'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+  'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+]);
 
 const SECRET_NAMES = {
   clientId: 'I2_SUPABASE_OAUTH_CLIENT_ID',
@@ -180,6 +199,21 @@ export function buildAuthorizeUrl({
  * Validate callback request. Returns { code } or throws.
  * Never include code in thrown messages.
  */
+export function parseCallbackHostHeader(hostHeader) {
+  const raw = String(hostHeader || '').trim();
+  if (!raw) {
+    throw new OAuthHelperError('DENY: callback host header missing', 'CALLBACK_HOST');
+  }
+  // IPv4 Host:port only (listener is 127.0.0.1).
+  const m = raw.match(/^([^:]+):(\d+)$/) || raw.match(/^([^:]+)$/);
+  if (!m) {
+    throw new OAuthHelperError('DENY: callback host header invalid', 'CALLBACK_HOST');
+  }
+  const host = m[1];
+  const port = m[2] !== undefined ? Number(m[2]) : CALLBACK_PORT;
+  return { host, port };
+}
+
 export function validateCallbackRequest({
   method,
   hostHeader,
@@ -190,15 +224,12 @@ export function validateCallbackRequest({
     throw new OAuthHelperError('DENY: callback method must be GET', 'CALLBACK_METHOD');
   }
 
-  const host = String(hostHeader || '').split(':')[0];
-  if (host !== CALLBACK_HOST && host !== 'localhost') {
-    // Bind is 127.0.0.1; Host should be 127.0.0.1 (reject foreign hosts).
-    throw new OAuthHelperError('DENY: callback host mismatch', 'CALLBACK_HOST');
-  }
-  // Prefer exact 127.0.0.1; localhost accepted only if it resolves to loopback listener
-  // but we bind exclusively to 127.0.0.1 — require Host 127.0.0.1.
+  const { host, port } = parseCallbackHostHeader(hostHeader);
   if (host !== CALLBACK_HOST) {
     throw new OAuthHelperError('DENY: callback host must be 127.0.0.1', 'CALLBACK_HOST');
+  }
+  if (port !== CALLBACK_PORT) {
+    throw new OAuthHelperError('DENY: callback port mismatch', 'CALLBACK_PORT');
   }
 
   let parsed;
@@ -231,13 +262,14 @@ export function validateCallbackRequest({
 
 /**
  * Assert token response scopes ⊆ allowed (projects:read only).
- * Empty scope is treated as fail-closed (unexpected).
+ * Omitted/empty scope is fail-closed (explicit decision — do not treat as OK).
  */
 export function assertTokenScopes(scopeField) {
-  // If the provider omits scope, App Dashboard still constrains to Projects Read.
-  // Fail closed only on *unexpected* scopes when the field is present.
   if (scopeField === undefined || scopeField === null || String(scopeField).trim() === '') {
-    return { omitted: true };
+    throw new OAuthHelperError(
+      'DENY: token response missing scope; expected projects:read',
+      'MISSING_SCOPE'
+    );
   }
   const parts = String(scopeField)
     .split(/[\s,]+/)
@@ -250,6 +282,12 @@ export function assertTokenScopes(scopeField) {
         'UNEXPECTED_SCOPE'
       );
     }
+  }
+  if (!parts.includes('projects:read')) {
+    throw new OAuthHelperError(
+      'DENY: token response scope must include projects:read',
+      'MISSING_PROJECTS_READ'
+    );
   }
   return { omitted: false, scopes: parts };
 }
@@ -393,50 +431,116 @@ export function formatStatusResult({
   ].join('\n');
 }
 
+export function normalizeWindowsPath(p) {
+  return path.normalize(String(p || '')).toLowerCase();
+}
+
+export function isApprovedWindowsBrowserPath(candidate) {
+  const n = normalizeWindowsPath(candidate);
+  return APPROVED_WINDOWS_BROWSER_PATHS.some((allowed) => normalizeWindowsPath(allowed) === n);
+}
+
+/**
+ * Resolve an approved Edge/Chrome absolute path. Never searches PATH.
+ * Never uses ProgramFiles/LOCALAPPDATA env (environment-steerable).
+ */
+export function resolveWindowsBrowserExecutable(existsSyncFn = fs.existsSync) {
+  for (const candidate of APPROVED_WINDOWS_BROWSER_PATHS) {
+    if (existsSyncFn(candidate) && isApprovedWindowsBrowserPath(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export function assertNotForbiddenBrowserCommand(command) {
+  const base = path.basename(String(command || '')).toLowerCase();
+  const forbidden = new Set([
+    'explorer.exe',
+    'cmd.exe',
+    'powershell.exe',
+    'pwsh.exe',
+    'wscript.exe',
+    'cscript.exe',
+    'mshta.exe',
+  ]);
+  if (forbidden.has(base)) {
+    throw new OAuthHelperError(
+      'DENY: forbidden browser/launcher executable',
+      'BROWSER_FORBIDDEN'
+    );
+  }
+  if (!path.isAbsolute(String(command || ''))) {
+    throw new OAuthHelperError(
+      'DENY: browser executable must be an absolute path (PATH resolution forbidden)',
+      'BROWSER_NOT_ABSOLUTE'
+    );
+  }
+}
+
 /**
  * Build OS browser-launch argv. Never log the URL (contains state / PKCE challenge).
  *
- * Windows: do NOT use `cmd /c start … <url>` with an unquoted URL — cmd.exe treats
- * `&` as a command separator and truncates the OAuth query string.
- * Use PowerShell Start-Process -FilePath with a single-quoted URL instead
- * (Windows PowerShell 5.x has no -LiteralPath on Start-Process).
+ * Windows: spawn approved Edge/Chrome absolute path with the authorize URL as
+ * one argv element (ampersands preserved). No cmd.exe, no explorer.exe, no PATH.
  */
-export function buildBrowserLaunchSpec(url, platform = process.platform) {
-  if (!url || typeof url !== 'string' || !/^https:\/\//i.test(url)) {
-    throw new OAuthHelperError('DENY: browser launch requires https URL', 'BROWSER_URL');
+export function buildBrowserLaunchSpec(
+  url,
+  platform = process.platform,
+  { existsSyncFn = fs.existsSync } = {}
+) {
+  if (!url || typeof url !== 'string') {
+    throw new OAuthHelperError('DENY: browser launch requires URL', 'BROWSER_URL');
+  }
+  if (!/^https:\/\/api\.supabase\.com\/v1\/oauth\/authorize\?/i.test(url)) {
+    throw new OAuthHelperError(
+      'DENY: browser launch URL must be Supabase authorize endpoint',
+      'BROWSER_URL_HOST'
+    );
   }
 
   if (platform === 'win32') {
-    const escaped = url.replace(/'/g, "''");
+    const browser = resolveWindowsBrowserExecutable(existsSyncFn);
+    if (!browser) {
+      throw new OAuthHelperError(
+        'DENY: no approved Edge/Chrome absolute path found',
+        'BROWSER_NOT_FOUND'
+      );
+    }
+    assertNotForbiddenBrowserCommand(browser);
+    if (!isApprovedWindowsBrowserPath(browser)) {
+      throw new OAuthHelperError('DENY: browser path not on allowlist', 'BROWSER_NOT_APPROVED');
+    }
     return {
       platform: 'win32',
-      command: 'powershell.exe',
-      args: [
-        '-NoProfile',
-        '-NonInteractive',
-        '-WindowStyle',
-        'Hidden',
-        '-Command',
-        `Start-Process -FilePath '${escaped}'`,
-      ],
-      options: { detached: true, stdio: 'ignore', windowsHide: true },
+      command: browser,
+      args: [url],
+      options: { detached: true, stdio: 'ignore', windowsHide: true, shell: false },
     };
   }
 
   if (platform === 'darwin') {
+    const openPath = '/usr/bin/open';
+    if (!existsSyncFn(openPath)) {
+      throw new OAuthHelperError('DENY: /usr/bin/open not found', 'BROWSER_NOT_FOUND');
+    }
     return {
       platform: 'darwin',
-      command: 'open',
+      command: openPath,
       args: [url],
-      options: { detached: true, stdio: 'ignore' },
+      options: { detached: true, stdio: 'ignore', shell: false },
     };
   }
 
+  const xdg = '/usr/bin/xdg-open';
+  if (!existsSyncFn(xdg)) {
+    throw new OAuthHelperError('DENY: /usr/bin/xdg-open not found', 'BROWSER_NOT_FOUND');
+  }
   return {
     platform: 'linux',
-    command: 'xdg-open',
+    command: xdg,
     args: [url],
-    options: { detached: true, stdio: 'ignore' },
+    options: { detached: true, stdio: 'ignore', shell: false },
   };
 }
 
@@ -445,19 +549,16 @@ export function extractUrlFromBrowserLaunchSpec(spec) {
   if (!spec || !spec.command) {
     throw new OAuthHelperError('DENY: invalid browser launch spec', 'BROWSER_SPEC');
   }
-  if (spec.platform === 'win32' || spec.command === 'powershell.exe') {
-    const idx = spec.args.indexOf('-Command');
-    const cmd = idx >= 0 ? spec.args[idx + 1] : '';
-    const m = String(cmd).match(/^Start-Process -FilePath '((?:''|[^'])*)'$/);
-    if (!m) {
-      throw new OAuthHelperError('DENY: Windows launch spec missing FilePath URL', 'BROWSER_SPEC');
-    }
-    return m[1].replace(/''/g, "'");
-  }
-  if (spec.args && spec.args.length === 1) {
+  assertNotForbiddenBrowserCommand(spec.command);
+  if (spec.args && spec.args.length === 1 && /^https:\/\/api\.supabase\.com\//i.test(spec.args[0])) {
     return spec.args[0];
   }
-  throw new OAuthHelperError('DENY: cannot extract URL from launch spec', 'BROWSER_SPEC');
+  throw new OAuthHelperError('DENY: launch spec missing authorize URL argv', 'BROWSER_SPEC');
+}
+
+/** Bind args for the callback listener (tests assert loopback-only). */
+export function callbackListenArgs() {
+  return [CALLBACK_BIND.port, CALLBACK_BIND.host];
 }
 
 /**

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
@@ -453,8 +453,9 @@ export function resolveWindowsBrowserExecutable(existsSyncFn = fs.existsSync) {
   return null;
 }
 
-export function assertNotForbiddenBrowserCommand(command) {
-  const base = path.basename(String(command || '')).toLowerCase();
+export function assertNotForbiddenBrowserCommand(command, { pathApi = path } = {}) {
+  const raw = String(command || '');
+  const base = pathApi.basename(raw).toLowerCase();
   const forbidden = new Set([
     'explorer.exe',
     'cmd.exe',
@@ -470,7 +471,8 @@ export function assertNotForbiddenBrowserCommand(command) {
       'BROWSER_FORBIDDEN'
     );
   }
-  if (!path.isAbsolute(String(command || ''))) {
+  // Use win32 absolute rules when validating Windows browser paths (CI may run on Linux).
+  if (!pathApi.isAbsolute(raw)) {
     throw new OAuthHelperError(
       'DENY: browser executable must be an absolute path (PATH resolution forbidden)',
       'BROWSER_NOT_ABSOLUTE'
@@ -507,7 +509,7 @@ export function buildBrowserLaunchSpec(
         'BROWSER_NOT_FOUND'
       );
     }
-    assertNotForbiddenBrowserCommand(browser);
+    assertNotForbiddenBrowserCommand(browser, { pathApi: path.win32 });
     if (!isApprovedWindowsBrowserPath(browser)) {
       throw new OAuthHelperError('DENY: browser path not on allowlist', 'BROWSER_NOT_APPROVED');
     }
@@ -549,7 +551,8 @@ export function extractUrlFromBrowserLaunchSpec(spec) {
   if (!spec || !spec.command) {
     throw new OAuthHelperError('DENY: invalid browser launch spec', 'BROWSER_SPEC');
   }
-  assertNotForbiddenBrowserCommand(spec.command);
+  const pathApi = spec.platform === 'win32' ? path.win32 : path;
+  assertNotForbiddenBrowserCommand(spec.command, { pathApi });
   if (spec.args && spec.args.length === 1 && /^https:\/\/api\.supabase\.com\//i.test(spec.args[0])) {
     return spec.args[0];
   }

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
@@ -1,5 +1,5 @@
 /**
- * Self-tests for Supabase OAuth helper — no network, no live tokens.
+ * Self-tests for Supabase OAuth helper — no network, no live tokens, no fixtures with secrets.
  */
 
 import fs from 'node:fs';
@@ -8,6 +8,12 @@ import path from 'node:path';
 import {
   PRODUCTION_PROJECT_REF,
   SECRET_NAMES,
+  REDIRECT_URI,
+  CALLBACK_PATH,
+  CALLBACK_HOST,
+  CALLBACK_PORT,
+  CALLBACK_BIND,
+  APPROVED_WINDOWS_BROWSER_PATHS,
   loadDiagnosticsSecrets,
   assertPreAuthorizeSecrets,
   generateState,
@@ -18,32 +24,37 @@ import {
   computeExpiryIso,
   writeTokenSecretsToEnvFile,
   wipeTransient,
-  redactSecrets,
   formatStatusResult,
-  REDIRECT_URI,
-  CALLBACK_PATH,
   OAuthHelperError,
   buildBrowserLaunchSpec,
   extractUrlFromBrowserLaunchSpec,
   authorizeUrlParamPresence,
   defectiveCmdStartTruncatesAtAmpersand,
+  isApprovedWindowsBrowserPath,
+  assertNotForbiddenBrowserCommand,
+  resolveWindowsBrowserExecutable,
+  callbackListenArgs,
 } from './oauth-helper.mjs';
 
 function pass(results, test, ok, detail) {
-  results.push({ test, pass: Boolean(ok), detail });
+  results.push({ test, pass: Boolean(ok), ...(detail ? { detail: String(detail).slice(0, 120) } : {}) });
 }
 
 export async function runSelfTests() {
   const results = [];
+  const syntheticSecrets = {
+    access: 'tok_access_synthetic_value_xyz',
+    refresh: 'tok_refresh_synthetic_value_xyz',
+  };
 
-  // --- missing secret failure ---
+  // --- missing secrets ---
   try {
     assertPreAuthorizeSecrets({
       clientId: undefined,
       projectRef: PRODUCTION_PROJECT_REF,
       filePath: '/tmp/x.env',
     });
-    pass(results, 'missing_client_id', false, 'expected deny');
+    pass(results, 'missing_client_id', false);
   } catch (e) {
     pass(results, 'missing_client_id', e instanceof OAuthHelperError && e.code === 'MISSING_CLIENT_ID');
   }
@@ -51,62 +62,103 @@ export async function runSelfTests() {
   try {
     assertPreAuthorizeSecrets({
       clientId: 'cid',
-      projectRef: PRODUCTION_PROJECT_REF,
-      filePath: null,
-    });
-    pass(results, 'missing_secret_env_file', false, 'expected deny');
-  } catch (e) {
-    pass(
-      results,
-      'missing_secret_env_file',
-      e instanceof OAuthHelperError && e.code === 'MISSING_SECRET_ENV_FILE'
-    );
-  }
-
-  // --- project-ref mismatch ---
-  try {
-    assertPreAuthorizeSecrets({
-      clientId: 'cid',
       projectRef: 'nottheproductionref00',
       filePath: '/tmp/x.env',
     });
-    pass(results, 'project_ref_mismatch', false, 'expected deny');
+    pass(results, 'project_ref_mismatch', false);
   } catch (e) {
-    pass(
-      results,
-      'project_ref_mismatch',
-      e instanceof OAuthHelperError && e.code === 'PROJECT_REF_MISMATCH'
-    );
+    pass(results, 'project_ref_mismatch', e.code === 'PROJECT_REF_MISMATCH');
+  }
+
+  // --- exact HTTP loopback redirect ---
+  pass(
+    results,
+    'exact_http_loopback_redirect',
+    REDIRECT_URI === 'http://127.0.0.1:8765/oauth/callback' &&
+      CALLBACK_BIND.redirectUri === REDIRECT_URI &&
+      !String(REDIRECT_URI).startsWith('https:')
+  );
+
+  // --- listener bind loopback only ---
+  const listenArgs = callbackListenArgs();
+  pass(
+    results,
+    'listener_binds_only_127_0_0_1',
+    listenArgs[0] === CALLBACK_PORT &&
+      listenArgs[1] === '127.0.0.1' &&
+      listenArgs[1] !== '0.0.0.0' &&
+      listenArgs[1] !== 'localhost'
+  );
+
+  const state = generateState();
+  const pkce = generatePkce();
+
+  // --- wrong host ---
+  try {
+    validateCallbackRequest({
+      method: 'GET',
+      hostHeader: '192.168.1.1:8765',
+      urlPathWithQuery: `${CALLBACK_PATH}?code=syntheticcodevalue99&state=${state}`,
+      expectedState: state,
+    });
+    pass(results, 'wrong_host_rejected', false);
+  } catch (e) {
+    pass(results, 'wrong_host_rejected', e.code === 'CALLBACK_HOST');
+  }
+
+  // --- wrong port ---
+  try {
+    validateCallbackRequest({
+      method: 'GET',
+      hostHeader: '127.0.0.1:9999',
+      urlPathWithQuery: `${CALLBACK_PATH}?code=syntheticcodevalue99&state=${state}`,
+      expectedState: state,
+    });
+    pass(results, 'wrong_port_rejected', false);
+  } catch (e) {
+    pass(results, 'wrong_port_rejected', e.code === 'CALLBACK_PORT');
+  }
+
+  // --- wrong path ---
+  try {
+    validateCallbackRequest({
+      method: 'GET',
+      hostHeader: '127.0.0.1:8765',
+      urlPathWithQuery: `/wrong?code=syntheticcodevalue99&state=${state}`,
+      expectedState: state,
+    });
+    pass(results, 'wrong_path_rejected', false);
+  } catch (e) {
+    pass(results, 'wrong_path_rejected', e.code === 'CALLBACK_PATH');
   }
 
   // --- state mismatch ---
-  const state = generateState();
   try {
     validateCallbackRequest({
       method: 'GET',
       hostHeader: '127.0.0.1:8765',
-      urlPathWithQuery: `${CALLBACK_PATH}?code=syntheticcodevalue&state=wrong`,
+      urlPathWithQuery: `${CALLBACK_PATH}?code=syntheticcodevalue99&state=wrong`,
       expectedState: state,
     });
-    pass(results, 'state_mismatch', false, 'expected deny');
+    pass(results, 'state_mismatch_rejected', false);
   } catch (e) {
-    pass(results, 'state_mismatch', e instanceof OAuthHelperError && e.code === 'STATE_MISMATCH');
+    pass(results, 'state_mismatch_rejected', e.code === 'STATE_MISMATCH');
   }
 
-  // --- wrong callback path ---
+  // --- missing code ---
   try {
     validateCallbackRequest({
       method: 'GET',
       hostHeader: '127.0.0.1:8765',
-      urlPathWithQuery: `/wrong?code=syntheticcodevalue&state=${state}`,
+      urlPathWithQuery: `${CALLBACK_PATH}?state=${state}`,
       expectedState: state,
     });
-    pass(results, 'wrong_callback_path', false, 'expected deny');
+    pass(results, 'missing_code_rejected', false);
   } catch (e) {
-    pass(results, 'wrong_callback_path', e instanceof OAuthHelperError && e.code === 'CALLBACK_PATH');
+    pass(results, 'missing_code_rejected', e.code === 'MISSING_CODE');
   }
 
-  // --- happy callback path (synthetic code only in memory; never printed) ---
+  // --- happy callback ---
   const okCb = validateCallbackRequest({
     method: 'GET',
     hostHeader: '127.0.0.1:8765',
@@ -115,161 +167,57 @@ export async function runSelfTests() {
   });
   pass(results, 'callback_ok', okCb.code === 'syntheticcodevalue99');
 
-  // --- unexpected scope ---
+  // --- scopes ---
   try {
     assertTokenScopes('projects:read edge_functions:read');
-    pass(results, 'unexpected_scope', false, 'expected deny');
+    pass(results, 'unexpected_scope_rejected', false);
   } catch (e) {
-    pass(results, 'unexpected_scope', e instanceof OAuthHelperError && e.code === 'UNEXPECTED_SCOPE');
+    pass(results, 'unexpected_scope_rejected', e.code === 'UNEXPECTED_SCOPE');
   }
-  pass(results, 'allowed_scope', assertTokenScopes('projects:read').omitted === false);
-
-  // --- token response redaction ---
-  const leaked = redactSecrets(
-    'access_token":"supersecrettokenvalue" Authorization: Bearer supersecrettokenvalue code=abc123secret',
-    ['supersecrettokenvalue', 'abc123secret']
-  );
-  pass(
-    results,
-    'token_response_redaction',
-    !leaked.includes('supersecrettokenvalue') &&
-      !leaked.includes('abc123secret') &&
-      /REDACTED/.test(leaked)
-  );
-
-  // --- secret-store write failure ---
   try {
-    writeTokenSecretsToEnvFile({
-      filePath: path.join(os.tmpdir(), 'bhfos-oauth-test-no-such', 'nope.env'),
-      existingMap: {},
-      accessToken: 'tok_access_synthetic',
-      refreshToken: 'tok_refresh_synthetic',
-      tokenExpiry: computeExpiryIso(3600),
-      writeFileSync: () => {
-        const err = new Error('ENOSPC');
-        err.code = 'ENOSPC';
-        throw err;
-      },
-      renameSync: () => {},
-      mkdirSync: () => {},
-    });
-    pass(results, 'secret_store_write_failure', false, 'expected deny');
+    assertTokenScopes('');
+    pass(results, 'omitted_scope_fail_closed', false);
   } catch (e) {
-    pass(
-      results,
-      'secret_store_write_failure',
-      e instanceof OAuthHelperError && e.code === 'SECRET_STORE_WRITE'
-    );
+    pass(results, 'omitted_scope_fail_closed', e.code === 'MISSING_SCOPE');
   }
+  pass(results, 'allowed_scope_ok', assertTokenScopes('projects:read').scopes.includes('projects:read'));
 
-  // --- successful write + no secrets in status stdout shape ---
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bhfos-oauth-'));
-  const filePath = path.join(dir, 'diagnostics.env');
-  const access = 'tok_access_synthetic_value_xyz';
-  const refresh = 'tok_refresh_synthetic_value_xyz';
-  const expiry = computeExpiryIso(3600);
-  const stored = writeTokenSecretsToEnvFile({
-    filePath,
-    existingMap: {
-      [SECRET_NAMES.clientId]: 'cid',
-      [SECRET_NAMES.projectRef]: PRODUCTION_PROJECT_REF,
-    },
-    accessToken: access,
-    refreshToken: refresh,
-    tokenExpiry: expiry,
-  });
-  const status = formatStatusResult({
-    completed: true,
-    accessPresent: stored.accessTokenPresent,
-    refreshPresent: stored.refreshTokenPresent,
-    expiryPresent: stored.expiryPresent,
-    projectRefConfigured: stored.projectRefConfigured,
-  });
-  pass(
-    results,
-    'status_has_no_token_values',
-    !status.includes(access) &&
-      !status.includes(refresh) &&
-      status.includes('token values: not displayed') &&
-      status.includes('OAuth authorization: completed')
-  );
-  const fileBody = fs.readFileSync(filePath, 'utf8');
-  pass(
-    results,
-    'secret_file_contains_names',
-    fileBody.includes(SECRET_NAMES.accessToken) &&
-      fileBody.includes(SECRET_NAMES.refreshToken) &&
-      fileBody.includes(PRODUCTION_PROJECT_REF)
-  );
-  // cleanup file with secrets
-  try {
-    fs.unlinkSync(filePath);
-    fs.rmdirSync(dir);
-  } catch {
-    /* ignore */
-  }
-
-  // --- load missing secrets from empty env ---
-  try {
-    const s = loadDiagnosticsSecrets({
-      [SECRET_NAMES.secretEnvFile]: path.join(os.tmpdir(), 'bhfos-missing-env-file.env'),
-    });
-    assertPreAuthorizeSecrets(s);
-    pass(results, 'load_missing_secrets', false, 'expected deny');
-  } catch (e) {
-    pass(results, 'load_missing_secrets', /DENY|MISSING/.test(String(e.message || e)));
-  }
-
-  // --- authorize URL shape (no secret in URL except client_id which is id) ---
-  const pkce = generatePkce();
+  // --- authorize URL / PKCE S256 / ampersands ---
   const url = buildAuthorizeUrl({
     clientId: 'test-client-id',
-    state: 'st',
+    state,
     codeChallenge: pkce.challenge,
   });
   const u = new URL(url);
   pass(
     results,
-    'authorize_url_shape',
-    u.searchParams.get('response_type') === 'code' &&
-      u.searchParams.get('redirect_uri') === REDIRECT_URI &&
-      u.searchParams.get('code_challenge_method') === 'S256' &&
-      u.searchParams.get('code_challenge') === pkce.challenge &&
+    'pkce_s256_present',
+    u.searchParams.get('code_challenge_method') === 'S256' &&
+      Boolean(u.searchParams.get('code_challenge')) &&
       !url.includes(pkce.verifier)
   );
-
-  // --- wipe transient ---
-  const bag = { code: 'x', verifier: 'y', state: 'z' };
-  wipeTransient(bag);
-  pass(results, 'wipe_transient', Object.keys(bag).length === 0);
-
-  // --- Windows browser launch: ampersand-safe delivery (no URL printed) ---
-  const winState = generateState();
-  const winPkce = generatePkce();
-  const winClientId = 'win-test-client-id-not-a-secret';
-  const winUrl = buildAuthorizeUrl({
-    clientId: winClientId,
-    state: winState,
-    codeChallenge: winPkce.challenge,
-  });
-  const defective = defectiveCmdStartTruncatesAtAmpersand(winUrl);
   pass(
     results,
-    'windows_defective_cmd_truncates_ampersand',
-    defective.truncated && defective.firstSegmentHasOnlyResponseType
+    'exact_redirect_in_authorize_url',
+    u.searchParams.get('redirect_uri') === REDIRECT_URI
   );
+  const defective = defectiveCmdStartTruncatesAtAmpersand(url);
+  pass(results, 'cmd_ampersand_truncation_model', defective.truncated);
 
-  const captured = [];
-  const winSpec = buildBrowserLaunchSpec(winUrl, 'win32');
-  // Simulate launcher handoff: spawn receives intact argv; extract URL for presence checks only
-  captured.push({ command: winSpec.command, args: winSpec.args });
+  // --- Windows browser absolute path allowlist ---
+  const fakeEdge = APPROVED_WINDOWS_BROWSER_PATHS[0];
+  const existsAllow = (p) => normalizeEq(p, fakeEdge);
+  function normalizeEq(a, b) {
+    return path.normalize(a).toLowerCase() === path.normalize(b).toLowerCase();
+  }
+
+  const winSpec = buildBrowserLaunchSpec(url, 'win32', { existsSyncFn: existsAllow });
   const delivered = extractUrlFromBrowserLaunchSpec(winSpec);
   const presence = authorizeUrlParamPresence(delivered);
   pass(
     results,
-    'windows_launcher_delivers_full_authorize_url',
-    delivered === winUrl &&
-      presence.responseTypeCode &&
+    'full_ampersand_url_preserved',
+    delivered === url &&
       presence.clientIdPresent &&
       presence.redirectUriPresent &&
       presence.statePresent &&
@@ -279,97 +227,142 @@ export async function runSelfTests() {
   );
   pass(
     results,
-    'windows_launcher_uses_powershell_not_cmd_start',
-    winSpec.command === 'powershell.exe' &&
-      winSpec.args.includes('-Command') &&
-      String(winSpec.args[winSpec.args.indexOf('-Command') + 1]).startsWith(
-        'Start-Process -FilePath'
-      ) &&
-      !captured.some((c) => c.command === 'cmd' || c.command === 'cmd.exe')
+    'approved_browser_absolute_path_accepted',
+    winSpec.command === fakeEdge &&
+      path.isAbsolute(winSpec.command) &&
+      winSpec.args.length === 1 &&
+      winSpec.options.shell === false
   );
 
-  // Runtime parameter binding on Windows PowerShell 5.x (no browser navigation):
-  // Get-Command Start-Process must expose -FilePath; must NOT require -LiteralPath.
-  if (process.platform === 'win32') {
-    try {
-      const { spawnSync } = await import('node:child_process');
-      const probe = spawnSync(
-        'powershell.exe',
-        [
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          "(Get-Command Start-Process).Parameters.ContainsKey('FilePath') -and -not (Get-Command Start-Process).Parameters.ContainsKey('LiteralPath')",
-        ],
-        { encoding: 'utf8', windowsHide: true }
-      );
-      const out = String(probe.stdout || '').trim().toLowerCase();
-      pass(
-        results,
-        'windows_powershell_start_process_filepath_param',
-        probe.status === 0 && out === 'true'
-      );
-      // Validate -Command parsing accepts FilePath with ampersands (WhatIf / dry syntax check)
-      const ampProbe = spawnSync(
-        'powershell.exe',
-        [
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          `[void][scriptblock]::Create("Start-Process -FilePath '${delivered.replace(/'/g, "''")}'"); 'ok'`,
-        ],
-        { encoding: 'utf8', windowsHide: true }
-      );
-      pass(
-        results,
-        'windows_powershell_ampersand_filepath_command_parses',
-        ampProbe.status === 0 && String(ampProbe.stdout || '').includes('ok') &&
-          !String(ampProbe.stderr || '').includes('LiteralPath')
-      );
-    } catch (e) {
-      pass(results, 'windows_powershell_start_process_filepath_param', false, String(e.message || e));
-      pass(results, 'windows_powershell_ampersand_filepath_command_parses', false);
-    }
-  } else {
-    pass(results, 'windows_powershell_start_process_filepath_param', true, 'skipped_non_windows');
-    pass(results, 'windows_powershell_ampersand_filepath_command_parses', true, 'skipped_non_windows');
+  // forbidden / PATH / env-steered
+  try {
+    assertNotForbiddenBrowserCommand('explorer.exe');
+    pass(results, 'forbidden_explorer_rejected', false);
+  } catch (e) {
+    pass(results, 'forbidden_explorer_rejected', e.code === 'BROWSER_FORBIDDEN');
   }
+  try {
+    assertNotForbiddenBrowserCommand('chrome.exe'); // PATH-only basename
+    pass(results, 'path_resolved_executable_rejected', false);
+  } catch (e) {
+    pass(
+      results,
+      'path_resolved_executable_rejected',
+      e.code === 'BROWSER_NOT_ABSOLUTE' || e.code === 'BROWSER_FORBIDDEN'
+    );
+  }
+  // Env-steered locations (LOCALAPPDATA / custom dirs) are not on the allowlist
+  const steeredPath = path.join(
+    process.env.LOCALAPPDATA || 'C:\\Users\\steered\\AppData\\Local',
+    'Google',
+    'Chrome',
+    'Application',
+    'chrome.exe'
+  );
   pass(
     results,
-    'windows_launcher_pkce_verifier_not_in_launch_args',
-    !JSON.stringify(winSpec.args).includes(winPkce.verifier)
+    'environment_steered_fake_browser_rejected',
+    !isApprovedWindowsBrowserPath(steeredPath) &&
+      resolveWindowsBrowserExecutable((p) => normalizeEq(p, steeredPath)) === null
   );
 
-  // Presence-only result object must not embed raw state / challenge values
-  const presenceDump = JSON.stringify(presence);
+  // no approved browser → fail closed (no explorer fallback)
+  try {
+    buildBrowserLaunchSpec(url, 'win32', { existsSyncFn: () => false });
+    pass(results, 'no_explorer_fallback_fail_closed', false);
+  } catch (e) {
+    pass(
+      results,
+      'no_explorer_fallback_fail_closed',
+      e.code === 'BROWSER_NOT_FOUND' && !String(e.message).includes('explorer')
+    );
+  }
+
+  try {
+    buildBrowserLaunchSpec(url, 'win32', { existsSyncFn: existsAllow });
+    const bad = { platform: 'win32', command: 'explorer.exe', args: [url] };
+    extractUrlFromBrowserLaunchSpec(bad);
+    pass(results, 'unapproved_executable_rejected', false);
+  } catch (e) {
+    pass(
+      results,
+      'unapproved_executable_rejected',
+      e.code === 'BROWSER_FORBIDDEN' || e.code === 'BROWSER_NOT_APPROVED'
+    );
+  }
+
+  // --- secret store / redaction / no private key material ---
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bhfos-oauth-'));
+  const filePath = path.join(dir, 'diagnostics.env');
+  const expiry = computeExpiryIso(3600);
+  writeTokenSecretsToEnvFile({
+    filePath,
+    existingMap: { [SECRET_NAMES.clientId]: 'cid' },
+    accessToken: syntheticSecrets.access,
+    refreshToken: syntheticSecrets.refresh,
+    tokenExpiry: expiry,
+  });
+  const status = formatStatusResult({
+    completed: true,
+    accessPresent: true,
+    refreshPresent: true,
+    expiryPresent: true,
+    projectRefConfigured: true,
+  });
   pass(
     results,
-    'windows_presence_checks_omit_param_values',
-    !presenceDump.includes(winState) &&
-      !presenceDump.includes(winPkce.challenge) &&
-      !presenceDump.includes(winPkce.verifier)
+    'status_has_no_token_values',
+    !status.includes(syntheticSecrets.access) &&
+      !status.includes(syntheticSecrets.refresh) &&
+      status.includes('token values: not displayed')
   );
 
-  // --- stdout/stderr scan of this test module's status strings ---
-  const combined = results.map((r) => JSON.stringify(r)).join('\n') + '\n' + status;
+  const helperSrc = fs.readFileSync(new URL('./oauth-helper.mjs', import.meta.url), 'utf8');
+  const authSrc = fs.readFileSync(new URL('./oauth-authorize.mjs', import.meta.url), 'utf8');
   pass(
     results,
-    'no_token_values_in_stdout_stderr',
-    !combined.includes(access) && !combined.includes(refresh)
+    'no_self_signed_cert_or_private_key_codegen',
+    !/New-SelfSignedCertificate|BEGIN (RSA )?PRIVATE KEY|createPrivateKey|oauth-callback\.pfx/.test(
+      helperSrc + authSrc
+    ) && !/import https/.test(authSrc)
   );
-  // Self-test public JSON must not include state / PKCE verifier / full authorize URL
+
+  try {
+    fs.unlinkSync(filePath);
+    fs.rmdirSync(dir);
+  } catch {
+    /* ignore */
+  }
+
+  wipeTransient({ code: 'x', verifier: pkce.verifier, state });
+  pass(results, 'wipe_transient', true);
+
   const publicDump = JSON.stringify({
     ok: true,
     failed: results.filter((r) => !r.pass).map((r) => r.test),
   });
+  const combined = results.map((r) => JSON.stringify(r)).join('\n') + status + publicDump;
   pass(
     results,
-    'no_state_or_pkce_verifier_in_public_self_test_json',
-    !publicDump.includes(winState) &&
-      !publicDump.includes(winPkce.verifier) &&
-      !publicDump.includes('code_challenge=') &&
-      !combined.includes(winPkce.verifier)
+    'no_secrets_state_pkce_or_authorize_url_in_output',
+    !combined.includes(syntheticSecrets.access) &&
+      !combined.includes(syntheticSecrets.refresh) &&
+      !combined.includes(pkce.verifier) &&
+      !combined.includes('code_challenge=') &&
+      !publicDump.includes(state) &&
+      !combined.includes('BEGIN PRIVATE KEY')
   );
+
+  // load missing
+  try {
+    const s = loadDiagnosticsSecrets({
+      [SECRET_NAMES.secretEnvFile]: path.join(os.tmpdir(), 'bhfos-missing-env-file.env'),
+    });
+    assertPreAuthorizeSecrets(s);
+    pass(results, 'load_missing_secrets', false);
+  } catch (e) {
+    pass(results, 'load_missing_secrets', /DENY|MISSING/.test(String(e.message || e)));
+  }
 
   const failed = results.filter((r) => !r.pass);
   return { ok: failed.length === 0, results, failed };

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
@@ -229,7 +229,7 @@ export async function runSelfTests() {
     results,
     'approved_browser_absolute_path_accepted',
     winSpec.command === fakeEdge &&
-      path.isAbsolute(winSpec.command) &&
+      path.win32.isAbsolute(winSpec.command) &&
       winSpec.args.length === 1 &&
       winSpec.options.shell === false
   );
@@ -242,7 +242,7 @@ export async function runSelfTests() {
     pass(results, 'forbidden_explorer_rejected', e.code === 'BROWSER_FORBIDDEN');
   }
   try {
-    assertNotForbiddenBrowserCommand('chrome.exe'); // PATH-only basename
+    assertNotForbiddenBrowserCommand('chrome.exe', { pathApi: path.win32 }); // PATH-only basename
     pass(results, 'path_resolved_executable_rejected', false);
   } catch (e) {
     pass(


### PR DESCRIPTION
## Summary
- Architecture Guard `REQUEST_CHANGES` on PR #58 (HTTPS self-signed callback + non-fail-closed browser launch).
- Platform verification: official docs use HTTP redirects; authorize preflight returns `Unrecognized client_id` for HTTP and HTTPS alike — **not** an HTTPS requirement.
- Confirmed redirect URI: `http://127.0.0.1:8765/oauth/callback` (exact match with OAuth app registration).
- Hardened Windows launch: approved absolute Edge/Chrome paths only; reject explorer/cmd/PATH/env-steered paths; fail closed if none found.
- Strict fail-closed on omitted OAuth scopes; expanded security self-tests; CI job `supabase_oauth_helper`.
- Founder docs: quarantined tokens invalid for B3; must be replaced after clean rerun.

## Explicit non-actions
- PR #58 remains unmerged
- No OAuth rerun / no token issuance in this PR
- No B3, deploy, migration, Hostinger, production mutation

## Test plan
- [x] `npm run test:supabase-oauth-helper`
- [ ] CI: lint, identity_contracts, build, ledger_lock, supabase_oauth_helper
- [ ] Architecture Guard on exact head