### PR TITLE
fix(ops): G2.3B-B2D platform-attested omitted OAuth scope + pre-store capability attestation

### DIFF
--- a/command-center/tools/supabase-diagnostics-adapter/README.md
+++ b/command-center/tools/supabase-diagnostics-adapter/README.md
@@ -50,6 +50,9 @@ Inventory names (values never in repo):
 - Tunnel credentials outside the repository
 - Tunnel stops after every authorize attempt; public callback closure verified
 - Windows browser launch uses approved Edge/Chrome **absolute** paths only
+- Token `scope` when **present**: fail-closed ⊆ `projects:read` only (`UNEXPECTED_SCOPE` DENY otherwise)
+- Token `scope` when **omitted/empty**: platform-attested OpenAPI omission (`OAuthTokenResponse` has no `scope`; `additionalProperties: false`) — **not** unconditional OK
+- Before any durable token write: pre-store capability attestation (allowlisted `GET /v1/projects/wwyxohjnyqnegzbxtuxs` must succeed; out-of-ceiling probe e.g. `/api-keys` must not)
 - Quarantined tokens from failed attempts (including PR #58) must be replaced before B3
 
 ```bash

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
@@ -43,6 +43,7 @@ import {
   validateCallbackRequest,
   buildTokenExchangeRequest,
   assertTokenScopes,
+  attestPreStoreCapabilities,
   computeExpiryIso,
   writeTokenSecretsToEnvFile,
   wipeTransient,
@@ -154,7 +155,7 @@ async function exchangeCode({ secrets, code, codeVerifier, fetchImpl = fetch }) 
     throw new Error(`DENY: token exchange failed (HTTP ${res.status})`);
   }
 
-  assertTokenScopes(json.scope);
+  const scopeInfo = assertTokenScopes(json.scope);
   if (!json.access_token || !json.refresh_token) {
     throw new Error('DENY: token response missing access_token or refresh_token');
   }
@@ -164,6 +165,7 @@ async function exchangeCode({ secrets, code, codeVerifier, fetchImpl = fetch }) 
     accessToken: json.access_token,
     refreshToken: json.refresh_token,
     tokenExpiry: expiry,
+    scopeInfo,
   };
 }
 
@@ -216,6 +218,13 @@ async function runAuthorizeExchange() {
     transient.refreshToken = tokens.refreshToken;
     console.log('token exchange completed');
     console.log('token values not displayed');
+    if (tokens.scopeInfo && tokens.scopeInfo.omitted) {
+      console.log('scope omitted (platform-attested OAuthTokenResponse); attesting capabilities');
+    }
+
+    // Pre-store capability attestation — fail closed; never store on failure.
+    await attestPreStoreCapabilities(tokens.accessToken);
+    console.log('pre-store capability attestation ok');
 
     let existingMap = secrets.fileMap || Object.create(null);
     try {

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
@@ -304,15 +304,25 @@ export function validateCallbackRequest({
 }
 
 /**
- * Assert token response scopes ⊆ allowed (projects:read only).
- * Omitted/empty scope is fail-closed (explicit decision — do not treat as OK).
+ * Assert token response scopes when the `scope` field is present.
+ *
+ * When omitted/empty: Management API OpenAPI `OAuthTokenResponse` has no `scope`
+ * property (`additionalProperties: false`), so omission is a platform-attested
+ * schema gap — not unconditional OK. Callers must run
+ * `attestPreStoreCapabilities` before any durable token write.
+ *
+ * When present: fail-closed ⊆ ALLOWED_SCOPES (`projects:read` only). No invented
+ * normalization (e.g. projects.read / rest).
  */
 export function assertTokenScopes(scopeField) {
   if (scopeField === undefined || scopeField === null || String(scopeField).trim() === '') {
-    throw new OAuthHelperError(
-      'DENY: token response missing scope; expected projects:read',
-      'MISSING_SCOPE'
-    );
+    return {
+      omitted: true,
+      scopes: [],
+      platformAttestedOmission: true,
+      reason:
+        'OAuthTokenResponse OpenAPI omits scope (additionalProperties:false); require pre-store capability attestation',
+    };
   }
   const parts = String(scopeField)
     .split(/[\s,]+/)
@@ -332,7 +342,124 @@ export function assertTokenScopes(scopeField) {
       'MISSING_PROJECTS_READ'
     );
   }
-  return { omitted: false, scopes: parts };
+  return { omitted: false, scopes: parts, platformAttestedOmission: false };
+}
+
+/**
+ * Out-of-ceiling probe path under the locked production ref.
+ * Must match a prohibited_path_substrings entry in allowlist.json (adapter-enforced).
+ */
+export function attestationOutOfCeilingPath(ref = PRODUCTION_PROJECT_REF) {
+  return `/v1/projects/${ref}/api-keys`;
+}
+
+/**
+ * Pre-store capability attestation with the ephemeral access token.
+ * Required before any durable env/token write (especially when scope is omitted).
+ *
+ * - Allowlisted GET /v1/projects/{production_ref} must succeed
+ * - At least one out-of-ceiling probe (api-keys) must NOT succeed
+ * Fail → do not store tokens.
+ *
+ * Reuses adapter allowlist/deny helpers; fetch is injected (no live network in tests).
+ */
+export async function attestPreStoreCapabilities(
+  accessToken,
+  {
+    fetchImpl = globalThis.fetch,
+    resolveAllowedPathFn,
+    assertNotProhibitedFn,
+    managementApiBase = 'https://api.supabase.com',
+  } = {}
+) {
+  if (!accessToken || typeof accessToken !== 'string') {
+    throw new OAuthHelperError(
+      'DENY: pre-store attestation requires ephemeral access token',
+      'ATTEST_MISSING_TOKEN'
+    );
+  }
+  if (typeof fetchImpl !== 'function') {
+    throw new OAuthHelperError('DENY: fetch unavailable for pre-store attestation', 'ATTEST_FETCH');
+  }
+
+  let resolveAllowedPath = resolveAllowedPathFn;
+  let assertNotProhibited = assertNotProhibitedFn;
+  if (!resolveAllowedPath || !assertNotProhibited) {
+    const adapter = await import('./adapter.mjs');
+    resolveAllowedPath = resolveAllowedPath || adapter.resolveAllowedPath;
+    assertNotProhibited = assertNotProhibited || adapter.assertNotProhibited;
+  }
+
+  const { method, path: allowPath, ref } = resolveAllowedPath('project_status', {});
+  if (ref !== PRODUCTION_PROJECT_REF || allowPath !== `/v1/projects/${PRODUCTION_PROJECT_REF}`) {
+    throw new OAuthHelperError(
+      'DENY: attestation allowlisted path mismatch',
+      'ATTEST_ALLOW_PATH'
+    );
+  }
+
+  const probePath = attestationOutOfCeilingPath(ref);
+  try {
+    assertNotProhibited(probePath);
+    throw new OAuthHelperError(
+      'DENY: attestation out-of-ceiling probe path is not prohibited by allowlist',
+      'ATTEST_PROBE_CONFIG'
+    );
+  } catch (e) {
+    if (e instanceof OAuthHelperError) throw e;
+    if (!/DENY/.test(String(e && e.message ? e.message : e))) {
+      throw new OAuthHelperError(
+        'DENY: attestation probe allowlist check failed unexpectedly',
+        'ATTEST_PROBE_CONFIG'
+      );
+    }
+  }
+
+  const base = String(managementApiBase || 'https://api.supabase.com').replace(/\/$/, '');
+  const headers = {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: 'application/json',
+  };
+
+  let allowRes;
+  try {
+    allowRes = await fetchImpl(`${base}${allowPath}`, { method, headers });
+  } catch {
+    throw new OAuthHelperError(
+      'DENY: pre-store capability attestation failed (allowlisted GET unreachable)',
+      'ATTEST_ALLOW_FAILED'
+    );
+  }
+  if (!allowRes || !allowRes.ok) {
+    const status = allowRes && typeof allowRes.status === 'number' ? allowRes.status : 'n/a';
+    throw new OAuthHelperError(
+      `DENY: pre-store capability attestation failed (allowlisted GET HTTP ${status})`,
+      'ATTEST_ALLOW_FAILED'
+    );
+  }
+
+  let probeRes;
+  try {
+    probeRes = await fetchImpl(`${base}${probePath}`, { method: 'GET', headers });
+  } catch {
+    throw new OAuthHelperError(
+      'DENY: pre-store capability attestation failed (out-of-ceiling probe unreachable)',
+      'ATTEST_PROBE_UNREACHABLE'
+    );
+  }
+  if (probeRes && probeRes.ok) {
+    throw new OAuthHelperError(
+      'DENY: pre-store capability attestation failed (out-of-ceiling probe succeeded)',
+      'ATTEST_CEILING_BREACH'
+    );
+  }
+
+  return {
+    allowlistedOk: true,
+    outOfCeilingDenied: true,
+    allowPath,
+    probePath,
+  };
 }
 
 export function computeExpiryIso(expiresIn, nowMs = Date.now()) {

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
@@ -26,6 +26,8 @@ import {
   buildTokenExchangeRequest,
   validateCallbackRequest,
   assertTokenScopes,
+  attestPreStoreCapabilities,
+  attestationOutOfCeilingPath,
   computeExpiryIso,
   writeTokenSecretsToEnvFile,
   wipeTransient,
@@ -206,13 +208,79 @@ export async function runSelfTests() {
   } catch (e) {
     pass(results, 'unexpected_scope_rejected', e.code === 'UNEXPECTED_SCOPE');
   }
-  try {
-    assertTokenScopes('');
-    pass(results, 'omitted_scope_fail_closed', false);
-  } catch (e) {
-    pass(results, 'omitted_scope_fail_closed', e.code === 'MISSING_SCOPE');
-  }
+  const omitted = assertTokenScopes('');
+  const omittedUndef = assertTokenScopes(undefined);
+  pass(
+    results,
+    'omitted_scope_platform_attested',
+    omitted.omitted === true &&
+      omitted.platformAttestedOmission === true &&
+      omittedUndef.omitted === true &&
+      Array.isArray(omitted.scopes) &&
+      omitted.scopes.length === 0
+  );
   pass(results, 'allowed_scope_ok', assertTokenScopes('projects:read').scopes.includes('projects:read'));
+
+  // --- pre-store capability attestation (injected fetch; no live network) ---
+  const allowPath = `/v1/projects/${PRODUCTION_PROJECT_REF}`;
+  const probePath = attestationOutOfCeilingPath();
+  pass(
+    results,
+    'attestation_probe_path_is_api_keys',
+    probePath === `/v1/projects/${PRODUCTION_PROJECT_REF}/api-keys`
+  );
+
+  const mockResolveAllowed = () => ({
+    method: 'GET',
+    path: allowPath,
+    ref: PRODUCTION_PROJECT_REF,
+    operation: 'project_status',
+  });
+  const mockAssertProhibited = (p) => {
+    if (String(p).includes('/api-keys')) {
+      throw new Error(`DENY: prohibited path pattern "/api-keys" in ${p}`);
+    }
+  };
+
+  try {
+    await attestPreStoreCapabilities('tok_ephemeral_attest_ok', {
+      fetchImpl: async (url) => {
+        if (String(url).endsWith(allowPath)) return { ok: true, status: 200 };
+        if (String(url).endsWith(probePath)) return { ok: false, status: 403 };
+        return { ok: false, status: 404 };
+      },
+      resolveAllowedPathFn: mockResolveAllowed,
+      assertNotProhibitedFn: mockAssertProhibited,
+    });
+    pass(results, 'attestation_allow_ok_probe_denied', true);
+  } catch (e) {
+    pass(results, 'attestation_allow_ok_probe_denied', false, e && e.message);
+  }
+
+  try {
+    await attestPreStoreCapabilities('tok_ephemeral_attest_allow_fail', {
+      fetchImpl: async (url) => {
+        if (String(url).endsWith(allowPath)) return { ok: false, status: 401 };
+        return { ok: false, status: 403 };
+      },
+      resolveAllowedPathFn: mockResolveAllowed,
+      assertNotProhibitedFn: mockAssertProhibited,
+    });
+    pass(results, 'attestation_allow_fail_no_store', false);
+  } catch (e) {
+    pass(results, 'attestation_allow_fail_no_store', e.code === 'ATTEST_ALLOW_FAILED');
+  }
+
+  try {
+    await attestPreStoreCapabilities('tok_ephemeral_attest_ceiling', {
+      fetchImpl: async () => ({ ok: true, status: 200 }),
+      resolveAllowedPathFn: mockResolveAllowed,
+      assertNotProhibitedFn: mockAssertProhibited,
+    });
+    pass(results, 'attestation_ceiling_breach_denied', false);
+  } catch (e) {
+    pass(results, 'attestation_ceiling_breach_denied', e.code === 'ATTEST_CEILING_BREACH');
+  }
 
   // --- authorize URL / PKCE S256 / ampersands ---
   const url = buildAuthorizeUrl({

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-tunnel.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-tunnel.mjs
@@ -419,19 +419,24 @@ export function createTunnelController(options = {}) {
           method: 'GET',
           redirect: 'manual',
         });
+        // Cloudflare edge errors after tunnel stop mean the public callback is closed.
+        if (res && (res.status === 502 || res.status === 530)) {
+          publicClosed = true;
+          return { status: status('public_callback_closed'), closed: true };
+        }
         // If still getting helper-like responses after stop, not closed yet.
         if (res && (res.status === 200 || res.status === 400 || res.status === 404)) {
           await sleepFn(250);
           continue;
         }
-        // Unexpected success statuses also fail closed until timeout.
+        // Other statuses: keep polling until timeout (do not claim closed).
         await sleepFn(250);
       } catch {
         publicClosed = true;
         return { status: status('public_callback_closed'), closed: true };
       }
     }
-    // Still reachable after stop → governance-blocked condition
+    // Still reachable after stop → surface failure (do not swallow as closed)
     publicClosed = false;
     throw new OAuthTunnelError(
       'DENY: public callback still reachable after tunnel stop',

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-tunnel.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-tunnel.self-test.mjs
@@ -301,6 +301,38 @@ export async function runTunnelSelfTests() {
     pass(results, 'closure_failure_blocks', e.code === 'TUNNEL_CLOSURE_FAILED');
   }
 
+  // --- 502/530 after stop counts as public callback closed ---
+  let killed502 = false;
+  const closed502Ctrl = createTunnelController({
+    env: {
+      [TUNNEL_SECRET_NAMES.credentialsFile]: credsOutside,
+      [TUNNEL_SECRET_NAMES.tunnelId]: 'synthetic',
+      [TUNNEL_SECRET_NAMES.cloudflaredExecutable]: fakeBin,
+    },
+    repoRoot,
+    readinessGate: 'FOUNDER_RUN_READY',
+    existsSyncFn: (p) => p === fakeBin || p === credsOutside || fs.existsSync(p),
+    spawnFn: () => ({
+      killed: false,
+      kill() {
+        killed502 = true;
+        this.killed = true;
+      },
+    }),
+    fetchImpl: async () => {
+      if (!killed502) return { status: 400 };
+      return { status: 502 };
+    },
+    sleepFn: async () => {},
+    configDir: tmp,
+  });
+  await closed502Ctrl.runWithTunnel(async () => 'ok');
+  pass(
+    results,
+    'closure_502_treated_as_closed',
+    closed502Ctrl.getState().publicClosed === true
+  );
+
   pass(results, 'fetch_probe_used', fetchCalls >= 1);
 
   try {


### PR DESCRIPTION
## Summary
- Treat omitted/empty token `scope` as platform-attested OpenAPI omission (`OAuthTokenResponse` has no `scope`; `additionalProperties: false`), not unconditional OK and not `MISSING_SCOPE` DENY.
- Before any durable token write, run pre-store capability attestation with the ephemeral access token: allowlisted `GET /v1/projects/wwyxohjnyqnegzbxtuxs` must succeed; out-of-ceiling `/api-keys` probe must not.
- When `scope` is present, keep fail-closed ⊆ `projects:read` only (`UNEXPECTED_SCOPE` DENY unchanged). No `ALLOWED_SCOPES` expansion.
- Optional hygiene: treat Cloudflare 502/530 as public callback closed after tunnel stop; still surface closure failure when still reachable.

## Test plan
- [x] `npm run test:supabase-oauth-helper` (includes oauth + tunnel + preflight)
- [x] `npm run test:supabase-diagnostics-adapter`
- [x] `npm run test:supabase-oauth-tunnel`
- [x] `npm run test:supabase-oauth-launcher-preflight`
- [ ] After merge: Diagnostics re-readiness → Founder re-authorize (tokens were never stored on prior DENY)

## Governance
- **FOUNDER_RUN_BLOCKED** until merge + Diagnostics re-readiness
- No live OAuth / tunnel / deploy in this PR
- Founder must re-authorize after merge

Made with [Cursor](https://cursor.com)