### PR TITLE
fix(ops): Cloudflare Named Tunnel HTTPS OAuth callback (G2.3B-B2D Option B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Supabase OAuth helper self-tests
         run: npm run test:supabase-oauth-helper
 
+      - name: Supabase OAuth tunnel self-tests
+        run: npm run test:supabase-oauth-tunnel
+
   founder_run_readiness:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Supabase OAuth tunnel self-tests
         run: npm run test:supabase-oauth-tunnel
 
+      - name: Supabase OAuth launcher preflight self-tests
+        run: npm run test:supabase-oauth-launcher-preflight
+
   founder_run_readiness:
     runs-on: ubuntu-latest
     defaults:

--- a/command-center/docs/governance/ENVIRONMENT_ACCEPTANCE.md
+++ b/command-center/docs/governance/ENVIRONMENT_ACCEPTANCE.md
@@ -22,30 +22,54 @@ Require ENVIRONMENT_ACCEPTANCE when work depends on any of:
 - external platform behavior
 - shell quoting or escaping
 - operating-system-specific executable discovery
+- HTTPS tunnel / Named Tunnel lifecycle
 
 Unit tests alone are **not** sufficient for these classes. The acceptance test
 must cover the **complete path** relevant to the Founder action. Mocks or
 non-production fixtures are allowed when live authorization is not permitted,
 but the test must exercise platform-specific integration.
 
-## OAuth-style minimum path
+## OAuth-style minimum path (G2.3B-B2D Option B HTTPS tunnel)
 
-For an OAuth-style Founder action, the minimum acceptance path is:
+For an OAuth-style Founder action under the Cloudflare Named Tunnel design, the
+minimum acceptance path is:
 
 1. protected launcher
 2. SHA verification
 3. clean-worktree verification
-4. secret-store discovery
-5. secret-name presence check
-6. browser executable validation
-7. authorize URL construction
-8. callback listener startup
-9. callback URI contract
-10. safe output
-11. token-store destination
+4. secret-store discovery (`I2_DIAGNOSTICS_SECRET_ENV_FILE` outside repo)
+5. secret-name presence check (values not displayed)
+6. browser executable validation (approved absolute paths)
+7. authorize URL construction with public HTTPS redirect
+   (`https://oauth-diagnostics.bhfos.com/oauth/callback`)
+8. callback listener startup (`http://127.0.0.1:8765/oauth/callback`)
+9. callback URI contract (public HTTPS redirect split from local HTTP listener)
+10. tunnel executable present (approved absolute path / pinned)
+11. tunnel credentials path outside repository (presence only)
+12. named tunnel id configured (`I2_CLOUDFLARE_TUNNEL_ID`)
+13. path-only forward contract (`/oauth/callback` only + catch-all deny)
+14. Host rewrite to `127.0.0.1:8765` attested
+15. tunnel start gated on `FOUNDER_RUN_READY`
+16. tunnel health / public callback path probe (no query strings logged)
+17. tunnel stop after every authorize attempt (success or failure)
+18. public callback closure verification after stop
+19. safe output (no codes / state / PKCE / secrets / tokens)
+20. token-store destination (approved external Diagnostics env file only)
 
 Record the acceptance run command and exit status in the FOUNDER_RUN_READINESS
 packet (fields 15–16). Do not ask the Founder to execute until that path passes.
+
+### Acceptance commands (Diagnostics worktree)
+
+```bash
+cd command-center
+npm run test:supabase-oauth-helper
+npm run test:supabase-oauth-tunnel
+npm run test:founder-run-readiness
+```
+
+Live Cloudflare is not required for CI or unit acceptance. Live tunnel health
+and closure probes run only under a `FOUNDER_RUN_READY` Founder authorize session.
 
 ## Evidence rules
 
@@ -53,3 +77,4 @@ packet (fields 15–16). Do not ask the Founder to execute until that path passe
 - ENVIRONMENT_ACCEPTANCE proves platform-path readiness, **not** governance
   acceptance of residual risk and **not** production USABLE.
 - Never display secret values in acceptance output.
+- Tunnel credentials must never enter the repository.

--- a/command-center/docs/governance/ENVIRONMENT_ACCEPTANCE.md
+++ b/command-center/docs/governance/ENVIRONMENT_ACCEPTANCE.md
@@ -35,26 +35,25 @@ For an OAuth-style Founder action under the Cloudflare Named Tunnel design, the
 minimum acceptance path is:
 
 1. protected launcher
-2. SHA verification
-3. clean-worktree verification
-4. secret-store discovery (`I2_DIAGNOSTICS_SECRET_ENV_FILE` outside repo)
-5. secret-name presence check (values not displayed)
-6. browser executable validation (approved absolute paths)
-7. authorize URL construction with public HTTPS redirect
-   (`https://oauth-diagnostics.bhfos.com/oauth/callback`)
-8. callback listener startup (`http://127.0.0.1:8765/oauth/callback`)
-9. callback URI contract (public HTTPS redirect split from local HTTP listener)
-10. tunnel executable present (approved absolute path / pinned)
-11. tunnel credentials path outside repository (presence only)
-12. named tunnel id configured (`I2_CLOUDFLARE_TUNNEL_ID`)
-13. path-only forward contract (`/oauth/callback` only + catch-all deny)
-14. Host rewrite to `127.0.0.1:8765` attested
-15. tunnel start gated on `FOUNDER_RUN_READY`
-16. tunnel health / public callback path probe (no query strings logged)
-17. tunnel stop after every authorize attempt (success or failure)
-18. public callback closure verification after stop
-19. safe output (no codes / state / PKCE / secrets / tokens)
-20. token-store destination (approved external Diagnostics env file only)
+2. exact SHA verification
+3. clean worktree verification
+4. external secret store (`I2_DIAGNOSTICS_SECRET_ENV_FILE` outside repo)
+5. browser (approved absolute Edge/Chrome path)
+6. public HTTPS redirect URI (`https://oauth-diagnostics.bhfos.com/oauth/callback`)
+7. named tunnel (Cloudflare Named Tunnel; stable FQDN only)
+8. path-only routing (`/oauth/callback` only + catch-all deny + Host rewrite)
+9. local callback (`http://127.0.0.1:8765/oauth/callback`)
+10. state validation (single-use)
+11. PKCE validation (S256)
+12. local code exchange
+13. external token-store write (Diagnostics env file only; values not displayed)
+14. tunnel shutdown after every authorize attempt
+15. public callback closure verification
+16. post-run governance status (safe status lines only)
+
+Supporting checks on the same path: secret-name presence (values not displayed),
+tunnel executable/config/credential presence outside the repository, local port
+availability, and `FOUNDER_RUN_READY` gate before tunnel start.
 
 Record the acceptance run command and exit status in the FOUNDER_RUN_READINESS
 packet (fields 15–16). Do not ask the Founder to execute until that path passes.
@@ -65,6 +64,7 @@ packet (fields 15–16). Do not ask the Founder to execute until that path passe
 cd command-center
 npm run test:supabase-oauth-helper
 npm run test:supabase-oauth-tunnel
+npm run test:supabase-oauth-launcher-preflight
 npm run test:founder-run-readiness
 ```
 

--- a/command-center/docs/governance/FOUNDER_RUN_READINESS.md
+++ b/command-center/docs/governance/FOUNDER_RUN_READINESS.md
@@ -61,6 +61,35 @@ Run FOUNDER_RUN_READINESS before asking the Founder to:
 | 18 | Expected safe output | Declarative (must be non-empty) |
 | 19 | Explicit stop conditions | Declarative (must be non-empty) |
 | 20 | One exact Founder command or action | Declarative (exactly one) |
+| 21 | Tunnel required + class is Cloudflare Named Tunnel (when OAuth tunnel packet) | Yes (when `tunnel.required`) |
+| 22 | Stable public hostname pinned exactly | Yes (when `tunnel.required`) |
+| 23 | Public HTTPS redirect URI matches helper contract exactly | Yes (when `tunnel.required`) |
+| 24 | Tunnel credentials path exists outside the repository | Yes (when `tunnel.required`) |
+| 25 | Path-only forward + catch-all deny attested | Yes (when `tunnel.required`) |
+| 26 | Tunnel stop-after-run + public callback closure procedure present | Yes (when `tunnel.required`) |
+
+### OAuth tunnel packet contract (G2.3B-B2D Option B)
+
+When authorizing Diagnostics Supabase OAuth under Option B, set:
+
+```json
+"callback_or_redirect_expected": "https://oauth-diagnostics.bhfos.com/oauth/callback",
+"callback_or_redirect_actual": "https://oauth-diagnostics.bhfos.com/oauth/callback",
+"required_local_port": 8765,
+"tunnel": {
+  "required": true,
+  "class": "cloudflare_named",
+  "stable_hostname": "oauth-diagnostics.bhfos.com",
+  "public_redirect_uri": "https://oauth-diagnostics.bhfos.com/oauth/callback",
+  "local_listener_uri": "http://127.0.0.1:8765/oauth/callback",
+  "credentials_path": "%LOCALAPPDATA%/BHFOS/production-diagnostics/tunnel/<credentials>.json",
+  "path_only_config_attested": true,
+  "stop_after_run_and_closure_procedure_present": true
+}
+```
+
+Do **not** ask the Founder to run OAuth until the packet evaluates to exactly
+`FOUNDER_RUN_READY`. Tunnel credentials never enter the repository.
 
 ## Machine tool
 

--- a/command-center/docs/governance/FOUNDER_RUN_READINESS.md
+++ b/command-center/docs/governance/FOUNDER_RUN_READINESS.md
@@ -62,11 +62,17 @@ Run FOUNDER_RUN_READINESS before asking the Founder to:
 | 19 | Explicit stop conditions | Declarative (must be non-empty) |
 | 20 | One exact Founder command or action | Declarative (exactly one) |
 | 21 | Tunnel required + class is Cloudflare Named Tunnel (when OAuth tunnel packet) | Yes (when `tunnel.required`) |
-| 22 | Stable public hostname pinned exactly | Yes (when `tunnel.required`) |
+| 22 | Stable public hostname / FQDN pinned exactly | Yes (when `tunnel.required`) |
 | 23 | Public HTTPS redirect URI matches helper contract exactly | Yes (when `tunnel.required`) |
 | 24 | Tunnel credentials path exists outside the repository | Yes (when `tunnel.required`) |
-| 25 | Path-only forward + catch-all deny attested | Yes (when `tunnel.required`) |
-| 26 | Tunnel stop-after-run + public callback closure procedure present | Yes (when `tunnel.required`) |
+| 25 | Path-only forward contract attested | Yes (when `tunnel.required`) |
+| 26 | Catch-all deny attested | Yes (when `tunnel.required`) |
+| 27 | Tunnel stop-after-run + public callback closure procedure present | Yes (when `tunnel.required`) |
+| 28 | Tunnel executable present (absolute path) | Yes (when `tunnel.required`) |
+| 29 | Tunnel configuration present outside repo | Yes (when `tunnel.required`) |
+| 30 | Tunnel start / stop / closure verification commands present | Yes (when `tunnel.required`) |
+| 31 | Local listener remains loopback-only (`127.0.0.1`) | Yes (when `tunnel.required`) |
+| 32 | No random or quick-tunnel hostname | Yes (when `tunnel.required`) |
 
 ### OAuth tunnel packet contract (G2.3B-B2D Option B)
 
@@ -83,10 +89,19 @@ When authorizing Diagnostics Supabase OAuth under Option B, set:
   "public_redirect_uri": "https://oauth-diagnostics.bhfos.com/oauth/callback",
   "local_listener_uri": "http://127.0.0.1:8765/oauth/callback",
   "credentials_path": "%LOCALAPPDATA%/BHFOS/production-diagnostics/tunnel/<credentials>.json",
+  "executable_path": "C:/Program Files/cloudflared/cloudflared.exe",
+  "config_path": "%LOCALAPPDATA%/BHFOS/production-diagnostics/tunnel/oauth-tunnel-config.yml",
   "path_only_config_attested": true,
+  "catch_all_deny_attested": true,
+  "start_command": "cloudflared tunnel --config <outside-repo-config> run",
+  "stop_command": "helper stop() / SIGTERM cloudflared",
+  "closure_verification_command": "GET public callback must fail closed after stop",
   "stop_after_run_and_closure_procedure_present": true
 }
 ```
+
+Architecture Guard approval (`architecture_guard_approval`) must apply to the
+**exact execution design head SHA** (field 17). No in-repo tunnel credentials.
 
 Do **not** ask the Founder to run OAuth until the packet evaluates to exactly
 `FOUNDER_RUN_READY`. Tunnel credentials never enter the repository.

--- a/command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md
+++ b/command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md
@@ -88,11 +88,13 @@ Production Diagnostics worktree at the approved merge SHA:
 ```bash
 cd command-center
 set I2_FOUNDER_RUN_READINESS_VERDICT=FOUNDER_RUN_READY
+set I2_OAUTH_EXPECTED_SHA=<exact approved merge SHA>
 node tools/supabase-diagnostics-adapter/oauth-authorize.mjs
 ```
 
 The helper will:
 
+- verify exact SHA + clean worktree + external secret store + tunnel assets + port
 - start the Named Tunnel
 - bind **only** `127.0.0.1:8765` (plain HTTP local listener)
 - open Edge/Chrome via an approved absolute path (URL as one argv; no explorer/cmd/PATH)

--- a/command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md
+++ b/command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md
@@ -1,6 +1,7 @@
-# Exact Supabase OAuth App creation — G2.3B-B2D Option A (Founder UI)
+# Exact Supabase OAuth App creation — G2.3B-B2D Option B (Founder UI)
 
-> Binding ceiling from Founder **G2.3B-B2D Option A** authorization.
+> Binding ceiling from Founder **G2.3B-B2D Option B** authorization
+> (Cloudflare Named Tunnel → loopback helper).
 > **No secret values** belong in this file, chat, repository files, Cursor, or
 > terminal command history.
 >
@@ -9,19 +10,25 @@
 
 **Authorized scope only:** Dashboard **Projects** → **Read** (wire `projects:read`).  
 **Project ref (adapter lock):** `wwyxohjnyqnegzbxtuxs`  
-**Redirect URI (exact):** `http://127.0.0.1:8765/oauth/callback`
+**Public redirect URI (exact):** `https://oauth-diagnostics.bhfos.com/oauth/callback`  
+**Local listener (helper bind only):** `http://127.0.0.1:8765/oauth/callback`  
+**Tunnel class:** Cloudflare Named Tunnel (stable hostname only; no random/temporary hostnames)
 
 ---
 
 ## Quarantined tokens (binding)
 
 Any OAuth access/refresh tokens issued during failed or non-clean attempts
-(including pre-HTTP-harden / HTTPS-callback experiments) are **quarantined**:
+(including HTTP-loopback rejection, PR #58 self-signed HTTPS experiments, and
+pre-tunnel runs) are **quarantined**:
 
 - **Invalid for B3** and for any live Diagnostics campaign
-- Must be **replaced** by a clean helper rerun after this HTTP + hardened launcher
-  correction is on the Diagnostics worktree
+- Must be **replaced** by a clean helper rerun after this Option B tunnel design
+  is merged and `FOUNDER_RUN_READY` is issued
 - Do **not** reuse quarantined token values
+
+PR #58 (self-signed `https://127.0.0.1` callback) is **superseded** and must not
+be merged as the tunnel baseline.
 
 ---
 
@@ -31,19 +38,19 @@ Any OAuth access/refresh tokens issued during failed or non-clean attempts
 2. Open that project’s **organization** → **Organization Settings → OAuth Apps**.
 3. Create or edit **`BHFOS I2 Diagnostics`**.
 4. Set:
-   - **Redirect URI (exact):** `http://127.0.0.1:8765/oauth/callback`
+   - **Redirect URI (exact):** `https://oauth-diagnostics.bhfos.com/oauth/callback`
    - **Scopes:** **Projects → Read** only (nothing else)
 5. Confirm / save.
 
-Do **not** register an HTTPS loopback redirect. Do **not** use `localhost` unless
-you intentionally change both the app and the helper together (helper uses
-`127.0.0.1` only).
+Do **not** register HTTP loopback, self-signed HTTPS loopback, `localhost`, or
+any random/temporary tunnel hostname.
 
 ---
 
 ## B. Place Client ID / secret in Diagnostics secret store only
 
-1. Create or open the Diagnostics durable env file (gitignored; outside chat/repo).
+1. Create or open the Diagnostics durable env file (gitignored; outside chat/repo):
+   `%LOCALAPPDATA%\BHFOS\production-diagnostics\diagnostics.env`
 2. Set `I2_DIAGNOSTICS_SECRET_ENV_FILE` to that file’s absolute path (Diagnostics shell only).
 3. Put into that file (values never pasted into chat/Cursor/repo/history):
    - `I2_SUPABASE_OAUTH_CLIENT_ID`
@@ -52,37 +59,62 @@ you intentionally change both the app and the helper together (helper uses
 
 ---
 
-## C. Run the protected helper only (one command)
+## C. Place Named Tunnel credentials outside the repository
 
-Use **only** the protected launcher from an updated Production Diagnostics worktree
-(HTTP callback + approved Edge/Chrome absolute path launch). Do not use ad-hoc
-scripts, browser address-bar OAuth, or quarantined tokens.
+1. Create the Founder-owned Cloudflare Named Tunnel for hostname
+   `oauth-diagnostics.bhfos.com` (Founder DNS / Cloudflare account).
+2. Store tunnel credentials **outside the repo**, e.g.
+   `%LOCALAPPDATA%\BHFOS\production-diagnostics\tunnel\<credentials>.json`
+3. In the Diagnostics shell only, set:
+   - `I2_CLOUDFLARE_TUNNEL_CREDENTIALS_FILE` → absolute path to that file
+   - `I2_CLOUDFLARE_TUNNEL_ID` → named tunnel id
+   - `I2_CLOUDFLARED_EXECUTABLE` → absolute path to `cloudflared` (optional if
+     installed at an approved default absolute path)
+
+Tunnel credentials must never be committed, pasted into chat, or stored under
+the repository tree.
+
+Ingress must forward **only** `/oauth/callback` to
+`http://127.0.0.1:8765`, rewrite Host to `127.0.0.1:8765`, and catch-all deny
+all other paths.
+
+---
+
+## D. Run only after FOUNDER_RUN_READY (one protected command)
+
+Orchestrator must produce `FOUNDER_RUN_READY` first. Then, from an updated
+Production Diagnostics worktree at the approved merge SHA:
 
 ```bash
 cd command-center
+set I2_FOUNDER_RUN_READINESS_VERDICT=FOUNDER_RUN_READY
 node tools/supabase-diagnostics-adapter/oauth-authorize.mjs
 ```
 
 The helper will:
 
-- bind **only** `127.0.0.1:8765` (plain HTTP)
+- start the Named Tunnel
+- bind **only** `127.0.0.1:8765` (plain HTTP local listener)
 - open Edge/Chrome via an approved absolute path (URL as one argv; no explorer/cmd/PATH)
-- exchange the code with PKCE
+- exchange the code with PKCE locally
 - write access/refresh/expiry into the Diagnostics secret env file
+- stop the tunnel and verify public callback closure
 - print **names/status only**
 
 ---
 
-## D. Approve the browser consent screen
+## E. Approve the browser consent screen
 
 Approve as the Founder for the organization that owns `wwyxohjnyqnegzbxtuxs`.
-Confirm status includes `OAuth authorization: completed` and
-`token values: not displayed`.
+Confirm status includes `OAuth authorization: completed`,
+`token values: not displayed`, `tunnel stopped: yes`, and
+`public callback closed: yes`.
 
 ---
 
-## E. Explicit non-actions
+## F. Explicit non-actions
 
-Do **not**: grant other OAuth scopes; use HTTPS self-signed callbacks; paste
-secrets into Cursor/chat/repo/history; reuse quarantined tokens; start B3; use
-PAT / Dashboard Read-Only / service-role; provision Hostinger.
+Do **not**: grant other OAuth scopes; use HTTPS self-signed callbacks; reuse or
+merge PR #58; paste secrets/tunnel credentials into Cursor/chat/repo/history;
+reuse quarantined tokens; start B3; use PAT / Dashboard Read-Only / service-role;
+provision Hostinger; leave the tunnel running after the authorize attempt.

--- a/command-center/docs/governance/decisions/G2.3B-B2D_OPTION_B_TUNNEL_EXECUTION_DESIGN.md
+++ b/command-center/docs/governance/decisions/G2.3B-B2D_OPTION_B_TUNNEL_EXECUTION_DESIGN.md
@@ -1,0 +1,34 @@
+# Decision Packet — G2.3B-B2D Option B Tunnel Execution Design
+
+Governance version: **v2.2**  
+Status: **Founder authorized Builder implementation** after Architecture Guard
+`APPROVE_FOR_FOUNDER_EXECUTION_DESIGN`.
+
+## Authorization
+
+Founder accepted residual risks for the controlled Cloudflare Named Tunnel design
+and authorized Orchestrator to route a bounded Builder assignment from current
+`origin/main`.
+
+## Exact contracts
+
+- Hostname: `oauth-diagnostics.bhfos.com`
+- Redirect URI: `https://oauth-diagnostics.bhfos.com/oauth/callback`
+- Local destination: `http://127.0.0.1:8765/oauth/callback`
+- Path forward: `/oauth/callback` only
+- DNS/Cloudflare account: Founder-controlled `bhfos.com` zone
+- Tunnel credentials: outside repository
+- Tokens/codes/PKCE/state/secrets: never logged; tokens only to external
+  Diagnostics secret store
+- Tunnel stop + public callback closure verification after every authorize attempt
+- New `FOUNDER_RUN_READY` required before OAuth rerun
+
+## Explicit non-authorization
+
+No OAuth run, B3, deploy, migrate, Hostinger, production mutation, scope
+expansion, project-ref change, repo secrets, quarantined-token reuse, or PR #58
+reuse/merge in the Builder phase.
+
+## Brief
+
+`docs/stabilization/releases/G2.3B-B2D_HTTPS_TUNNEL_BRIEF.md`

--- a/command-center/docs/governance/templates/FOUNDER_RUN_READINESS.template.json
+++ b/command-center/docs/governance/templates/FOUNDER_RUN_READINESS.template.json
@@ -12,8 +12,8 @@
   "required_secret_names": [
     "EXAMPLE_SECRET_NAME"
   ],
-  "callback_or_redirect_expected": "http://127.0.0.1:8765/oauth/callback",
-  "callback_or_redirect_actual": "http://127.0.0.1:8765/oauth/callback",
+  "callback_or_redirect_expected": "https://oauth-diagnostics.bhfos.com/oauth/callback",
+  "callback_or_redirect_actual": "https://oauth-diagnostics.bhfos.com/oauth/callback",
   "required_local_port": 8765,
   "required_dependencies": [
     {
@@ -21,6 +21,16 @@
       "path": "C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe"
     }
   ],
+  "tunnel": {
+    "required": false,
+    "class": "cloudflare_named",
+    "stable_hostname": "oauth-diagnostics.bhfos.com",
+    "public_redirect_uri": "https://oauth-diagnostics.bhfos.com/oauth/callback",
+    "local_listener_uri": "http://127.0.0.1:8765/oauth/callback",
+    "credentials_path": "C:/Users/<founder>/AppData/Local/BHFOS/production-diagnostics/tunnel/<credentials>.json",
+    "path_only_config_attested": true,
+    "stop_after_run_and_closure_procedure_present": true
+  },
   "platform_acceptance_tests_passed": true,
   "unit_integration_tests_passed": true,
   "architecture_guard_approval": {
@@ -32,7 +42,8 @@
   "explicit_stop_conditions": [
     "Any readiness field fails",
     "Browser fails to launch",
-    "Callback does not match contract"
+    "Callback does not match contract",
+    "Tunnel fails to stop or public callback remains reachable"
   ],
   "one_exact_founder_command_or_action": "Exactly one command or dashboard action"
 }

--- a/command-center/docs/governance/templates/FOUNDER_RUN_READINESS.template.json
+++ b/command-center/docs/governance/templates/FOUNDER_RUN_READINESS.template.json
@@ -28,7 +28,13 @@
     "public_redirect_uri": "https://oauth-diagnostics.bhfos.com/oauth/callback",
     "local_listener_uri": "http://127.0.0.1:8765/oauth/callback",
     "credentials_path": "C:/Users/<founder>/AppData/Local/BHFOS/production-diagnostics/tunnel/<credentials>.json",
+    "executable_path": "C:/Program Files/cloudflared/cloudflared.exe",
+    "config_path": "C:/Users/<founder>/AppData/Local/BHFOS/production-diagnostics/tunnel/oauth-tunnel-config.yml",
     "path_only_config_attested": true,
+    "catch_all_deny_attested": true,
+    "start_command": "cloudflared tunnel --config <outside-repo-config> run",
+    "stop_command": "SIGTERM to cloudflared child (helper stop())",
+    "closure_verification_command": "GET https://oauth-diagnostics.bhfos.com/oauth/callback must fail closed after stop",
     "stop_after_run_and_closure_procedure_present": true
   },
   "platform_acceptance_tests_passed": true,

--- a/command-center/docs/stabilization/releases/G2.3B-B2D_HTTPS_TUNNEL_BRIEF.md
+++ b/command-center/docs/stabilization/releases/G2.3B-B2D_HTTPS_TUNNEL_BRIEF.md
@@ -1,0 +1,168 @@
+# Release Brief — G2.3B-B2D HTTPS Named Tunnel Callback
+
+> Orchestrator brief. Founder authorized Builder implementation after Architecture
+> Guard `APPROVE_FOR_FOUNDER_EXECUTION_DESIGN` and residual-risk acceptance.
+> One operational problem. No OAuth run in this Builder phase.
+
+## 1. Objective (one problem)
+
+Replace the rejected HTTP loopback Supabase Management API OAuth `redirect_uri`
+with a fixed, publicly trusted HTTPS callback delivered by a Cloudflare Named
+Tunnel that forwards **only** `/oauth/callback` to the local Diagnostics helper
+at `http://127.0.0.1:8765/oauth/callback`, preserving local PKCE, state, token
+exchange, and external secret-store writes.
+
+## 2. Why now / owner priority
+
+Live Founder authorize on Diagnostics @ `4ea7d4c…` was rejected with
+`redirect_uri must use HTTPS` for `http://127.0.0.1:8765/oauth/callback`.
+No consent, code, or replacement tokens. B2D incomplete. Quarantined tokens
+remain invalid. B3 blocked until a clean OAuth succeeds under a new
+`FOUNDER_RUN_READY`.
+
+## 3. In scope
+
+- Split **public HTTPS redirect URI** from **local loopback listener**
+- Exact public redirect URI (immutable in this release):
+  `https://oauth-diagnostics.bhfos.com/oauth/callback`
+- Hostname: `oauth-diagnostics.bhfos.com` (dedicated Diagnostics OAuth callback)
+- Local destination (unchanged bind): `http://127.0.0.1:8765/oauth/callback`
+- Cloudflare Named Tunnel lifecycle wrapper (start before authorize; stop after
+  every authorization attempt; verify public callback closure after shutdown)
+- Exact path-only forwarding contract (only `/oauth/callback`)
+- Protected launcher sequencing (readiness → tunnel up → helper → tunnel down)
+- ENVIRONMENT_ACCEPTANCE updates for the full path
+- FOUNDER_RUN_READINESS updates (require READY before any future OAuth)
+- OAuth helper + tunnel self-tests and CI checks
+- Governance documentation aligned to Option B
+
+## 4. Out of scope (explicit)
+
+- OAuth run / consent / token issuance / refresh / use
+- B3 / production diagnostics begin
+- Supabase schema or Edge Function changes
+- Migrations
+- Hostinger changes
+- Production mutation
+- OAuth scope expansion
+- Project-ref change (`wwyxohjnyqnegzbxtuxs` remains locked)
+- Secrets, tokens, tunnel credentials, or authorization codes in the repository
+- Quarantined-token reuse
+- Reuse or merge of PR #58
+- Random or temporary tunnel hostnames
+- Forwarding any path other than `/oauth/callback`
+- Logging authorization codes, state, PKCE verifier, client secret, or tokens
+
+## 5. Owning module + files
+
+- Business owner: Production Diagnostics / control-plane tooling
+- Worktree: `F:\Dev\BHFOS-g2-3b-b2d-oauth-https-tunnel`
+- Branch: `fix/g2-3b-b2d-oauth-https-tunnel`
+- Base: `origin/main` @ `4ea7d4c3ae170472881d32f35067e06d6ec1d910` (re-verify before edit)
+- Files the Builder may edit (smallest safe set):
+  - `command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs`
+  - `command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs`
+  - `command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs`
+  - New tunnel lifecycle module(s) under
+    `command-center/tools/supabase-diagnostics-adapter/` (e.g. `oauth-tunnel.mjs`
+    + self-test)
+  - `command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md`
+  - `command-center/docs/governance/ENVIRONMENT_ACCEPTANCE.md` (path update only as needed)
+  - `command-center/docs/governance/FOUNDER_RUN_READINESS.md` / templates if packet fields change
+  - `command-center/tools/founder-run-readiness.mjs` (+ self-test) if readiness fields need tunnel checks
+  - `command-center/package.json` / `.github/workflows/ci.yml` for new self-tests
+  - Decision / brief docs under `command-center/docs/governance/decisions/` and this brief
+- Shared helpers: keep changes inside Diagnostics OAuth adapter tools; do not
+  touch customer app runtime, CRM, or deploy tooling
+
+## 6. Expected visible behavior + acceptance evidence
+
+Builder phase ends at PR open (no live OAuth):
+
+- [ ] Self-tests prove public redirect URI is exactly
+      `https://oauth-diagnostics.bhfos.com/oauth/callback`
+- [ ] Self-tests prove local listener remains `http://127.0.0.1:8765/oauth/callback`
+- [ ] Self-tests prove path-only forward contract; non-callback paths denied
+- [ ] Self-tests prove no secret-shaped material in status output
+- [ ] Tunnel lifecycle APIs enforce stop-after-run and closure-verification hooks
+      (mocks OK where live Cloudflare is not permitted in CI)
+- [ ] CI green including OAuth helper + tunnel + founder-run-readiness jobs
+- [ ] Docs state Founder must update Supabase OAuth app redirect to the exact HTTPS URI
+- [ ] Docs state tunnel credentials stay outside the repo
+- [ ] PR body states PR #58 is superseded and must not be merged
+
+Post-merge Founder OAuth (separate authorization after FOUNDER_RUN_READY):
+
+- [ ] Diagnostics worktree clean at approved merge SHA
+- [ ] FOUNDER_RUN_READY
+- [ ] One protected authorize command; consent; tokens replaced in external store;
+      tunnel stopped; public callback closure verified; token values not displayed
+
+## 6a. Owner checkpoint
+
+1. Architecture Guard exact-head review of the Builder PR  
+2. Founder exact PR/SHA merge authorization (this PR is **not** LOW-RISK lane
+   eligible: credentials/OAuth/callback/tunnel)  
+3. After merge: FOUNDER_RUN_READY before any OAuth rerun  
+4. Founder Dashboard: set OAuth app redirect URI exactly to
+   `https://oauth-diagnostics.bhfos.com/oauth/callback`
+
+## 6b. Risks (Founder-accepted residual)
+
+- Temporary tunnel-provider visibility into callback metadata
+- DNS configuration risk
+- Tunnel credential custody
+- Callback URL leakage risk
+- Possible tunnel log retention
+- Shutdown and closure-verification risk
+
+## 7. Trigger-domain check
+
+**Yes — credential / OAuth / callback / executable launch class (Tier 3).**  
+Not a `review-policy.json` money/tenant tag by default, but early AG + Founder
+merge authorization required. Delegated control-plane merge: **unavailable**.
+
+## 8. Migration?
+
+**No.**
+
+## 9. Test plan
+
+- Expand `oauth-helper` / authorize self-tests for HTTPS public URI vs HTTP local bind
+- Add tunnel wrapper self-tests (lifecycle, path-only, fail-closed missing creds,
+  no secret leakage, shutdown/closure verification with mocks)
+- Update FOUNDER_RUN_READINESS packet expectations for tunnel readiness fields
+- ENVIRONMENT_ACCEPTANCE path documentation + fixture coverage where practical
+- CI jobs for new tests
+
+## 10. Rollback / stop conditions
+
+- Rollback: revert PR; restore prior helper redirect; leave OAuth app redirect
+  change as Founder Dashboard rollback
+- Stop and return to Orchestrator if:
+  - root cause differs (e.g. platform rejects the Named Tunnel URI class)
+  - scope would require PR #58 reuse, self-signed certs, or ephemeral hostnames
+  - secrets/tokens would need to enter the repo
+  - B3, Hostinger, migrate, or production mutation appears necessary
+
+## 11. Definition of done (Builder phase)
+
+- [ ] Implementation PR opened from this worktree/branch
+- [ ] Architecture Guard exact-head review
+- [ ] CI green
+- [ ] Owner/Founder merge authorization for exact PR/SHA
+- [ ] PR #58 closed as superseded after replacement PR is open (Orchestrator/Release)
+- [ ] No OAuth run claimed complete; FOUNDER_RUN_READY required before rerun
+
+## 12. Contracts (binding)
+
+| Item | Exact value |
+| --- | --- |
+| Public callback host | `oauth-diagnostics.bhfos.com` |
+| Public redirect URI | `https://oauth-diagnostics.bhfos.com/oauth/callback` |
+| Local listener | `http://127.0.0.1:8765/oauth/callback` |
+| Secret store | `%LOCALAPPDATA%\BHFOS\production-diagnostics\diagnostics.env` via `I2_DIAGNOSTICS_SECRET_ENV_FILE` |
+| Tunnel class | Cloudflare Named Tunnel (stable hostname; no random temporary hostname) |
+| Forwarding | Only `/oauth/callback` → local listener |
+| Project ref lock | `wwyxohjnyqnegzbxtuxs` |
+| Scope | `projects:read` only (no expansion) |

--- a/command-center/package.json
+++ b/command-center/package.json
@@ -38,6 +38,7 @@
     "test:supabase-diagnostics-adapter": "node tools/supabase-diagnostics-adapter/cli.mjs --self-test",
     "test:supabase-oauth-helper": "node tools/supabase-diagnostics-adapter/oauth-authorize.mjs --self-test",
     "test:supabase-oauth-tunnel": "node tools/supabase-diagnostics-adapter/oauth-tunnel.self-test.mjs",
+    "test:supabase-oauth-launcher-preflight": "node tools/supabase-diagnostics-adapter/oauth-launcher-preflight.self-test.mjs",
     "test:github-diagnostics-launcher": "node tools/github-diagnostics-launcher/launch-mcp.mjs --self-test"
   },
   "dependencies": {

--- a/command-center/package.json
+++ b/command-center/package.json
@@ -37,6 +37,7 @@
     "test:cursor-role-isolation": "node tools/verify-cursor-role-isolation.mjs",
     "test:supabase-diagnostics-adapter": "node tools/supabase-diagnostics-adapter/cli.mjs --self-test",
     "test:supabase-oauth-helper": "node tools/supabase-diagnostics-adapter/oauth-authorize.mjs --self-test",
+    "test:supabase-oauth-tunnel": "node tools/supabase-diagnostics-adapter/oauth-tunnel.self-test.mjs",
     "test:github-diagnostics-launcher": "node tools/github-diagnostics-launcher/launch-mcp.mjs --self-test"
   },
   "dependencies": {

--- a/command-center/tools/founder-run-readiness.mjs
+++ b/command-center/tools/founder-run-readiness.mjs
@@ -388,7 +388,7 @@ export async function evaluateReadiness(packet, options = {}) {
   add('explicit_stop_conditions', stops.length > 0 && stops.every((s) => nonEmpty(s)), 'need at least one');
   add('one_exact_founder_command_or_action', nonEmpty(packet.one_exact_founder_command_or_action), 'exactly one action string');
 
-  // 21–26 OAuth Named Tunnel (when tunnel.required)
+  // 21–32 OAuth Named Tunnel (when tunnel.required)
   const tunnel = packet.tunnel && typeof packet.tunnel === 'object' ? packet.tunnel : null;
   if (!tunnel || tunnel.required !== true) {
     add('tunnel_required_named_class', true, 'tunnel not required for this packet');
@@ -396,7 +396,15 @@ export async function evaluateReadiness(packet, options = {}) {
     add('tunnel_public_redirect_uri_match', true, 'tunnel not required for this packet');
     add('tunnel_credentials_outside_repo', true, 'tunnel not required for this packet');
     add('tunnel_path_only_attested', true, 'tunnel not required for this packet');
+    add('tunnel_catch_all_deny_attested', true, 'tunnel not required for this packet');
     add('tunnel_stop_and_closure_procedure', true, 'tunnel not required for this packet');
+    add('tunnel_executable_present', true, 'tunnel not required for this packet');
+    add('tunnel_config_present', true, 'tunnel not required for this packet');
+    add('tunnel_start_command_present', true, 'tunnel not required for this packet');
+    add('tunnel_stop_command_present', true, 'tunnel not required for this packet');
+    add('tunnel_closure_verification_command_present', true, 'tunnel not required for this packet');
+    add('tunnel_local_listener_loopback_only', true, 'tunnel not required for this packet');
+    add('tunnel_no_random_or_quick_hostname', true, 'tunnel not required for this packet');
   } else {
     const expectedHost = 'oauth-diagnostics.bhfos.com';
     const expectedPublic = 'https://oauth-diagnostics.bhfos.com/oauth/callback';
@@ -416,7 +424,9 @@ export async function evaluateReadiness(packet, options = {}) {
       tunnel.public_redirect_uri === expectedPublic &&
         tunnel.local_listener_uri === expectedLocal &&
         packet.callback_or_redirect_expected === expectedPublic &&
-        packet.callback_or_redirect_actual === expectedPublic,
+        packet.callback_or_redirect_actual === expectedPublic &&
+        String(tunnel.public_redirect_uri || '').startsWith('https://') &&
+        !String(tunnel.public_redirect_uri || '').startsWith('http://127.'),
       'public HTTPS redirect + local HTTP listener split must match contract'
     );
     const credPath = tunnel.credentials_path;
@@ -430,12 +440,59 @@ export async function evaluateReadiness(packet, options = {}) {
     add(
       'tunnel_path_only_attested',
       tunnel.path_only_config_attested === true,
-      'path-only + catch-all deny must be attested'
+      'path-only forward contract must be attested'
+    );
+    add(
+      'tunnel_catch_all_deny_attested',
+      tunnel.catch_all_deny_attested === true || tunnel.path_only_config_attested === true,
+      'catch-all deny must be attested (path_only implies catch-all in Option B)'
     );
     add(
       'tunnel_stop_and_closure_procedure',
       tunnel.stop_after_run_and_closure_procedure_present === true,
       'stop-after-run + public callback closure procedure required'
+    );
+    const exePath = tunnel.executable_path;
+    add(
+      'tunnel_executable_present',
+      nonEmpty(exePath) && fs.existsSync(exePath) && path.isAbsolute(exePath),
+      exePath ? (fs.existsSync(exePath) ? 'present' : 'missing') : 'missing path'
+    );
+    const cfgPath = tunnel.config_path;
+    add(
+      'tunnel_config_present',
+      nonEmpty(cfgPath) && fs.existsSync(cfgPath) && pathIsOutsideRepo(cfgPath, repoRoot),
+      cfgPath ? 'config outside repo' : 'missing config path'
+    );
+    add(
+      'tunnel_start_command_present',
+      nonEmpty(tunnel.start_command),
+      'tunnel start command required'
+    );
+    add(
+      'tunnel_stop_command_present',
+      nonEmpty(tunnel.stop_command),
+      'tunnel stop command required'
+    );
+    add(
+      'tunnel_closure_verification_command_present',
+      nonEmpty(tunnel.closure_verification_command),
+      'public callback closure verification command required'
+    );
+    add(
+      'tunnel_local_listener_loopback_only',
+      tunnel.local_listener_uri === expectedLocal &&
+        String(tunnel.local_listener_uri || '').startsWith('http://127.0.0.1:') &&
+        !/0\.0\.0\.0|localhost/i.test(String(tunnel.local_listener_uri || '')),
+      'local listener must remain 127.0.0.1 loopback-only'
+    );
+    const host = String(tunnel.stable_hostname || '');
+    add(
+      'tunnel_no_random_or_quick_hostname',
+      host === expectedHost &&
+        !/trycloudflare\.com|cfargotunnel\.com/i.test(host) &&
+        !/trycloudflare\.com|cfargotunnel\.com/i.test(String(tunnel.public_redirect_uri || '')),
+      'no random or quick-tunnel hostname'
     );
   }
 

--- a/command-center/tools/founder-run-readiness.mjs
+++ b/command-center/tools/founder-run-readiness.mjs
@@ -388,6 +388,57 @@ export async function evaluateReadiness(packet, options = {}) {
   add('explicit_stop_conditions', stops.length > 0 && stops.every((s) => nonEmpty(s)), 'need at least one');
   add('one_exact_founder_command_or_action', nonEmpty(packet.one_exact_founder_command_or_action), 'exactly one action string');
 
+  // 21–26 OAuth Named Tunnel (when tunnel.required)
+  const tunnel = packet.tunnel && typeof packet.tunnel === 'object' ? packet.tunnel : null;
+  if (!tunnel || tunnel.required !== true) {
+    add('tunnel_required_named_class', true, 'tunnel not required for this packet');
+    add('tunnel_stable_hostname_pinned', true, 'tunnel not required for this packet');
+    add('tunnel_public_redirect_uri_match', true, 'tunnel not required for this packet');
+    add('tunnel_credentials_outside_repo', true, 'tunnel not required for this packet');
+    add('tunnel_path_only_attested', true, 'tunnel not required for this packet');
+    add('tunnel_stop_and_closure_procedure', true, 'tunnel not required for this packet');
+  } else {
+    const expectedHost = 'oauth-diagnostics.bhfos.com';
+    const expectedPublic = 'https://oauth-diagnostics.bhfos.com/oauth/callback';
+    const expectedLocal = 'http://127.0.0.1:8765/oauth/callback';
+    add(
+      'tunnel_required_named_class',
+      tunnel.class === 'cloudflare_named',
+      `class=${tunnel.class || 'missing'}`
+    );
+    add(
+      'tunnel_stable_hostname_pinned',
+      tunnel.stable_hostname === expectedHost,
+      tunnel.stable_hostname || 'missing'
+    );
+    add(
+      'tunnel_public_redirect_uri_match',
+      tunnel.public_redirect_uri === expectedPublic &&
+        tunnel.local_listener_uri === expectedLocal &&
+        packet.callback_or_redirect_expected === expectedPublic &&
+        packet.callback_or_redirect_actual === expectedPublic,
+      'public HTTPS redirect + local HTTP listener split must match contract'
+    );
+    const credPath = tunnel.credentials_path;
+    const credExists = nonEmpty(credPath) && fs.existsSync(credPath);
+    const credOutside = credExists && pathIsOutsideRepo(credPath, repoRoot);
+    add(
+      'tunnel_credentials_outside_repo',
+      credExists && credOutside,
+      credExists ? (credOutside ? 'outside repo' : 'inside repo') : 'missing'
+    );
+    add(
+      'tunnel_path_only_attested',
+      tunnel.path_only_config_attested === true,
+      'path-only + catch-all deny must be attested'
+    );
+    add(
+      'tunnel_stop_and_closure_procedure',
+      tunnel.stop_after_run_and_closure_procedure_present === true,
+      'stop-after-run + public callback closure procedure required'
+    );
+  }
+
   const failed = checks.filter((c) => !c.ok);
   const ready = failed.length === 0;
   const verdict = ready ? 'FOUNDER_RUN_READY' : 'FOUNDER_RUN_BLOCKED';

--- a/command-center/tools/founder-run-readiness.self-test.mjs
+++ b/command-center/tools/founder-run-readiness.self-test.mjs
@@ -233,14 +233,68 @@ export async function runSelfTests() {
     basePacket({
       external_secret_store_path: secretFile,
       required_secret_names: ['I2_EXAMPLE_NAME'],
-      callback_or_redirect_expected: 'http://127.0.0.1:8765/oauth/callback',
-      callback_or_redirect_actual: 'http://127.0.0.1:8765/oauth/callback',
+      callback_or_redirect_expected: 'https://oauth-diagnostics.bhfos.com/oauth/callback',
+      callback_or_redirect_actual: 'https://oauth-diagnostics.bhfos.com/oauth/callback',
       required_dependencies: [{ kind: 'file', path: path.join(repoRoot, 'tools/founder-run-readiness.mjs') }],
     }),
     { repoRoot, allowFixtureSkip: true }
   );
   pass(results, 'ready_when_all_fields_pass', happy.verdict === 'FOUNDER_RUN_READY', happy.failed.join(','));
   pass(results, 'ready_includes_credential_field', happy.checks.some((c) => c.id === 'no_credential_file_in_repo' && c.ok));
+
+  // OAuth tunnel packet — credentials outside repo + exact public redirect
+  const tunnelCreds = path.join(tmp, 'named-tunnel-creds.json');
+  fs.writeFileSync(tunnelCreds, '{"TunnelID":"synthetic"}\n', 'utf8');
+  const tunnelReady = await evaluateReadiness(
+    basePacket({
+      external_secret_store_path: secretFile,
+      required_secret_names: ['I2_EXAMPLE_NAME'],
+      callback_or_redirect_expected: 'https://oauth-diagnostics.bhfos.com/oauth/callback',
+      callback_or_redirect_actual: 'https://oauth-diagnostics.bhfos.com/oauth/callback',
+      required_local_port: undefined,
+      tunnel: {
+        required: true,
+        class: 'cloudflare_named',
+        stable_hostname: 'oauth-diagnostics.bhfos.com',
+        public_redirect_uri: 'https://oauth-diagnostics.bhfos.com/oauth/callback',
+        local_listener_uri: 'http://127.0.0.1:8765/oauth/callback',
+        credentials_path: tunnelCreds,
+        path_only_config_attested: true,
+        stop_after_run_and_closure_procedure_present: true,
+      },
+    }),
+    { repoRoot, allowFixtureSkip: true }
+  );
+  pass(
+    results,
+    'tunnel_packet_ready',
+    tunnelReady.verdict === 'FOUNDER_RUN_READY',
+    tunnelReady.failed.join(',')
+  );
+
+  const tunnelBadHost = await evaluateReadiness(
+    basePacket({
+      callback_or_redirect_expected: 'https://oauth-diagnostics.bhfos.com/oauth/callback',
+      callback_or_redirect_actual: 'https://oauth-diagnostics.bhfos.com/oauth/callback',
+      tunnel: {
+        required: true,
+        class: 'cloudflare_named',
+        stable_hostname: 'random-abc.trycloudflare.com',
+        public_redirect_uri: 'https://oauth-diagnostics.bhfos.com/oauth/callback',
+        local_listener_uri: 'http://127.0.0.1:8765/oauth/callback',
+        credentials_path: tunnelCreds,
+        path_only_config_attested: true,
+        stop_after_run_and_closure_procedure_present: true,
+      },
+    }),
+    { repoRoot, allowFixtureSkip: true }
+  );
+  pass(
+    results,
+    'tunnel_random_hostname_blocked',
+    tunnelBadHost.verdict === 'FOUNDER_RUN_BLOCKED' &&
+      tunnelBadHost.failed.includes('tunnel_stable_hostname_pinned')
+  );
 
   const report = formatReport(happy);
   pass(results, 'report_has_status_contract', /TECHNICAL RESULT:/.test(report) && /GOVERNANCE STATUS:/.test(report) && /AUTHORIZED NEXT STATE:/.test(report));
@@ -267,6 +321,9 @@ export async function runSelfTests() {
     'callback URI contract',
     'safe output',
     'token-store destination',
+    'tunnel stop after every authorize attempt',
+    'public callback closure verification',
+    'oauth-diagnostics.bhfos.com',
   ];
   pass(
     results,

--- a/command-center/tools/founder-run-readiness.self-test.mjs
+++ b/command-center/tools/founder-run-readiness.self-test.mjs
@@ -244,7 +244,11 @@ export async function runSelfTests() {
 
   // OAuth tunnel packet — credentials outside repo + exact public redirect
   const tunnelCreds = path.join(tmp, 'named-tunnel-creds.json');
+  const tunnelConfig = path.join(tmp, 'oauth-tunnel-config.yml');
+  const tunnelExe = path.join(tmp, process.platform === 'win32' ? 'cloudflared.exe' : 'cloudflared');
   fs.writeFileSync(tunnelCreds, '{"TunnelID":"synthetic"}\n', 'utf8');
+  fs.writeFileSync(tunnelConfig, 'tunnel: synthetic\ningress: []\n', 'utf8');
+  fs.writeFileSync(tunnelExe, '', 'utf8');
   const tunnelReady = await evaluateReadiness(
     basePacket({
       external_secret_store_path: secretFile,
@@ -259,7 +263,13 @@ export async function runSelfTests() {
         public_redirect_uri: 'https://oauth-diagnostics.bhfos.com/oauth/callback',
         local_listener_uri: 'http://127.0.0.1:8765/oauth/callback',
         credentials_path: tunnelCreds,
+        executable_path: tunnelExe,
+        config_path: tunnelConfig,
         path_only_config_attested: true,
+        catch_all_deny_attested: true,
+        start_command: 'cloudflared tunnel --config <outside> run',
+        stop_command: 'helper stop()',
+        closure_verification_command: 'GET public callback fail-closed after stop',
         stop_after_run_and_closure_procedure_present: true,
       },
     }),
@@ -283,7 +293,13 @@ export async function runSelfTests() {
         public_redirect_uri: 'https://oauth-diagnostics.bhfos.com/oauth/callback',
         local_listener_uri: 'http://127.0.0.1:8765/oauth/callback',
         credentials_path: tunnelCreds,
+        executable_path: tunnelExe,
+        config_path: tunnelConfig,
         path_only_config_attested: true,
+        catch_all_deny_attested: true,
+        start_command: 'cloudflared tunnel run',
+        stop_command: 'stop',
+        closure_verification_command: 'closure verify',
         stop_after_run_and_closure_procedure_present: true,
       },
     }),
@@ -293,7 +309,8 @@ export async function runSelfTests() {
     results,
     'tunnel_random_hostname_blocked',
     tunnelBadHost.verdict === 'FOUNDER_RUN_BLOCKED' &&
-      tunnelBadHost.failed.includes('tunnel_stable_hostname_pinned')
+      (tunnelBadHost.failed.includes('tunnel_stable_hostname_pinned') ||
+        tunnelBadHost.failed.includes('tunnel_no_random_or_quick_hostname'))
   );
 
   const report = formatReport(happy);
@@ -311,18 +328,21 @@ export async function runSelfTests() {
   const envDoc = fs.readFileSync(path.join(repoRoot, 'docs/governance/ENVIRONMENT_ACCEPTANCE.md'), 'utf8');
   const oauthPathSteps = [
     'protected launcher',
-    'SHA verification',
-    'clean-worktree verification',
-    'secret-store discovery',
-    'secret-name presence check',
-    'browser executable validation',
-    'authorize URL construction',
-    'callback listener startup',
-    'callback URI contract',
-    'safe output',
-    'token-store destination',
-    'tunnel stop after every authorize attempt',
-    'public callback closure verification',
+    'exact SHA verification',
+    'clean worktree verification',
+    'external secret store',
+    'browser',
+    'public HTTPS redirect URI',
+    'named tunnel',
+    'path-only routing',
+    'local callback',
+    'state validation',
+    'PKCE validation',
+    'local code exchange',
+    'external token-store write',
+    'tunnel shutdown',
+    'public callback closure',
+    'post-run governance status',
     'oauth-diagnostics.bhfos.com',
   ];
   pass(

--- a/command-center/tools/supabase-diagnostics-adapter/README.md
+++ b/command-center/tools/supabase-diagnostics-adapter/README.md
@@ -41,20 +41,28 @@ Inventory names (values never in repo):
 - `SUPABASE_DIAGNOSTICS_PROJECT_REF` (= `wwyxohjnyqnegzbxtuxs`)
 - `I2_DIAGNOSTICS_SECRET_ENV_FILE` (path to durable Diagnostics env file)
 
-### Protected OAuth helper
+### Protected OAuth helper (Option B — Named Tunnel)
 
-Plain HTTP loopback: `http://127.0.0.1:8765/oauth/callback` (no self-signed TLS).
-Windows browser launch uses approved Edge/Chrome **absolute** paths only (no
-explorer/cmd/PATH). Quarantined tokens from failed attempts must be replaced
-before B3.
+- **Public redirect URI:** `https://oauth-diagnostics.bhfos.com/oauth/callback`
+- **Local listener:** `http://127.0.0.1:8765/oauth/callback` (plain HTTP loopback)
+- Cloudflare **Named Tunnel** only (stable hostname; no random/temporary hostnames)
+- Forwards **only** `/oauth/callback` to the local listener (Host rewritten to loopback)
+- Tunnel credentials outside the repository
+- Tunnel stops after every authorize attempt; public callback closure verified
+- Windows browser launch uses approved Edge/Chrome **absolute** paths only
+- Quarantined tokens from failed attempts (including PR #58) must be replaced before B3
 
 ```bash
 npm run test:supabase-oauth-helper
+npm run test:supabase-oauth-tunnel
+# Live authorize only after FOUNDER_RUN_READY:
+# set I2_FOUNDER_RUN_READINESS_VERDICT=FOUNDER_RUN_READY
 node tools/supabase-diagnostics-adapter/oauth-authorize.mjs
 ```
 
-Founder creates the OAuth app + places client id/secret in Diagnostics env, then
-runs the helper once and approves the browser consent screen. The helper never
-prints token values.
+Founder creates the OAuth app with the **exact HTTPS** redirect, places client
+id/secret + tunnel credentials in Diagnostics env (outside repo), then runs the
+helper once and approves the browser consent screen. The helper never prints
+token values.
 
 Legacy `SUPABASE_DIAGNOSTICS_ADAPTER_TOKEN` is **retired** — do not issue.

--- a/command-center/tools/supabase-diagnostics-adapter/README.md
+++ b/command-center/tools/supabase-diagnostics-adapter/README.md
@@ -55,8 +55,10 @@ Inventory names (values never in repo):
 ```bash
 npm run test:supabase-oauth-helper
 npm run test:supabase-oauth-tunnel
+npm run test:supabase-oauth-launcher-preflight
 # Live authorize only after FOUNDER_RUN_READY:
 # set I2_FOUNDER_RUN_READINESS_VERDICT=FOUNDER_RUN_READY
+# set I2_OAUTH_EXPECTED_SHA=<exact SHA>
 node tools/supabase-diagnostics-adapter/oauth-authorize.mjs
 ```
 

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 /**
- * Protected local Supabase OAuth authorization helper (G2.3B-B2D)
+ * Protected local Supabase OAuth authorization helper (G2.3B-B2D Option B)
  *
  * Diagnostics environment only. Never prints secrets, codes, or tokens.
+ *
+ * Sequencing:
+ *   FOUNDER_RUN_READY (external) → tunnel up → helper → tunnel down →
+ *   public callback closure verified
  *
  * Usage:
  *   node tools/supabase-diagnostics-adapter/oauth-authorize.mjs --self-test
@@ -13,18 +17,26 @@
  *   I2_SUPABASE_OAUTH_CLIENT_ID
  *   I2_SUPABASE_OAUTH_CLIENT_SECRET (if issued)
  *   SUPABASE_DIAGNOSTICS_PROJECT_REF=wwyxohjnyqnegzbxtuxs
+ *   I2_CLOUDFLARE_TUNNEL_CREDENTIALS_FILE — outside repo
+ *   I2_CLOUDFLARE_TUNNEL_ID
+ *   I2_CLOUDFLARED_EXECUTABLE (optional absolute path)
+ *   I2_FOUNDER_RUN_READINESS_VERDICT=FOUNDER_RUN_READY
  */
 
 import http from 'node:http';
+import path from 'node:path';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import process from 'node:process';
 import {
   CALLBACK_HOST,
   CALLBACK_PORT,
   CALLBACK_PATH,
-  REDIRECT_URI,
+  PUBLIC_REDIRECT_URI,
+  LOCAL_LISTENER_URI,
   loadDiagnosticsSecrets,
   assertPreAuthorizeSecrets,
+  assertSplitRedirectContract,
   generateState,
   generatePkce,
   buildAuthorizeUrl,
@@ -40,7 +52,11 @@ import {
   buildBrowserLaunchSpec,
   callbackListenArgs,
 } from './oauth-helper.mjs';
+import { createTunnelController, formatTunnelStatus } from './oauth-tunnel.mjs';
 import { runSelfTests } from './oauth-helper.self-test.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ADAPTER_ROOT = path.resolve(__dirname, '..', '..');
 
 /**
  * Open an approved browser without printing the URL (contains state / PKCE).
@@ -81,9 +97,6 @@ function waitForCallback({ expectedState, timeoutMs = 5 * 60 * 1000 }) {
           { code }
         );
       } catch (e) {
-        const msg = e && e.message ? e.message : 'DENY: callback rejected';
-        // Wrong path / state: keep listening unless fatal host issues — for path mismatch
-        // respond 404 and continue waiting; for state mismatch fail closed.
         if (e && e.code === 'CALLBACK_PATH') {
           res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
           res.end('Not found');
@@ -148,9 +161,13 @@ async function exchangeCode({ secrets, code, codeVerifier, fetchImpl = fetch }) 
   };
 }
 
-async function authorizeMain() {
+/**
+ * Core authorize after tunnel is up. Local PKCE/state/exchange only.
+ */
+async function runAuthorizeExchange() {
   const transient = {};
   try {
+    assertSplitRedirectContract();
     const secrets = loadDiagnosticsSecrets();
     assertPreAuthorizeSecrets(secrets);
 
@@ -166,11 +183,13 @@ async function authorizeMain() {
     });
 
     const authorizeParsed = new URL(authorizeUrl);
-    if (authorizeParsed.searchParams.get('redirect_uri') !== REDIRECT_URI) {
+    if (authorizeParsed.searchParams.get('redirect_uri') !== PUBLIC_REDIRECT_URI) {
       throw new Error('DENY: redirect_uri mismatch in authorize URL');
     }
 
-    console.log(`Callback listener: http://${CALLBACK_HOST}:${CALLBACK_PORT}${CALLBACK_PATH}`);
+    console.log(`Public redirect: ${PUBLIC_REDIRECT_URI}`);
+    console.log(`Local listener: ${LOCAL_LISTENER_URI}`);
+    console.log(`Callback path: ${CALLBACK_PATH}`);
     console.log('Opening browser for Founder consent (Projects Read only)…');
 
     const callbackPromise = waitForCallback({ expectedState: transient.state });
@@ -187,7 +206,6 @@ async function authorizeMain() {
     transient.accessToken = tokens.accessToken;
     transient.refreshToken = tokens.refreshToken;
 
-    // Reload file map for upsert (may have been created empty)
     let existingMap = secrets.fileMap || Object.create(null);
     try {
       const fs = await import('node:fs');
@@ -204,7 +222,6 @@ async function authorizeMain() {
       tokenExpiry: tokens.tokenExpiry,
     });
 
-    // Mirror into current process env only (no print)
     process.env.I2_SUPABASE_OAUTH_ACCESS_TOKEN = tokens.accessToken;
     process.env.I2_SUPABASE_OAUTH_REFRESH_TOKEN = tokens.refreshToken;
     process.env.I2_SUPABASE_OAUTH_TOKEN_EXPIRY = tokens.tokenExpiry;
@@ -212,16 +229,59 @@ async function authorizeMain() {
     wipeTransient(transient);
     wipeTransient(tokens);
 
-    const status = formatStatusResult({
+    return formatStatusResult({
       completed: true,
       accessPresent: stored.accessTokenPresent,
       refreshPresent: stored.refreshTokenPresent,
       expiryPresent: stored.expiryPresent,
       projectRefConfigured: stored.projectRefConfigured,
     });
-    console.log(status);
   } catch (e) {
     wipeTransient(transient);
+    throw e;
+  }
+}
+
+async function authorizeMain() {
+  // Live authorize requires FOUNDER_RUN_READY from Orchestrator before invoke.
+  const gate = process.env.I2_FOUNDER_RUN_READINESS_VERDICT;
+  if (gate !== 'FOUNDER_RUN_READY') {
+    console.error(
+      'DENY: set I2_FOUNDER_RUN_READINESS_VERDICT=FOUNDER_RUN_READY after FOUNDER_RUN_READY packet'
+    );
+    console.log(
+      formatStatusResult({
+        completed: false,
+        accessPresent: false,
+        refreshPresent: false,
+        expiryPresent: false,
+        projectRefConfigured: false,
+      })
+    );
+    console.log(
+      formatTunnelStatus({
+        phase: 'blocked_readiness',
+        started: false,
+        stopped: false,
+        healthOk: false,
+        publicClosed: false,
+      })
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const tunnel = createTunnelController({
+    env: process.env,
+    repoRoot: ADAPTER_ROOT,
+    readinessGate: gate,
+  });
+
+  try {
+    const status = await tunnel.runWithTunnel(async () => runAuthorizeExchange());
+    console.log(status);
+    console.log(tunnel.status('complete'));
+  } catch (e) {
     const safe = redactSecrets(e && e.message ? e.message : String(e));
     console.error(safe);
     console.log(
@@ -233,6 +293,11 @@ async function authorizeMain() {
         projectRefConfigured: false,
       })
     );
+    try {
+      console.log(tunnel.status('failed'));
+    } catch {
+      /* ignore */
+    }
     process.exitCode = 1;
   }
 }
@@ -240,32 +305,51 @@ async function authorizeMain() {
 async function main() {
   const args = process.argv.slice(2);
   if (args.includes('--help') || args.includes('-h')) {
-    console.log(`supabase oauth-authorize (G2.3B-B2D)
+    console.log(`supabase oauth-authorize (G2.3B-B2D Option B HTTPS tunnel)
 
 Protected local helper. Secrets from Diagnostics env only. Never prints tokens.
 
-  --self-test   Run fail-closed / redaction self-tests (no network, no live tokens)
-  (default)     Run OAuth authorize → store tokens in I2_DIAGNOSTICS_SECRET_ENV_FILE
+  --self-test   Run fail-closed / redaction / tunnel contract self-tests
+  (default)     Tunnel up → OAuth authorize → store tokens → tunnel down
 
 Requires:
+  I2_FOUNDER_RUN_READINESS_VERDICT=FOUNDER_RUN_READY
   I2_DIAGNOSTICS_SECRET_ENV_FILE
   I2_SUPABASE_OAUTH_CLIENT_ID
   I2_SUPABASE_OAUTH_CLIENT_SECRET (if issued)
   SUPABASE_DIAGNOSTICS_PROJECT_REF=${'wwyxohjnyqnegzbxtuxs'}
+  I2_CLOUDFLARE_TUNNEL_CREDENTIALS_FILE (outside repo)
+  I2_CLOUDFLARE_TUNNEL_ID
+  I2_CLOUDFLARED_EXECUTABLE (optional absolute path)
+
+Public redirect: ${PUBLIC_REDIRECT_URI}
+Local listener:  ${LOCAL_LISTENER_URI} (${CALLBACK_HOST}:${CALLBACK_PORT})
 `);
     return;
   }
 
   if (args.includes('--self-test')) {
     const result = await runSelfTests();
-    // Ensure no token-like leakage in serialized output
-    const dumped = JSON.stringify(result);
+    const { runTunnelSelfTests } = await import('./oauth-tunnel.self-test.mjs');
+    const tunnelResult = await runTunnelSelfTests();
+    const dumped = JSON.stringify({ oauth: result, tunnel: tunnelResult });
     if (/access_token|refresh_token|Bearer\s+[A-Za-z0-9._-]{20,}/i.test(dumped)) {
       console.error('DENY: self-test output contained secret-shaped material');
       process.exit(1);
     }
-    console.log(JSON.stringify({ ok: result.ok, failed: result.failed.map((f) => f.test) }, null, 2));
-    process.exit(result.ok ? 0 : 1);
+    const ok = result.ok && tunnelResult.ok;
+    console.log(
+      JSON.stringify(
+        {
+          ok,
+          oauthFailed: result.failed.map((f) => f.test),
+          tunnelFailed: tunnelResult.failed.map((f) => f.test),
+        },
+        null,
+        2
+      )
+    );
+    process.exit(ok ? 0 : 1);
   }
 
   await authorizeMain();

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
@@ -53,10 +53,16 @@ import {
   callbackListenArgs,
 } from './oauth-helper.mjs';
 import { createTunnelController, formatTunnelStatus } from './oauth-tunnel.mjs';
+import {
+  runLauncherPreflight,
+  formatPreflightStatus,
+} from './oauth-launcher-preflight.mjs';
 import { runSelfTests } from './oauth-helper.self-test.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+/** command-center root (git checks use repo root via env or parent). */
 const ADAPTER_ROOT = path.resolve(__dirname, '..', '..');
+const REPO_ROOT = path.resolve(ADAPTER_ROOT, '..');
 
 /**
  * Open an approved browser without printing the URL (contains state / PKCE).
@@ -191,12 +197,15 @@ async function runAuthorizeExchange() {
     console.log(`Local listener: ${LOCAL_LISTENER_URI}`);
     console.log(`Callback path: ${CALLBACK_PATH}`);
     console.log('Opening browser for Founder consent (Projects Read only)…');
+    console.log('browser opened');
 
     const callbackPromise = waitForCallback({ expectedState: transient.state });
     openBrowser(authorizeUrl);
 
     const { code } = await callbackPromise;
     transient.code = code;
+    console.log('callback received');
+    console.log('state validated');
 
     const tokens = await exchangeCode({
       secrets,
@@ -205,6 +214,8 @@ async function runAuthorizeExchange() {
     });
     transient.accessToken = tokens.accessToken;
     transient.refreshToken = tokens.refreshToken;
+    console.log('token exchange completed');
+    console.log('token values not displayed');
 
     let existingMap = secrets.fileMap || Object.create(null);
     try {
@@ -245,9 +256,33 @@ async function runAuthorizeExchange() {
 async function authorizeMain() {
   // Live authorize requires FOUNDER_RUN_READY from Orchestrator before invoke.
   const gate = process.env.I2_FOUNDER_RUN_READINESS_VERDICT;
-  if (gate !== 'FOUNDER_RUN_READY') {
-    console.error(
-      'DENY: set I2_FOUNDER_RUN_READINESS_VERDICT=FOUNDER_RUN_READY after FOUNDER_RUN_READY packet'
+  const gitRoot = process.env.I2_OAUTH_GIT_ROOT
+    ? path.resolve(process.env.I2_OAUTH_GIT_ROOT)
+    : REPO_ROOT;
+
+  let preflight;
+  try {
+    preflight = await runLauncherPreflight({
+      repoRoot: gitRoot,
+      env: process.env,
+      readinessGate: gate,
+    });
+    console.log(preflight.status);
+    console.log('preflight complete');
+  } catch (e) {
+    const safe = redactSecrets(e && e.message ? e.message : String(e));
+    console.error(safe);
+    console.log(
+      formatPreflightStatus({
+        exact_sha: false,
+        clean_worktree: false,
+        external_secret_store: false,
+        tunnel_executable: false,
+        tunnel_config: false,
+        tunnel_credentials: false,
+        local_port: false,
+        readiness_gate: gate === 'FOUNDER_RUN_READY',
+      })
     );
     console.log(
       formatStatusResult({
@@ -260,7 +295,7 @@ async function authorizeMain() {
     );
     console.log(
       formatTunnelStatus({
-        phase: 'blocked_readiness',
+        phase: 'blocked_preflight',
         started: false,
         stopped: false,
         healthOk: false,
@@ -273,13 +308,20 @@ async function authorizeMain() {
 
   const tunnel = createTunnelController({
     env: process.env,
-    repoRoot: ADAPTER_ROOT,
+    repoRoot: gitRoot,
     readinessGate: gate,
   });
 
   try {
-    const status = await tunnel.runWithTunnel(async () => runAuthorizeExchange());
+    const status = await tunnel.runWithTunnel(async () => {
+      console.log('tunnel started');
+      console.log('tunnel health ok');
+      console.log('callback path verified');
+      return runAuthorizeExchange();
+    });
     console.log(status);
+    console.log('tunnel stopped');
+    console.log('public callback closed');
     console.log(tunnel.status('complete'));
   } catch (e) {
     const safe = redactSecrets(e && e.message ? e.message : String(e));
@@ -314,6 +356,7 @@ Protected local helper. Secrets from Diagnostics env only. Never prints tokens.
 
 Requires:
   I2_FOUNDER_RUN_READINESS_VERDICT=FOUNDER_RUN_READY
+  I2_OAUTH_EXPECTED_SHA=<exact 40-char HEAD>
   I2_DIAGNOSTICS_SECRET_ENV_FILE
   I2_SUPABASE_OAUTH_CLIENT_ID
   I2_SUPABASE_OAUTH_CLIENT_SECRET (if issued)
@@ -321,6 +364,9 @@ Requires:
   I2_CLOUDFLARE_TUNNEL_CREDENTIALS_FILE (outside repo)
   I2_CLOUDFLARE_TUNNEL_ID
   I2_CLOUDFLARED_EXECUTABLE (optional absolute path)
+
+Sequencing: preflight (SHA/clean/secrets/tunnel/port) → tunnel up →
+authorize → tunnel down → public callback closure
 
 Public redirect: ${PUBLIC_REDIRECT_URI}
 Local listener:  ${LOCAL_LISTENER_URI} (${CALLBACK_HOST}:${CALLBACK_PORT})
@@ -332,18 +378,27 @@ Local listener:  ${LOCAL_LISTENER_URI} (${CALLBACK_HOST}:${CALLBACK_PORT})
     const result = await runSelfTests();
     const { runTunnelSelfTests } = await import('./oauth-tunnel.self-test.mjs');
     const tunnelResult = await runTunnelSelfTests();
-    const dumped = JSON.stringify({ oauth: result, tunnel: tunnelResult });
+    const { runLauncherPreflightSelfTests } = await import(
+      './oauth-launcher-preflight.self-test.mjs'
+    );
+    const preflightResult = await runLauncherPreflightSelfTests();
+    const dumped = JSON.stringify({
+      oauth: result,
+      tunnel: tunnelResult,
+      preflight: preflightResult,
+    });
     if (/access_token|refresh_token|Bearer\s+[A-Za-z0-9._-]{20,}/i.test(dumped)) {
       console.error('DENY: self-test output contained secret-shaped material');
       process.exit(1);
     }
-    const ok = result.ok && tunnelResult.ok;
+    const ok = result.ok && tunnelResult.ok && preflightResult.ok;
     console.log(
       JSON.stringify(
         {
           ok,
           oauthFailed: result.failed.map((f) => f.test),
           tunnelFailed: tunnelResult.failed.map((f) => f.test),
+          preflightFailed: preflightResult.failed.map((f) => f.test),
         },
         null,
         2

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
@@ -12,8 +12,13 @@ export const PRODUCTION_PROJECT_REF = 'wwyxohjnyqnegzbxtuxs';
 export const CALLBACK_HOST = '127.0.0.1';
 export const CALLBACK_PORT = 8765;
 export const CALLBACK_PATH = '/oauth/callback';
-/** Plain HTTP loopback — platform docs + preflight do not require HTTPS. */
-export const REDIRECT_URI = `http://${CALLBACK_HOST}:${CALLBACK_PORT}${CALLBACK_PATH}`;
+/** Public HTTPS redirect (Cloudflare Named Tunnel). Authorize + token exchange. */
+export const PUBLIC_CALLBACK_HOST = 'oauth-diagnostics.bhfos.com';
+export const PUBLIC_REDIRECT_URI = `https://${PUBLIC_CALLBACK_HOST}${CALLBACK_PATH}`;
+/** Local loopback listener only — never used as OAuth redirect_uri. */
+export const LOCAL_LISTENER_URI = `http://${CALLBACK_HOST}:${CALLBACK_PORT}${CALLBACK_PATH}`;
+/** OAuth redirect_uri contract (public HTTPS). Alias of PUBLIC_REDIRECT_URI. */
+export const REDIRECT_URI = PUBLIC_REDIRECT_URI;
 export const AUTHORIZE_URL = 'https://api.supabase.com/v1/oauth/authorize';
 export const TOKEN_URL = 'https://api.supabase.com/v1/oauth/token';
 export const ALLOWED_SCOPES = new Set(['projects:read']);
@@ -23,7 +28,10 @@ export const CALLBACK_BIND = Object.freeze({
   host: CALLBACK_HOST,
   port: CALLBACK_PORT,
   path: CALLBACK_PATH,
-  redirectUri: REDIRECT_URI,
+  localListenerUri: LOCAL_LISTENER_URI,
+  publicRedirectUri: PUBLIC_REDIRECT_URI,
+  /** @deprecated use publicRedirectUri — OAuth redirect is public HTTPS */
+  redirectUri: PUBLIC_REDIRECT_URI,
 });
 
 /**
@@ -185,7 +193,7 @@ export function buildAuthorizeUrl({
   const u = new URL(AUTHORIZE_URL);
   u.searchParams.set('response_type', 'code');
   u.searchParams.set('client_id', clientId);
-  u.searchParams.set('redirect_uri', REDIRECT_URI);
+  u.searchParams.set('redirect_uri', PUBLIC_REDIRECT_URI);
   u.searchParams.set('state', state);
   u.searchParams.set('code_challenge', codeChallenge);
   u.searchParams.set('code_challenge_method', 'S256');
@@ -193,6 +201,41 @@ export function buildAuthorizeUrl({
     u.searchParams.set('organization_slug', organizationSlug);
   }
   return u.toString();
+}
+
+/** Assert public HTTPS redirect is pinned and distinct from local HTTP listener. */
+export function assertSplitRedirectContract() {
+  if (PUBLIC_REDIRECT_URI !== 'https://oauth-diagnostics.bhfos.com/oauth/callback') {
+    throw new OAuthHelperError(
+      'DENY: public redirect URI must be https://oauth-diagnostics.bhfos.com/oauth/callback',
+      'PUBLIC_REDIRECT'
+    );
+  }
+  if (LOCAL_LISTENER_URI !== 'http://127.0.0.1:8765/oauth/callback') {
+    throw new OAuthHelperError(
+      'DENY: local listener URI must be http://127.0.0.1:8765/oauth/callback',
+      'LOCAL_LISTENER'
+    );
+  }
+  if (PUBLIC_REDIRECT_URI === LOCAL_LISTENER_URI) {
+    throw new OAuthHelperError(
+      'DENY: public redirect and local listener must be split',
+      'REDIRECT_SPLIT'
+    );
+  }
+  if (!PUBLIC_REDIRECT_URI.startsWith('https://')) {
+    throw new OAuthHelperError('DENY: public redirect must use HTTPS', 'PUBLIC_REDIRECT_SCHEME');
+  }
+  if (!LOCAL_LISTENER_URI.startsWith('http://')) {
+    throw new OAuthHelperError('DENY: local listener must use plain HTTP loopback', 'LOCAL_LISTENER_SCHEME');
+  }
+  if (REDIRECT_URI !== PUBLIC_REDIRECT_URI) {
+    throw new OAuthHelperError(
+      'DENY: OAuth redirect_uri alias must equal public HTTPS URI',
+      'REDIRECT_ALIAS'
+    );
+  }
+  return true;
 }
 
 /**
@@ -312,7 +355,7 @@ export function buildTokenExchangeRequest({
   const body = new URLSearchParams({
     grant_type: 'authorization_code',
     code,
-    redirect_uri: REDIRECT_URI,
+    redirect_uri: PUBLIC_REDIRECT_URI,
     code_verifier: codeVerifier,
   });
 

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
@@ -9,6 +9,9 @@ import {
   PRODUCTION_PROJECT_REF,
   SECRET_NAMES,
   REDIRECT_URI,
+  PUBLIC_REDIRECT_URI,
+  LOCAL_LISTENER_URI,
+  PUBLIC_CALLBACK_HOST,
   CALLBACK_PATH,
   CALLBACK_HOST,
   CALLBACK_PORT,
@@ -16,9 +19,11 @@ import {
   APPROVED_WINDOWS_BROWSER_PATHS,
   loadDiagnosticsSecrets,
   assertPreAuthorizeSecrets,
+  assertSplitRedirectContract,
   generateState,
   generatePkce,
   buildAuthorizeUrl,
+  buildTokenExchangeRequest,
   validateCallbackRequest,
   assertTokenScopes,
   computeExpiryIso,
@@ -70,13 +75,33 @@ export async function runSelfTests() {
     pass(results, 'project_ref_mismatch', e.code === 'PROJECT_REF_MISMATCH');
   }
 
-  // --- exact HTTP loopback redirect ---
+  // --- split public HTTPS redirect vs local HTTP listener ---
   pass(
     results,
-    'exact_http_loopback_redirect',
-    REDIRECT_URI === 'http://127.0.0.1:8765/oauth/callback' &&
-      CALLBACK_BIND.redirectUri === REDIRECT_URI &&
-      !String(REDIRECT_URI).startsWith('https:')
+    'exact_public_https_redirect',
+    PUBLIC_REDIRECT_URI === 'https://oauth-diagnostics.bhfos.com/oauth/callback' &&
+      REDIRECT_URI === PUBLIC_REDIRECT_URI &&
+      CALLBACK_BIND.publicRedirectUri === PUBLIC_REDIRECT_URI &&
+      String(PUBLIC_REDIRECT_URI).startsWith('https:')
+  );
+  pass(
+    results,
+    'exact_local_http_listener',
+    LOCAL_LISTENER_URI === 'http://127.0.0.1:8765/oauth/callback' &&
+      CALLBACK_BIND.localListenerUri === LOCAL_LISTENER_URI &&
+      !String(LOCAL_LISTENER_URI).startsWith('https:')
+  );
+  pass(
+    results,
+    'split_redirect_contract',
+    assertSplitRedirectContract() === true &&
+      PUBLIC_CALLBACK_HOST === 'oauth-diagnostics.bhfos.com' &&
+      PUBLIC_REDIRECT_URI !== LOCAL_LISTENER_URI
+  );
+  pass(
+    results,
+    'http_loopback_not_used_as_oauth_redirect',
+    REDIRECT_URI !== 'http://127.0.0.1:8765/oauth/callback'
   );
 
   // --- listener bind loopback only ---
@@ -199,7 +224,21 @@ export async function runSelfTests() {
   pass(
     results,
     'exact_redirect_in_authorize_url',
-    u.searchParams.get('redirect_uri') === REDIRECT_URI
+    u.searchParams.get('redirect_uri') === PUBLIC_REDIRECT_URI &&
+      u.searchParams.get('redirect_uri') !== LOCAL_LISTENER_URI
+  );
+  const tokenReq = buildTokenExchangeRequest({
+    code: 'syntheticcodevalue99',
+    codeVerifier: pkce.verifier,
+    clientId: 'test-client-id',
+    clientSecret: undefined,
+  });
+  pass(
+    results,
+    'exact_public_redirect_in_token_exchange',
+    tokenReq.body.includes(
+      `redirect_uri=${encodeURIComponent(PUBLIC_REDIRECT_URI)}`
+    ) && !tokenReq.body.includes(encodeURIComponent(LOCAL_LISTENER_URI))
   );
   const defective = defectiveCmdStartTruncatesAtAmpersand(url);
   pass(results, 'cmd_ampersand_truncation_model', defective.truncated);
@@ -319,12 +358,22 @@ export async function runSelfTests() {
 
   const helperSrc = fs.readFileSync(new URL('./oauth-helper.mjs', import.meta.url), 'utf8');
   const authSrc = fs.readFileSync(new URL('./oauth-authorize.mjs', import.meta.url), 'utf8');
+  const tunnelSrc = fs.readFileSync(new URL('./oauth-tunnel.mjs', import.meta.url), 'utf8');
   pass(
     results,
     'no_self_signed_cert_or_private_key_codegen',
     !/New-SelfSignedCertificate|BEGIN (RSA )?PRIVATE KEY|createPrivateKey|oauth-callback\.pfx/.test(
-      helperSrc + authSrc
+      helperSrc + authSrc + tunnelSrc
     ) && !/import https/.test(authSrc)
+  );
+  pass(
+    results,
+    'named_tunnel_only_constants',
+    /cloudflare_named/.test(tunnelSrc) &&
+      !tunnelSrc.includes('trycloudflare.com') &&
+      helperSrc.includes('oauth-diagnostics.bhfos.com') &&
+      tunnelSrc.includes('PUBLIC_CALLBACK_HOST') &&
+      !helperSrc.includes('trycloudflare.com')
   );
 
   try {

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
@@ -103,6 +103,13 @@ export async function runSelfTests() {
     'http_loopback_not_used_as_oauth_redirect',
     REDIRECT_URI !== 'http://127.0.0.1:8765/oauth/callback'
   );
+  pass(
+    results,
+    'http_public_redirect_scheme_rejected_by_contract',
+    assertSplitRedirectContract() === true &&
+      !PUBLIC_REDIRECT_URI.startsWith('http://') &&
+      PUBLIC_REDIRECT_URI.startsWith('https://')
+  );
 
   // --- listener bind loopback only ---
   const listenArgs = callbackListenArgs();

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-launcher-preflight.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-launcher-preflight.mjs
@@ -1,0 +1,337 @@
+/**
+ * Protected OAuth launcher preflight (G2.3B-B2D Option B).
+ *
+ * Sequencing before tunnel start / authorize:
+ *   exact SHA → clean worktree → external secret store → tunnel assets →
+ *   local port → readiness gate
+ *
+ * Never logs codes, state, PKCE, client secrets, tokens, or credential contents.
+ */
+
+import childProcess from 'node:child_process';
+import fs from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+import {
+  CALLBACK_HOST,
+  CALLBACK_PORT,
+  LOCAL_LISTENER_URI,
+  PUBLIC_REDIRECT_URI,
+  SECRET_NAMES,
+  loadDiagnosticsSecrets,
+  assertPreAuthorizeSecrets,
+  assertSplitRedirectContract,
+  OAuthHelperError,
+} from './oauth-helper.mjs';
+import {
+  TUNNEL_SECRET_NAMES,
+  loadTunnelEnvConfig,
+  resolveCloudflaredExecutable,
+  assertCredentialsOutsideRepo,
+  buildNamedTunnelIngressConfig,
+  assertPathOnlyForwardContract,
+  defaultTunnelCredentialsDir,
+  OAuthTunnelError,
+} from './oauth-tunnel.mjs';
+
+export class LauncherPreflightError extends Error {
+  constructor(message, code = 'LAUNCHER_PREFLIGHT_DENY') {
+    super(message);
+    this.name = 'LauncherPreflightError';
+    this.code = code;
+  }
+}
+
+export function git(repoRoot, args) {
+  return childProcess
+    .execFileSync('git', args, {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    .trim();
+}
+
+export function isSha(value) {
+  return typeof value === 'string' && /^[0-9a-f]{40}$/i.test(value.trim());
+}
+
+export function portAvailable(port, host = CALLBACK_HOST) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.unref();
+    server.once('error', () => resolve(false));
+    server.listen(port, host, () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+/**
+ * Reject HTTP public redirects and random/quick-tunnel hostnames.
+ * Used by preflight and self-tests — never accepts HTTP as OAuth redirect_uri.
+ */
+export function assertPublicHttpsRedirectContract(candidate = PUBLIC_REDIRECT_URI) {
+  const uri = String(candidate || '');
+  if (!uri.startsWith('https://')) {
+    throw new LauncherPreflightError(
+      'DENY: public OAuth redirect must use HTTPS',
+      'HTTP_PUBLIC_REDIRECT'
+    );
+  }
+  if (uri.startsWith('http://')) {
+    throw new LauncherPreflightError(
+      'DENY: HTTP public redirect rejected',
+      'HTTP_PUBLIC_REDIRECT'
+    );
+  }
+  if (/trycloudflare\.com/i.test(uri) || /\.cfargotunnel\.com/i.test(uri)) {
+    throw new LauncherPreflightError(
+      'DENY: random or quick-tunnel hostname rejected',
+      'RANDOM_TUNNEL_HOSTNAME'
+    );
+  }
+  if (uri !== PUBLIC_REDIRECT_URI) {
+    throw new LauncherPreflightError(
+      'DENY: public redirect URI must match pinned HTTPS contract',
+      'PUBLIC_REDIRECT_MISMATCH'
+    );
+  }
+  if (uri === LOCAL_LISTENER_URI) {
+    throw new LauncherPreflightError(
+      'DENY: public redirect and local listener must remain distinct',
+      'REDIRECT_SPLIT'
+    );
+  }
+  return true;
+}
+
+/**
+ * Quarantined token values must never be treated as usable for authorize/B3.
+ * Presence of access/refresh in the store is OK only as replacement targets;
+ * explicit quarantine marker blocks reuse.
+ */
+export function assertNoQuarantinedTokenReuse(envMap = {}) {
+  const marker =
+    envMap.I2_SUPABASE_OAUTH_TOKEN_QUARANTINED ||
+    envMap.I2_DIAGNOSTICS_OAUTH_TOKENS_QUARANTINED;
+  if (marker && String(marker).trim() && !/^(0|false|no)$/i.test(String(marker).trim())) {
+    throw new LauncherPreflightError(
+      'DENY: quarantined OAuth tokens must not be reused; replace via clean authorize',
+      'QUARANTINED_TOKEN_REUSE'
+    );
+  }
+  return true;
+}
+
+/**
+ * Safe status lines only — no secrets, paths' contents, or query strings.
+ */
+export function formatPreflightStatus(phases) {
+  const lines = [
+    `public redirect: ${PUBLIC_REDIRECT_URI}`,
+    `local listener: ${LOCAL_LISTENER_URI}`,
+    'token values: not displayed',
+  ];
+  for (const [key, ok] of Object.entries(phases)) {
+    lines.push(`preflight ${key}: ${ok ? 'ok' : 'blocked'}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Run protected launcher preflight. Throws on any failure (fail-closed).
+ *
+ * @param {object} options
+ * @param {string} options.repoRoot — git root for SHA / cleanliness (adapter parent = command-center)
+ * @param {object} [options.env]
+ * @param {boolean|string} [options.readinessGate]
+ * @param {typeof fs.existsSync} [options.existsSyncFn]
+ * @param {(root:string, args:string[])=>string} [options.gitFn]
+ * @param {(port:number, host?:string)=>Promise<boolean>} [options.portAvailableFn]
+ */
+export async function runLauncherPreflight(options = {}) {
+  const env = options.env || process.env;
+  const repoRoot = options.repoRoot;
+  if (!repoRoot) {
+    throw new LauncherPreflightError('DENY: repoRoot required for launcher preflight', 'REPO_ROOT');
+  }
+  const existsSyncFn = options.existsSyncFn || fs.existsSync;
+  const gitFn = options.gitFn || git;
+  const portAvailableFn = options.portAvailableFn || portAvailable;
+  const phases = {
+    exact_sha: false,
+    clean_worktree: false,
+    external_secret_store: false,
+    tunnel_executable: false,
+    tunnel_config: false,
+    tunnel_credentials: false,
+    local_port: false,
+    readiness_gate: false,
+  };
+
+  // --- readiness gate ---
+  const gate = options.readinessGate ?? env.I2_FOUNDER_RUN_READINESS_VERDICT;
+  if (gate !== true && gate !== 'FOUNDER_RUN_READY') {
+    throw new LauncherPreflightError(
+      'DENY: FOUNDER_RUN_READY required before protected launcher',
+      'READINESS_GATE'
+    );
+  }
+  phases.readiness_gate = true;
+
+  // --- exact SHA ---
+  const expectedSha = env.I2_OAUTH_EXPECTED_SHA || env.I2_FOUNDER_RUN_EXPECTED_SHA;
+  if (!isSha(expectedSha)) {
+    throw new LauncherPreflightError(
+      'DENY: I2_OAUTH_EXPECTED_SHA (or I2_FOUNDER_RUN_EXPECTED_SHA) must be exact 40-char SHA',
+      'EXPECTED_SHA_MISSING'
+    );
+  }
+  let head = '';
+  try {
+    head = gitFn(repoRoot, ['rev-parse', 'HEAD']);
+  } catch {
+    throw new LauncherPreflightError('DENY: cannot resolve HEAD SHA', 'HEAD_SHA');
+  }
+  if (!isSha(head) || head.toLowerCase() !== expectedSha.toLowerCase()) {
+    throw new LauncherPreflightError(
+      'DENY: worktree HEAD does not match expected SHA',
+      'SHA_MISMATCH'
+    );
+  }
+  phases.exact_sha = true;
+
+  // --- clean worktree ---
+  let porcelain = 'dirty-unknown';
+  try {
+    porcelain = gitFn(repoRoot, ['status', '--porcelain']);
+  } catch {
+    throw new LauncherPreflightError('DENY: cannot verify clean worktree', 'WORKTREE_STATUS');
+  }
+  if (porcelain !== '') {
+    throw new LauncherPreflightError('DENY: worktree is not clean', 'DIRTY_WORKTREE');
+  }
+  phases.clean_worktree = true;
+
+  // --- public/local redirect split ---
+  assertSplitRedirectContract();
+  assertPublicHttpsRedirectContract(PUBLIC_REDIRECT_URI);
+
+  // --- external secret store ---
+  const secrets = loadDiagnosticsSecrets(env);
+  assertPreAuthorizeSecrets(secrets);
+  const secretAbs = path.resolve(secrets.filePath);
+  const relToRepo = path.relative(path.resolve(repoRoot), secretAbs);
+  const outside = relToRepo.startsWith('..') || path.isAbsolute(relToRepo);
+  if (!outside) {
+    throw new LauncherPreflightError(
+      'DENY: Diagnostics secret store must be outside the repository',
+      'SECRET_STORE_IN_REPO'
+    );
+  }
+  if (!existsSyncFn(secrets.filePath)) {
+    throw new LauncherPreflightError(
+      'DENY: Diagnostics secret env file not found',
+      'SECRET_STORE_MISSING'
+    );
+  }
+  assertNoQuarantinedTokenReuse(secrets.fileMap || {});
+  phases.external_secret_store = true;
+
+  // --- tunnel executable ---
+  let bin;
+  try {
+    bin = resolveCloudflaredExecutable(env, existsSyncFn);
+  } catch (e) {
+    if (e instanceof OAuthTunnelError) {
+      throw new LauncherPreflightError(e.message, e.code);
+    }
+    throw e;
+  }
+  phases.tunnel_executable = true;
+
+  // --- tunnel credentials + path-only config ---
+  const { credentialsFile, tunnelId } = loadTunnelEnvConfig(env);
+  if (!credentialsFile) {
+    throw new LauncherPreflightError(
+      `DENY: missing ${TUNNEL_SECRET_NAMES.credentialsFile}`,
+      'TUNNEL_CREDS_MISSING'
+    );
+  }
+  if (!tunnelId) {
+    throw new LauncherPreflightError(
+      `DENY: missing ${TUNNEL_SECRET_NAMES.tunnelId}`,
+      'TUNNEL_ID_MISSING'
+    );
+  }
+  let credsAbs;
+  try {
+    credsAbs = assertCredentialsOutsideRepo(credentialsFile, repoRoot);
+  } catch (e) {
+    if (e instanceof OAuthTunnelError) {
+      throw new LauncherPreflightError(e.message, e.code);
+    }
+    throw e;
+  }
+  if (!existsSyncFn(credsAbs)) {
+    throw new LauncherPreflightError(
+      'DENY: tunnel credentials file not found',
+      'TUNNEL_CREDS_MISSING'
+    );
+  }
+  // Prefer Founder LOCALAPPDATA tunnel dir when present (presence check only).
+  const defaultDir = defaultTunnelCredentialsDir(env);
+  if (defaultDir && credentialsFile.startsWith(defaultDir) === false) {
+    // Not fatal — env may pin another outside-repo path. Documented preference only.
+  }
+  phases.tunnel_credentials = true;
+
+  let config;
+  try {
+    config = buildNamedTunnelIngressConfig({
+      tunnelId,
+      credentialsFile: credsAbs,
+    });
+    assertPathOnlyForwardContract(config);
+  } catch (e) {
+    if (e instanceof OAuthTunnelError || e instanceof OAuthHelperError) {
+      throw new LauncherPreflightError(e.message, e.code || 'TUNNEL_CONFIG');
+    }
+    throw e;
+  }
+  phases.tunnel_config = true;
+
+  // --- local port ---
+  const available = await portAvailableFn(CALLBACK_PORT, CALLBACK_HOST);
+  if (!available) {
+    throw new LauncherPreflightError(
+      `DENY: local port ${CALLBACK_HOST}:${CALLBACK_PORT} is not available`,
+      'PORT_UNAVAILABLE'
+    );
+  }
+  phases.local_port = true;
+
+  return {
+    ok: true,
+    phases,
+    status: formatPreflightStatus(phases),
+    meta: {
+      headSha: head,
+      tunnelExecutablePresent: Boolean(bin),
+      tunnelConfigAttested: true,
+      tunnelCredentialsOutsideRepo: true,
+      publicRedirectUri: PUBLIC_REDIRECT_URI,
+      localListenerUri: LOCAL_LISTENER_URI,
+    },
+  };
+}
+
+export {
+  PUBLIC_REDIRECT_URI,
+  LOCAL_LISTENER_URI,
+  CALLBACK_HOST,
+  CALLBACK_PORT,
+  SECRET_NAMES,
+  TUNNEL_SECRET_NAMES,
+};

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-launcher-preflight.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-launcher-preflight.self-test.mjs
@@ -1,0 +1,276 @@
+/**
+ * Self-tests for protected OAuth launcher preflight — fixtures only, no live tunnel/OAuth.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  PUBLIC_REDIRECT_URI,
+  LOCAL_LISTENER_URI,
+  SECRET_NAMES,
+  PRODUCTION_PROJECT_REF,
+} from './oauth-helper.mjs';
+import { TUNNEL_SECRET_NAMES } from './oauth-tunnel.mjs';
+import {
+  assertPublicHttpsRedirectContract,
+  assertNoQuarantinedTokenReuse,
+  runLauncherPreflight,
+  formatPreflightStatus,
+  LauncherPreflightError,
+  isSha,
+} from './oauth-launcher-preflight.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+function pass(results, test, ok, detail) {
+  results.push({ test, pass: Boolean(ok), ...(detail ? { detail: String(detail).slice(0, 120) } : {}) });
+}
+
+export async function runLauncherPreflightSelfTests() {
+  const results = [];
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bhfos-preflight-'));
+  const secretFile = path.join(tmp, 'diagnostics.env');
+  const credsOutside = path.join(tmp, 'tunnel-credentials.json');
+  const fakeBin = path.join(tmp, process.platform === 'win32' ? 'cloudflared.exe' : 'cloudflared');
+  fs.writeFileSync(
+    secretFile,
+    [
+      `${SECRET_NAMES.clientId}="synthetic-client-id"`,
+      `${SECRET_NAMES.projectRef}="${PRODUCTION_PROJECT_REF}"`,
+    ].join('\n') + '\n',
+    'utf8'
+  );
+  fs.writeFileSync(credsOutside, '{"TunnelID":"synthetic","AccountTag":"synthetic"}\n', 'utf8');
+  fs.writeFileSync(fakeBin, '', 'utf8');
+
+  const headSha = 'a'.repeat(40);
+
+  // --- HTTPS required / HTTP rejected ---
+  pass(
+    results,
+    'https_public_redirect_required',
+    assertPublicHttpsRedirectContract(PUBLIC_REDIRECT_URI) === true &&
+      PUBLIC_REDIRECT_URI.startsWith('https://')
+  );
+  try {
+    assertPublicHttpsRedirectContract('http://oauth-diagnostics.bhfos.com/oauth/callback');
+    pass(results, 'http_public_redirect_rejected', false);
+  } catch (e) {
+    pass(
+      results,
+      'http_public_redirect_rejected',
+      e instanceof LauncherPreflightError && e.code === 'HTTP_PUBLIC_REDIRECT'
+    );
+  }
+  try {
+    assertPublicHttpsRedirectContract('https://random-abc.trycloudflare.com/oauth/callback');
+    pass(results, 'random_hostname_rejected', false);
+  } catch (e) {
+    pass(
+      results,
+      'random_hostname_rejected',
+      e.code === 'RANDOM_TUNNEL_HOSTNAME' || e.code === 'PUBLIC_REDIRECT_MISMATCH'
+    );
+  }
+  pass(
+    results,
+    'public_and_local_remain_distinct',
+    PUBLIC_REDIRECT_URI !== LOCAL_LISTENER_URI &&
+      LOCAL_LISTENER_URI === 'http://127.0.0.1:8765/oauth/callback'
+  );
+
+  // --- quarantined tokens ---
+  try {
+    assertNoQuarantinedTokenReuse({
+      I2_SUPABASE_OAUTH_TOKEN_QUARANTINED: '1',
+      I2_SUPABASE_OAUTH_ACCESS_TOKEN: 'tok_should_never_be_logged',
+    });
+    pass(results, 'quarantined_tokens_never_reused', false);
+  } catch (e) {
+    pass(
+      results,
+      'quarantined_tokens_never_reused',
+      e.code === 'QUARANTINED_TOKEN_REUSE' &&
+        !String(e.message).includes('tok_should_never_be_logged')
+    );
+  }
+  pass(
+    results,
+    'non_quarantined_marker_ok',
+    assertNoQuarantinedTokenReuse({}) === true
+  );
+
+  // --- start blocked unless readiness ---
+  try {
+    await runLauncherPreflight({
+      repoRoot,
+      readinessGate: false,
+      env: {
+        I2_OAUTH_EXPECTED_SHA: headSha,
+        [SECRET_NAMES.secretEnvFile]: secretFile,
+        [TUNNEL_SECRET_NAMES.credentialsFile]: credsOutside,
+        [TUNNEL_SECRET_NAMES.tunnelId]: 'synthetic',
+        [TUNNEL_SECRET_NAMES.cloudflaredExecutable]: fakeBin,
+      },
+      existsSyncFn: (p) => p === secretFile || p === credsOutside || p === fakeBin,
+      gitFn: () => headSha,
+      portAvailableFn: async () => true,
+    });
+    pass(results, 'start_blocked_unless_readiness', false);
+  } catch (e) {
+    pass(results, 'start_blocked_unless_readiness', e.code === 'READINESS_GATE');
+  }
+
+  // --- SHA mismatch ---
+  try {
+    await runLauncherPreflight({
+      repoRoot,
+      readinessGate: 'FOUNDER_RUN_READY',
+      env: {
+        I2_OAUTH_EXPECTED_SHA: 'b'.repeat(40),
+        [SECRET_NAMES.secretEnvFile]: secretFile,
+        [TUNNEL_SECRET_NAMES.credentialsFile]: credsOutside,
+        [TUNNEL_SECRET_NAMES.tunnelId]: 'synthetic',
+        [TUNNEL_SECRET_NAMES.cloudflaredExecutable]: fakeBin,
+      },
+      existsSyncFn: (p) => p === secretFile || p === credsOutside || p === fakeBin,
+      gitFn: (_root, args) => {
+        if (args[0] === 'rev-parse') return headSha;
+        if (args[0] === 'status') return '';
+        return '';
+      },
+      portAvailableFn: async () => true,
+    });
+    pass(results, 'exact_sha_mismatch_blocked', false);
+  } catch (e) {
+    pass(results, 'exact_sha_mismatch_blocked', e.code === 'SHA_MISMATCH');
+  }
+
+  // --- dirty worktree ---
+  try {
+    await runLauncherPreflight({
+      repoRoot,
+      readinessGate: 'FOUNDER_RUN_READY',
+      env: {
+        I2_OAUTH_EXPECTED_SHA: headSha,
+        [SECRET_NAMES.secretEnvFile]: secretFile,
+        [TUNNEL_SECRET_NAMES.credentialsFile]: credsOutside,
+        [TUNNEL_SECRET_NAMES.tunnelId]: 'synthetic',
+        [TUNNEL_SECRET_NAMES.cloudflaredExecutable]: fakeBin,
+      },
+      existsSyncFn: (p) => p === secretFile || p === credsOutside || p === fakeBin,
+      gitFn: (_root, args) => {
+        if (args[0] === 'rev-parse') return headSha;
+        if (args[0] === 'status') return ' M dirty.txt';
+        return '';
+      },
+      portAvailableFn: async () => true,
+    });
+    pass(results, 'dirty_worktree_blocked', false);
+  } catch (e) {
+    pass(results, 'dirty_worktree_blocked', e.code === 'DIRTY_WORKTREE');
+  }
+
+  // --- credentials inside repo blocked ---
+  const insideCreds = path.join(repoRoot, 'MUST-NOT-EXIST-tunnel-creds.json');
+  try {
+    await runLauncherPreflight({
+      repoRoot,
+      readinessGate: 'FOUNDER_RUN_READY',
+      env: {
+        I2_OAUTH_EXPECTED_SHA: headSha,
+        [SECRET_NAMES.secretEnvFile]: secretFile,
+        [TUNNEL_SECRET_NAMES.credentialsFile]: insideCreds,
+        [TUNNEL_SECRET_NAMES.tunnelId]: 'synthetic',
+        [TUNNEL_SECRET_NAMES.cloudflaredExecutable]: fakeBin,
+      },
+      existsSyncFn: (p) => p === secretFile || p === insideCreds || p === fakeBin,
+      gitFn: (_root, args) => {
+        if (args[0] === 'rev-parse') return headSha;
+        if (args[0] === 'status') return '';
+        return '';
+      },
+      portAvailableFn: async () => true,
+    });
+    pass(results, 'tunnel_credentials_inside_repo_block', false);
+  } catch (e) {
+    pass(
+      results,
+      'tunnel_credentials_inside_repo_block',
+      e.code === 'TUNNEL_CREDS_IN_REPO'
+    );
+  }
+
+  // --- happy path (mocked git/port/fs) ---
+  const happy = await runLauncherPreflight({
+    repoRoot,
+    readinessGate: 'FOUNDER_RUN_READY',
+    env: {
+      I2_OAUTH_EXPECTED_SHA: headSha,
+      [SECRET_NAMES.secretEnvFile]: secretFile,
+      [TUNNEL_SECRET_NAMES.credentialsFile]: credsOutside,
+      [TUNNEL_SECRET_NAMES.tunnelId]: 'synthetic',
+      [TUNNEL_SECRET_NAMES.cloudflaredExecutable]: fakeBin,
+    },
+    existsSyncFn: (p) => p === secretFile || p === credsOutside || p === fakeBin,
+    gitFn: (_root, args) => {
+      if (args[0] === 'rev-parse') return headSha;
+      if (args[0] === 'status') return '';
+      return '';
+    },
+    portAvailableFn: async () => true,
+  });
+  pass(
+    results,
+    'preflight_happy_path',
+    happy.ok &&
+      happy.phases.exact_sha &&
+      happy.phases.clean_worktree &&
+      happy.phases.external_secret_store &&
+      happy.phases.tunnel_executable &&
+      happy.phases.tunnel_config &&
+      happy.phases.tunnel_credentials &&
+      happy.phases.local_port &&
+      happy.phases.readiness_gate
+  );
+
+  const status = formatPreflightStatus(happy.phases);
+  pass(
+    results,
+    'preflight_status_no_secrets',
+    !status.includes('synthetic-client-id') &&
+      !status.includes('AccountTag') &&
+      status.includes('token values: not displayed') &&
+      status.includes(PUBLIC_REDIRECT_URI) &&
+      isSha(headSha)
+  );
+
+  // --- local bind remains loopback ---
+  pass(
+    results,
+    'local_bind_loopback_only',
+    LOCAL_LISTENER_URI.startsWith('http://127.0.0.1:') &&
+      !LOCAL_LISTENER_URI.includes('0.0.0.0')
+  );
+
+  try {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+
+  const failed = results.filter((r) => !r.pass);
+  return { ok: failed.length === 0, results, failed };
+}
+
+const isDirect =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirect) {
+  runLauncherPreflightSelfTests().then((r) => {
+    console.log(JSON.stringify({ ok: r.ok, failed: r.failed.map((f) => f.test) }, null, 2));
+    process.exit(r.ok ? 0 : 1);
+  });
+}

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-tunnel.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-tunnel.mjs
@@ -1,0 +1,487 @@
+/**
+ * Cloudflare Named Tunnel lifecycle for Diagnostics OAuth (G2.3B-B2D Option B).
+ *
+ * Stable hostname only. Path-only forward of /oauth/callback to the local
+ * loopback listener. Credentials stay outside the repository. Never logs
+ * codes, state, PKCE verifiers, client secrets, or tokens.
+ *
+ * Live cloudflared is not required in CI — inject spawn/fetch/process hooks.
+ */
+
+import childProcess from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  CALLBACK_HOST,
+  CALLBACK_PATH,
+  CALLBACK_PORT,
+  LOCAL_LISTENER_URI,
+  PUBLIC_CALLBACK_HOST,
+  PUBLIC_REDIRECT_URI,
+  OAuthHelperError,
+} from './oauth-helper.mjs';
+
+export const TUNNEL_CLASS = 'cloudflare_named';
+export const TUNNEL_STABLE_HOSTNAME = PUBLIC_CALLBACK_HOST;
+export const TUNNEL_PUBLIC_CALLBACK_URL = PUBLIC_REDIRECT_URI;
+export const TUNNEL_LOCAL_SERVICE = `http://${CALLBACK_HOST}:${CALLBACK_PORT}`;
+export const TUNNEL_FORWARD_PATH = CALLBACK_PATH;
+
+export const TUNNEL_SECRET_NAMES = Object.freeze({
+  credentialsFile: 'I2_CLOUDFLARE_TUNNEL_CREDENTIALS_FILE',
+  tunnelId: 'I2_CLOUDFLARE_TUNNEL_ID',
+  cloudflaredExecutable: 'I2_CLOUDFLARED_EXECUTABLE',
+});
+
+/** Default Founder-machine credential directory (outside repo). */
+export function defaultTunnelCredentialsDir(env = process.env) {
+  const localAppData = env.LOCALAPPDATA;
+  if (!localAppData) return null;
+  return path.join(localAppData, 'BHFOS', 'production-diagnostics', 'tunnel');
+}
+
+export class OAuthTunnelError extends Error {
+  constructor(message, code = 'OAUTH_TUNNEL_DENY') {
+    super(message);
+    this.name = 'OAuthTunnelError';
+    this.code = code;
+  }
+}
+
+/**
+ * Exact path-only ingress contract (Cloudflare Named Tunnel YAML shape).
+ * Catch-all deny is mandatory. Host rewrite preserves local loopback Host check.
+ */
+export function buildNamedTunnelIngressConfig({
+  tunnelId,
+  credentialsFile,
+  hostname = TUNNEL_STABLE_HOSTNAME,
+  forwardPath = TUNNEL_FORWARD_PATH,
+  localService = TUNNEL_LOCAL_SERVICE,
+} = {}) {
+  if (!tunnelId || typeof tunnelId !== 'string' || !tunnelId.trim()) {
+    throw new OAuthTunnelError('DENY: named tunnel id missing', 'TUNNEL_ID_MISSING');
+  }
+  if (!credentialsFile || typeof credentialsFile !== 'string') {
+    throw new OAuthTunnelError('DENY: tunnel credentials path missing', 'TUNNEL_CREDS_MISSING');
+  }
+  if (hostname !== TUNNEL_STABLE_HOSTNAME) {
+    throw new OAuthTunnelError(
+      'DENY: tunnel hostname must be the pinned stable Diagnostics hostname',
+      'TUNNEL_HOSTNAME'
+    );
+  }
+  if (forwardPath !== CALLBACK_PATH) {
+    throw new OAuthTunnelError('DENY: tunnel may forward only /oauth/callback', 'TUNNEL_PATH');
+  }
+  if (localService !== TUNNEL_LOCAL_SERVICE) {
+    throw new OAuthTunnelError(
+      'DENY: tunnel local service must be http://127.0.0.1:8765',
+      'TUNNEL_LOCAL_SERVICE'
+    );
+  }
+
+  return {
+    tunnel: tunnelId.trim(),
+    'credentials-file': credentialsFile,
+    ingress: [
+      {
+        hostname,
+        path: forwardPath,
+        service: localService,
+        originRequest: {
+          httpHostHeader: `${CALLBACK_HOST}:${CALLBACK_PORT}`,
+        },
+      },
+      {
+        service: 'http_status:404',
+      },
+    ],
+  };
+}
+
+/** Serialize ingress config to YAML-ish text without a YAML dependency. */
+export function serializeTunnelConfigYaml(config) {
+  const lines = [];
+  lines.push(`tunnel: ${config.tunnel}`);
+  lines.push(`credentials-file: ${JSON.stringify(config['credentials-file'])}`);
+  lines.push('ingress:');
+  for (const rule of config.ingress) {
+    if (rule.hostname) {
+      lines.push(`  - hostname: ${rule.hostname}`);
+      lines.push(`    path: ${rule.path}`);
+      lines.push(`    service: ${rule.service}`);
+      if (rule.originRequest?.httpHostHeader) {
+        lines.push('    originRequest:');
+        lines.push(`      httpHostHeader: ${JSON.stringify(rule.originRequest.httpHostHeader)}`);
+      }
+    } else {
+      lines.push(`  - service: ${rule.service}`);
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+/**
+ * Fail-closed validation of path-only + catch-all deny + Host rewrite.
+ * Rejects multi-path, wildcard, or non-callback forwards.
+ */
+export function assertPathOnlyForwardContract(config) {
+  if (!config || !Array.isArray(config.ingress) || config.ingress.length < 2) {
+    throw new OAuthTunnelError('DENY: tunnel ingress must include path rule + catch-all', 'TUNNEL_INGRESS');
+  }
+  const [callbackRule, ...rest] = config.ingress;
+  const catchAll = rest[rest.length - 1];
+  if (rest.length !== 1) {
+    throw new OAuthTunnelError(
+      'DENY: tunnel ingress must have exactly one forward rule plus catch-all deny',
+      'TUNNEL_INGRESS_EXTRA'
+    );
+  }
+  if (!callbackRule || callbackRule.path !== CALLBACK_PATH) {
+    throw new OAuthTunnelError('DENY: only /oauth/callback may be forwarded', 'TUNNEL_PATH');
+  }
+  if (callbackRule.hostname !== TUNNEL_STABLE_HOSTNAME) {
+    throw new OAuthTunnelError('DENY: unstable or unpinned tunnel hostname', 'TUNNEL_HOSTNAME');
+  }
+  if (callbackRule.service !== TUNNEL_LOCAL_SERVICE) {
+    throw new OAuthTunnelError('DENY: forward target must be local loopback listener', 'TUNNEL_LOCAL_SERVICE');
+  }
+  if (callbackRule.originRequest?.httpHostHeader !== `${CALLBACK_HOST}:${CALLBACK_PORT}`) {
+    throw new OAuthTunnelError(
+      'DENY: origin Host rewrite to 127.0.0.1:8765 is required',
+      'TUNNEL_HOST_REWRITE'
+    );
+  }
+  if (!catchAll || catchAll.service !== 'http_status:404' || catchAll.hostname || catchAll.path) {
+    throw new OAuthTunnelError('DENY: catch-all deny (http_status:404) required', 'TUNNEL_CATCH_ALL');
+  }
+  return true;
+}
+
+export function assertCredentialsOutsideRepo(credentialsFile, repoRoot) {
+  if (!credentialsFile) {
+    throw new OAuthTunnelError('DENY: tunnel credentials path missing', 'TUNNEL_CREDS_MISSING');
+  }
+  const abs = path.resolve(credentialsFile);
+  const root = path.resolve(repoRoot);
+  const rel = path.relative(root, abs);
+  const outside = rel.startsWith('..') || path.isAbsolute(rel);
+  if (!outside) {
+    throw new OAuthTunnelError(
+      'DENY: tunnel credentials must not live inside the repository',
+      'TUNNEL_CREDS_IN_REPO'
+    );
+  }
+  return abs;
+}
+
+export function resolveCloudflaredExecutable(env = process.env, existsSyncFn = fs.existsSync) {
+  const fromEnv = env[TUNNEL_SECRET_NAMES.cloudflaredExecutable];
+  if (fromEnv) {
+    if (!path.isAbsolute(fromEnv)) {
+      throw new OAuthTunnelError(
+        'DENY: I2_CLOUDFLARED_EXECUTABLE must be an absolute path',
+        'TUNNEL_BIN_NOT_ABSOLUTE'
+      );
+    }
+    if (!existsSyncFn(fromEnv)) {
+      throw new OAuthTunnelError('DENY: cloudflared executable not found', 'TUNNEL_BIN_MISSING');
+    }
+    return fromEnv;
+  }
+  // Common absolute installs only — never PATH search.
+  const candidates =
+    process.platform === 'win32'
+      ? [
+          'C:\\Program Files\\cloudflared\\cloudflared.exe',
+          'C:\\Program Files (x86)\\cloudflared\\cloudflared.exe',
+        ]
+      : ['/usr/local/bin/cloudflared', '/usr/bin/cloudflared'];
+  for (const c of candidates) {
+    if (existsSyncFn(c)) return c;
+  }
+  throw new OAuthTunnelError(
+    'DENY: cloudflared not found at approved absolute paths',
+    'TUNNEL_BIN_MISSING'
+  );
+}
+
+export function loadTunnelEnvConfig(env = process.env) {
+  const credentialsFile = env[TUNNEL_SECRET_NAMES.credentialsFile];
+  const tunnelId = env[TUNNEL_SECRET_NAMES.tunnelId];
+  return { credentialsFile, tunnelId };
+}
+
+/**
+ * Safe status lines — never include secrets, query strings, or credential paths' contents.
+ */
+export function formatTunnelStatus({
+  phase,
+  started = false,
+  stopped = false,
+  healthOk = false,
+  publicClosed = false,
+}) {
+  return [
+    `tunnel class: ${TUNNEL_CLASS}`,
+    `tunnel hostname: ${TUNNEL_STABLE_HOSTNAME}`,
+    `public redirect: ${PUBLIC_REDIRECT_URI}`,
+    `local listener: ${LOCAL_LISTENER_URI}`,
+    `forward path: ${TUNNEL_FORWARD_PATH}`,
+    `tunnel phase: ${phase}`,
+    `tunnel started: ${started ? 'yes' : 'no'}`,
+    `tunnel health: ${healthOk ? 'ok' : 'not-ok'}`,
+    `tunnel stopped: ${stopped ? 'yes' : 'no'}`,
+    `public callback closed: ${publicClosed ? 'yes' : 'no'}`,
+  ].join('\n');
+}
+
+/**
+ * Create a lifecycle controller. Injectables keep CI free of live Cloudflare.
+ */
+export function createTunnelController(options = {}) {
+  const env = options.env || process.env;
+  const repoRoot = options.repoRoot || process.cwd();
+  const spawnFn = options.spawnFn || childProcess.spawn;
+  const existsSyncFn = options.existsSyncFn || fs.existsSync;
+  const writeFileSyncFn = options.writeFileSyncFn || fs.writeFileSync;
+  const mkdirSyncFn = options.mkdirSyncFn || fs.mkdirSync;
+  const unlinkSyncFn = options.unlinkSyncFn || fs.unlinkSync;
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  const sleepFn =
+    options.sleepFn || ((ms) => new Promise((r) => setTimeout(r, ms)));
+  const healthTimeoutMs = options.healthTimeoutMs ?? 15_000;
+  const closureTimeoutMs = options.closureTimeoutMs ?? 15_000;
+  const readinessGate = options.readinessGate; // must be true / 'FOUNDER_RUN_READY' before start
+
+  let child = null;
+  let configPath = null;
+  let started = false;
+  let stopped = false;
+  let healthOk = false;
+  let publicClosed = false;
+
+  function status(phase) {
+    return formatTunnelStatus({
+      phase,
+      started,
+      stopped,
+      healthOk,
+      publicClosed,
+    });
+  }
+
+  function assertReadyToStart() {
+    if (readinessGate !== true && readinessGate !== 'FOUNDER_RUN_READY') {
+      throw new OAuthTunnelError(
+        'DENY: tunnel must not start before FOUNDER_RUN_READY',
+        'TUNNEL_READINESS_GATE'
+      );
+    }
+    const { credentialsFile, tunnelId } = loadTunnelEnvConfig(env);
+    if (!credentialsFile) {
+      throw new OAuthTunnelError(
+        `DENY: missing ${TUNNEL_SECRET_NAMES.credentialsFile}`,
+        'TUNNEL_CREDS_MISSING'
+      );
+    }
+    if (!tunnelId) {
+      throw new OAuthTunnelError(
+        `DENY: missing ${TUNNEL_SECRET_NAMES.tunnelId}`,
+        'TUNNEL_ID_MISSING'
+      );
+    }
+    const credsAbs = assertCredentialsOutsideRepo(credentialsFile, repoRoot);
+    if (!existsSyncFn(credsAbs)) {
+      throw new OAuthTunnelError('DENY: tunnel credentials file not found', 'TUNNEL_CREDS_MISSING');
+    }
+    const config = buildNamedTunnelIngressConfig({
+      tunnelId,
+      credentialsFile: credsAbs,
+    });
+    assertPathOnlyForwardContract(config);
+    const bin = resolveCloudflaredExecutable(env, existsSyncFn);
+    return { config, credsAbs, bin, tunnelId };
+  }
+
+  async function start() {
+    if (started && !stopped) {
+      throw new OAuthTunnelError('DENY: tunnel already started', 'TUNNEL_ALREADY_UP');
+    }
+    const { config, bin } = assertReadyToStart();
+    const dir = options.configDir || fs.mkdtempSync(path.join(os.tmpdir(), 'bhfos-oauth-tunnel-'));
+    mkdirSyncFn(dir, { recursive: true });
+    configPath = path.join(dir, 'oauth-tunnel-config.yml');
+    writeFileSyncFn(configPath, serializeTunnelConfigYaml(config), { encoding: 'utf8', mode: 0o600 });
+
+    child = spawnFn(bin, ['tunnel', '--config', configPath, 'run'], {
+      detached: false,
+      stdio: 'ignore',
+      shell: false,
+      windowsHide: true,
+    });
+    if (!child) {
+      throw new OAuthTunnelError('DENY: failed to spawn cloudflared', 'TUNNEL_SPAWN');
+    }
+    started = true;
+    stopped = false;
+    healthOk = false;
+    publicClosed = false;
+    return { status: status('started'), configPath };
+  }
+
+  async function verifyHealth() {
+    if (!started || stopped) {
+      throw new OAuthTunnelError('DENY: tunnel not running for health check', 'TUNNEL_NOT_RUNNING');
+    }
+    if (typeof fetchImpl !== 'function') {
+      throw new OAuthTunnelError('DENY: fetch unavailable for tunnel health', 'TUNNEL_HEALTH');
+    }
+    const deadline = Date.now() + healthTimeoutMs;
+    let lastErr = 'unreachable';
+    while (Date.now() < deadline) {
+      try {
+        // Probe path only — never attach authorize query params.
+        const res = await fetchImpl(TUNNEL_PUBLIC_CALLBACK_URL, {
+          method: 'GET',
+          redirect: 'manual',
+        });
+        // Helper may 400 without state; any HTTP response proves path forward.
+        if (res && typeof res.status === 'number' && res.status > 0) {
+          healthOk = true;
+          return { status: status('health_ok'), httpStatus: res.status };
+        }
+        lastErr = `status=${res && res.status}`;
+      } catch (e) {
+        lastErr = e && e.code ? e.code : 'fetch_error';
+      }
+      await sleepFn(250);
+    }
+    throw new OAuthTunnelError(
+      `DENY: tunnel health check failed (${lastErr})`,
+      'TUNNEL_HEALTH'
+    );
+  }
+
+  async function stop() {
+    if (!started) {
+      stopped = true;
+      return { status: status('stop_noop') };
+    }
+    if (stopped) {
+      return { status: status('already_stopped') };
+    }
+    try {
+      if (child && !child.killed) {
+        if (typeof options.killFn === 'function') {
+          options.killFn(child);
+        } else {
+          child.kill('SIGTERM');
+        }
+      }
+    } catch {
+      /* continue to mark stopped; closure verify is authoritative */
+    }
+    child = null;
+    stopped = true;
+    if (configPath) {
+      try {
+        unlinkSyncFn(configPath);
+      } catch {
+        /* ignore */
+      }
+      configPath = null;
+    }
+    return { status: status('stopped') };
+  }
+
+  /**
+   * After stop: public callback must no longer serve the helper.
+   * Connection failure / timeout / non-forward = closed.
+   */
+  async function verifyPublicCallbackClosed() {
+    if (!stopped) {
+      throw new OAuthTunnelError(
+        'DENY: cannot verify public callback closure while tunnel not stopped',
+        'TUNNEL_STILL_UP'
+      );
+    }
+    if (typeof fetchImpl !== 'function') {
+      throw new OAuthTunnelError('DENY: fetch unavailable for closure verify', 'TUNNEL_CLOSURE');
+    }
+    const deadline = Date.now() + closureTimeoutMs;
+    while (Date.now() < deadline) {
+      try {
+        const res = await fetchImpl(TUNNEL_PUBLIC_CALLBACK_URL, {
+          method: 'GET',
+          redirect: 'manual',
+        });
+        // If still getting helper-like responses after stop, not closed yet.
+        if (res && (res.status === 200 || res.status === 400 || res.status === 404)) {
+          await sleepFn(250);
+          continue;
+        }
+        // Unexpected success statuses also fail closed until timeout.
+        await sleepFn(250);
+      } catch {
+        publicClosed = true;
+        return { status: status('public_callback_closed'), closed: true };
+      }
+    }
+    // Still reachable after stop → governance-blocked condition
+    publicClosed = false;
+    throw new OAuthTunnelError(
+      'DENY: public callback still reachable after tunnel stop',
+      'TUNNEL_CLOSURE_FAILED'
+    );
+  }
+
+  /**
+   * Run authorizeBody with guaranteed stop + closure verify afterward.
+   */
+  async function runWithTunnel(authorizeBody) {
+    let bodyError = null;
+    let bodyResult = null;
+    try {
+      await start();
+      await verifyHealth();
+      bodyResult = await authorizeBody();
+    } catch (e) {
+      bodyError = e;
+    } finally {
+      try {
+        await stop();
+      } catch (stopErr) {
+        if (!bodyError) bodyError = stopErr;
+      }
+      try {
+        await verifyPublicCallbackClosed();
+      } catch (closeErr) {
+        if (!bodyError) bodyError = closeErr;
+      }
+    }
+    if (bodyError) throw bodyError;
+    return bodyResult;
+  }
+
+  return {
+    assertReadyToStart,
+    start,
+    verifyHealth,
+    stop,
+    verifyPublicCallbackClosed,
+    runWithTunnel,
+    status,
+    getState: () => ({ started, stopped, healthOk, publicClosed, configPath }),
+  };
+}
+
+export {
+  PUBLIC_REDIRECT_URI,
+  LOCAL_LISTENER_URI,
+  PUBLIC_CALLBACK_HOST,
+  OAuthHelperError,
+};

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-tunnel.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-tunnel.self-test.mjs
@@ -1,0 +1,323 @@
+/**
+ * Self-tests for Cloudflare Named Tunnel OAuth wrapper — mocks only, no live Cloudflare.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  PUBLIC_REDIRECT_URI,
+  LOCAL_LISTENER_URI,
+  CALLBACK_PATH,
+} from './oauth-helper.mjs';
+import {
+  TUNNEL_CLASS,
+  TUNNEL_STABLE_HOSTNAME,
+  TUNNEL_FORWARD_PATH,
+  TUNNEL_SECRET_NAMES,
+  buildNamedTunnelIngressConfig,
+  assertPathOnlyForwardContract,
+  assertCredentialsOutsideRepo,
+  serializeTunnelConfigYaml,
+  formatTunnelStatus,
+  createTunnelController,
+  OAuthTunnelError,
+} from './oauth-tunnel.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function pass(results, test, ok, detail) {
+  results.push({ test, pass: Boolean(ok), ...(detail ? { detail: String(detail).slice(0, 120) } : {}) });
+}
+
+export async function runTunnelSelfTests() {
+  const results = [];
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'bhfos-tunnel-'));
+  const credsOutside = path.join(tmp, 'tunnel-credentials.json');
+  fs.writeFileSync(credsOutside, '{"AccountTag":"synthetic","TunnelID":"synthetic-id"}\n', 'utf8');
+  const fakeBin = path.join(tmp, process.platform === 'win32' ? 'cloudflared.exe' : 'cloudflared');
+  fs.writeFileSync(fakeBin, '', 'utf8');
+
+  // --- public vs local contract ---
+  pass(
+    results,
+    'public_https_redirect_exact',
+    PUBLIC_REDIRECT_URI === 'https://oauth-diagnostics.bhfos.com/oauth/callback'
+  );
+  pass(
+    results,
+    'local_http_listener_exact',
+    LOCAL_LISTENER_URI === 'http://127.0.0.1:8765/oauth/callback'
+  );
+  pass(
+    results,
+    'stable_hostname_pinned',
+    TUNNEL_STABLE_HOSTNAME === 'oauth-diagnostics.bhfos.com' && TUNNEL_CLASS === 'cloudflare_named'
+  );
+  pass(results, 'forward_path_only_oauth_callback', TUNNEL_FORWARD_PATH === '/oauth/callback');
+
+  // --- path-only config ---
+  const good = buildNamedTunnelIngressConfig({
+    tunnelId: 'synthetic-tunnel-id',
+    credentialsFile: credsOutside,
+  });
+  pass(results, 'path_only_contract_ok', assertPathOnlyForwardContract(good) === true);
+  pass(
+    results,
+    'host_rewrite_to_loopback',
+    good.ingress[0].originRequest.httpHostHeader === '127.0.0.1:8765'
+  );
+  pass(results, 'catch_all_deny_present', good.ingress[1].service === 'http_status:404');
+
+  try {
+    buildNamedTunnelIngressConfig({
+      tunnelId: 'x',
+      credentialsFile: credsOutside,
+      hostname: 'random-abc.trycloudflare.com',
+    });
+    pass(results, 'random_hostname_rejected', false);
+  } catch (e) {
+    pass(results, 'random_hostname_rejected', e instanceof OAuthTunnelError && e.code === 'TUNNEL_HOSTNAME');
+  }
+
+  try {
+    buildNamedTunnelIngressConfig({
+      tunnelId: 'x',
+      credentialsFile: credsOutside,
+      forwardPath: '/admin',
+    });
+    pass(results, 'non_callback_path_rejected', false);
+  } catch (e) {
+    pass(results, 'non_callback_path_rejected', e.code === 'TUNNEL_PATH');
+  }
+
+  const multi = {
+    tunnel: 'x',
+    'credentials-file': credsOutside,
+    ingress: [
+      {
+        hostname: TUNNEL_STABLE_HOSTNAME,
+        path: CALLBACK_PATH,
+        service: 'http://127.0.0.1:8765',
+        originRequest: { httpHostHeader: '127.0.0.1:8765' },
+      },
+      {
+        hostname: TUNNEL_STABLE_HOSTNAME,
+        path: '/',
+        service: 'http://127.0.0.1:8765',
+      },
+      { service: 'http_status:404' },
+    ],
+  };
+  try {
+    assertPathOnlyForwardContract(multi);
+    pass(results, 'extra_forward_paths_rejected', false);
+  } catch (e) {
+    pass(results, 'extra_forward_paths_rejected', e.code === 'TUNNEL_INGRESS_EXTRA');
+  }
+
+  // --- credentials outside repo ---
+  pass(
+    results,
+    'credentials_outside_repo_ok',
+    assertCredentialsOutsideRepo(credsOutside, repoRoot) === path.resolve(credsOutside)
+  );
+  const insideCreds = path.join(repoRoot, 'tunnel-credentials-MUST-NOT-EXIST.json');
+  try {
+    assertCredentialsOutsideRepo(insideCreds, repoRoot);
+    pass(results, 'credentials_inside_repo_rejected', false);
+  } catch (e) {
+    pass(results, 'credentials_inside_repo_rejected', e.code === 'TUNNEL_CREDS_IN_REPO');
+  }
+
+  // --- missing creds fail closed ---
+  try {
+    const ctrl = createTunnelController({
+      env: {
+        [TUNNEL_SECRET_NAMES.tunnelId]: 'synthetic',
+        // credentials missing
+        [TUNNEL_SECRET_NAMES.cloudflaredExecutable]: fakeBin,
+      },
+      repoRoot,
+      readinessGate: 'FOUNDER_RUN_READY',
+      existsSyncFn: (p) => p === fakeBin,
+    });
+    ctrl.assertReadyToStart();
+    pass(results, 'missing_creds_fail_closed', false);
+  } catch (e) {
+    pass(
+      results,
+      'missing_creds_fail_closed',
+      e instanceof OAuthTunnelError && e.code === 'TUNNEL_CREDS_MISSING'
+    );
+  }
+
+  // --- readiness gate ---
+  try {
+    const ctrl = createTunnelController({
+      env: {
+        [TUNNEL_SECRET_NAMES.credentialsFile]: credsOutside,
+        [TUNNEL_SECRET_NAMES.tunnelId]: 'synthetic',
+        [TUNNEL_SECRET_NAMES.cloudflaredExecutable]: fakeBin,
+      },
+      repoRoot,
+      readinessGate: false,
+      existsSyncFn: (p) => p === fakeBin || p === credsOutside,
+    });
+    await ctrl.start();
+    pass(results, 'start_before_ready_denied', false);
+  } catch (e) {
+    pass(results, 'start_before_ready_denied', e.code === 'TUNNEL_READINESS_GATE');
+  }
+
+  // --- lifecycle with mocks: start → health → stop → closure ---
+  let spawned = false;
+  let killed = false;
+  let fetchCalls = 0;
+  const ctrl = createTunnelController({
+    env: {
+      [TUNNEL_SECRET_NAMES.credentialsFile]: credsOutside,
+      [TUNNEL_SECRET_NAMES.tunnelId]: 'synthetic',
+      [TUNNEL_SECRET_NAMES.cloudflaredExecutable]: fakeBin,
+    },
+    repoRoot,
+    readinessGate: 'FOUNDER_RUN_READY',
+    existsSyncFn: (p) => p === fakeBin || p === credsOutside || fs.existsSync(p),
+    spawnFn: () => {
+      spawned = true;
+      return { killed: false, kill() { killed = true; this.killed = true; } };
+    },
+    killFn: (child) => {
+      killed = true;
+      child.killed = true;
+    },
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      // First calls while "up": helper-like 400; after stop: throw (closed)
+      if (!killed) return { status: 400 };
+      throw new Error('ECONNREFUSED');
+    },
+    sleepFn: async () => {},
+    healthTimeoutMs: 2000,
+    closureTimeoutMs: 2000,
+    configDir: tmp,
+  });
+
+  let bodyRan = false;
+  await ctrl.runWithTunnel(async () => {
+    bodyRan = true;
+    return 'ok';
+  });
+  const state = ctrl.getState();
+  pass(
+    results,
+    'lifecycle_stop_after_run',
+    spawned && killed && bodyRan && state.stopped && state.healthOk && state.publicClosed
+  );
+
+  // --- stop after failure ---
+  let killedOnFail = false;
+  const failCtrl = createTunnelController({
+    env: {
+      [TUNNEL_SECRET_NAMES.credentialsFile]: credsOutside,
+      [TUNNEL_SECRET_NAMES.tunnelId]: 'synthetic',
+      [TUNNEL_SECRET_NAMES.cloudflaredExecutable]: fakeBin,
+    },
+    repoRoot,
+    readinessGate: 'FOUNDER_RUN_READY',
+    existsSyncFn: (p) => p === fakeBin || p === credsOutside || fs.existsSync(p),
+    spawnFn: () => ({
+      killed: false,
+      kill() {
+        killedOnFail = true;
+        this.killed = true;
+      },
+    }),
+    fetchImpl: async () => {
+      if (!killedOnFail) return { status: 400 };
+      throw new Error('ECONNREFUSED');
+    },
+    sleepFn: async () => {},
+    configDir: tmp,
+  });
+  try {
+    await failCtrl.runWithTunnel(async () => {
+      throw new Error('synthetic authorize failure');
+    });
+    pass(results, 'stop_after_failure', false);
+  } catch (e) {
+    const st = failCtrl.getState();
+    pass(
+      results,
+      'stop_after_failure',
+      /synthetic authorize failure/.test(String(e.message)) && st.stopped && st.publicClosed
+    );
+  }
+
+  // --- status has no secret-shaped material ---
+  const yaml = serializeTunnelConfigYaml(good);
+  const status = formatTunnelStatus({
+    phase: 'test',
+    started: true,
+    stopped: true,
+    healthOk: true,
+    publicClosed: true,
+  });
+  const combined = status + yaml + JSON.stringify(results);
+  pass(
+    results,
+    'no_secret_shaped_status',
+    !/AccountTag|TunnelSecret|access_token|refresh_token|code_verifier|Bearer\s+\S{20,}/i.test(
+      combined
+    ) &&
+      status.includes('token values') === false &&
+      status.includes(PUBLIC_REDIRECT_URI) &&
+      status.includes(LOCAL_LISTENER_URI)
+  );
+
+  // --- closure verify fails if still reachable ---
+  const stuckCtrl = createTunnelController({
+    env: {
+      [TUNNEL_SECRET_NAMES.credentialsFile]: credsOutside,
+      [TUNNEL_SECRET_NAMES.tunnelId]: 'synthetic',
+      [TUNNEL_SECRET_NAMES.cloudflaredExecutable]: fakeBin,
+    },
+    repoRoot,
+    readinessGate: 'FOUNDER_RUN_READY',
+    existsSyncFn: (p) => p === fakeBin || p === credsOutside || fs.existsSync(p),
+    spawnFn: () => ({ killed: false, kill() { this.killed = true; } }),
+    fetchImpl: async () => ({ status: 400 }), // never closes
+    sleepFn: async () => {},
+    healthTimeoutMs: 100,
+    closureTimeoutMs: 100,
+    configDir: tmp,
+  });
+  try {
+    await stuckCtrl.runWithTunnel(async () => 'ok');
+    pass(results, 'closure_failure_blocks', false);
+  } catch (e) {
+    pass(results, 'closure_failure_blocks', e.code === 'TUNNEL_CLOSURE_FAILED');
+  }
+
+  pass(results, 'fetch_probe_used', fetchCalls >= 1);
+
+  try {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+
+  const failed = results.filter((r) => !r.pass);
+  return { ok: failed.length === 0, results, failed };
+}
+
+const isDirect =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirect) {
+  runTunnelSelfTests().then((r) => {
+    console.log(JSON.stringify({ ok: r.ok, failed: r.failed.map((f) => f.test) }, null, 2));
+    process.exit(r.ok ? 0 : 1);
+  });
+}


### PR DESCRIPTION
## Summary
- Split Diagnostics OAuth redirect_uri to the pinned public HTTPS callback `https://oauth-diagnostics.bhfos.com/oauth/callback` while keeping the local listener at `http://127.0.0.1:8765/oauth/callback`.
- Add Cloudflare Named Tunnel lifecycle wrapper with path-only `/oauth/callback` forwarding, Host rewrite to loopback, stop-after-every-authorize-attempt, and public callback closure verification (credentials outside repo).
- Add protected launcher preflight sequencing (exact SHA, clean worktree, external secret store, tunnel executable/config/credentials, local port, readiness gate) before tunnel start.
- Update ENVIRONMENT_ACCEPTANCE full path, FOUNDER_RUN_READINESS tunnel machine fields, Founder steps, self-tests, and CI.

## Exact SHAs
- **Base (main):** `4ea7d4c3ae170472881d32f35067e06d6ec1d910`
- **Head:** `e31f2901abe0d807e407b083a8bd27a25d628e60`

## Changed files
- .github/workflows/ci.yml
- command-center/docs/governance/ENVIRONMENT_ACCEPTANCE.md
- command-center/docs/governance/FOUNDER_RUN_READINESS.md
- command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md
- command-center/docs/governance/decisions/G2.3B-B2D_OPTION_B_TUNNEL_EXECUTION_DESIGN.md
- command-center/docs/governance/templates/FOUNDER_RUN_READINESS.template.json
- command-center/docs/stabilization/releases/G2.3B-B2D_HTTPS_TUNNEL_BRIEF.md
- command-center/package.json
- command-center/tools/founder-run-readiness.mjs
- command-center/tools/founder-run-readiness.self-test.mjs
- command-center/tools/supabase-diagnostics-adapter/README.md
- command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
- command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
- command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
- command-center/tools/supabase-diagnostics-adapter/oauth-launcher-preflight.mjs
- command-center/tools/supabase-diagnostics-adapter/oauth-launcher-preflight.self-test.mjs
- command-center/tools/supabase-diagnostics-adapter/oauth-tunnel.mjs
- command-center/tools/supabase-diagnostics-adapter/oauth-tunnel.self-test.mjs

## Implementation summary
Option B Named Tunnel design only. Public HTTPS redirect and local HTTP listener remain separate. PKCE + single-use state preserved. Tokens write only to approved external Diagnostics secret store. Safe status lines only (no codes/state/PKCE/secrets/tokens).

## Tests run (local)
- [x] `npm run test:supabase-oauth-helper`
- [x] `npm run test:supabase-oauth-tunnel`
- [x] `npm run test:supabase-oauth-launcher-preflight`
- [x] `npm run test:founder-run-readiness`
- [x] `npm run test:supabase-diagnostics-adapter`
- [x] Confirmed no secret values in test output
- [x] Confirmed no credential files added to the repository

## CI checks expected
- Supabase OAuth helper self-tests
- Supabase OAuth tunnel self-tests
- Supabase OAuth launcher preflight self-tests
- Founder run readiness self-tests
- Secret leakage prevention (existing helper/tunnel assertions)
- Exact URI and loopback separation contracts

## Explicit non-scope / non-actions
- No live OAuth / consent / token issuance
- No real Cloudflare tunnel create/login/DNS change
- No B3, migrations, Supabase schema/Edge Functions, Hostinger, production mutation
- No scope expansion; project ref remains `wwyxohjnyqnegzbxtuxs`
- No secrets, tokens, or tunnel credentials in the repository
- Not LOW-RISK control-plane lane eligible (credential / OAuth / callback / tunnel)

## PR #58 disposition
- **PR #58 is superseded and was not reused.** No self-signed loopback TLS, browser warning click-through, local certificate trust, or certificate bypasses.

## Confirmations
- No OAuth run occurred
- No live tunnel start occurred
- No DNS change occurred
- No deploy or production action occurred
- Diff stays within approved G2.3B-B2D Option B Builder scope