### PR TITLE
fix(ops): G2.3B-B3 adapter-owned project-health services query

### DIFF
--- a/command-center/tools/supabase-diagnostics-adapter/adapter.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/adapter.mjs
@@ -25,6 +25,13 @@ const allowlistPath = path.join(here, 'allowlist.json');
 /** Hard-coded production project ref — adapter isolation boundary (not token ACL). */
 export const PRODUCTION_PROJECT_REF = 'wwyxohjnyqnegzbxtuxs';
 
+/**
+ * Adapter-owned fixed query for project_health only.
+ * Management API GET /v1/projects/{ref}/health requires `services` (array enum).
+ * Never accept agent-supplied query strings.
+ */
+export const PROJECT_HEALTH_FIXED_QUERY = 'services=db&services=auth&services=rest';
+
 export function loadAllowlist() {
   return JSON.parse(fs.readFileSync(allowlistPath, 'utf8'));
 }
@@ -76,17 +83,22 @@ export function resolveAllowedPath(operation, { agentRef } = {}) {
   }
 
   const ref = resolveProductionProjectRef({ agentRef });
-  const built = op.pathTemplate.replace('{ref}', ref);
+  let built = op.pathTemplate.replace('{ref}', ref);
+  if (operation === 'project_health') {
+    built = `${built}?${PROJECT_HEALTH_FIXED_QUERY}`;
+  }
 
-  if (list.prohibited_exact_paths?.includes(built)) {
-    throw new Error(`DENY: exact path prohibited: ${built}`);
+  const pathOnly = built.split('?')[0];
+
+  if (list.prohibited_exact_paths?.includes(pathOnly)) {
+    throw new Error(`DENY: exact path prohibited: ${pathOnly}`);
   }
 
   const exactOk = Object.values(list.operations).some(
-    (o) => o.status === 'allowed' && o.pathTemplate.replace('{ref}', ref) === built
+    (o) => o.status === 'allowed' && o.pathTemplate.replace('{ref}', ref) === pathOnly
   );
   if (!exactOk) {
-    throw new Error(`DENY: path not on allowlist: ${built}`);
+    throw new Error(`DENY: path not on allowlist: ${pathOnly}`);
   }
 
   assertNotProhibited(built);
@@ -96,7 +108,10 @@ export function resolveAllowedPath(operation, { agentRef } = {}) {
 /** Paths that must never be requested. */
 export function assertNotProhibited(requestPath) {
   const list = loadAllowlist();
-  const pathOnly = String(requestPath).split('?')[0];
+  const raw = String(requestPath);
+  const qIdx = raw.indexOf('?');
+  const pathOnly = qIdx === -1 ? raw : raw.slice(0, qIdx);
+  const query = qIdx === -1 ? '' : raw.slice(qIdx + 1);
 
   if (list.prohibited_exact_paths?.includes(pathOnly)) {
     throw new Error(`DENY: exact path prohibited: ${pathOnly}`);
@@ -107,12 +122,16 @@ export function assertNotProhibited(requestPath) {
   }
 
   for (const pattern of list.prohibited_path_substrings) {
-    if (requestPath.includes(pattern)) {
+    if (raw.includes(pattern)) {
       throw new Error(`DENY: prohibited path pattern "${pattern}" in ${requestPath}`);
     }
   }
 
-  if (String(requestPath).includes('?')) {
+  if (qIdx !== -1) {
+    const allowedHealthPath = `/v1/projects/${PRODUCTION_PROJECT_REF}/health`;
+    if (pathOnly === allowedHealthPath && query === PROJECT_HEALTH_FIXED_QUERY) {
+      return;
+    }
     throw new Error('DENY: query strings are not permitted on adapter requests');
   }
 }
@@ -200,18 +219,76 @@ export function selfTest() {
   const results = [];
   const goodRef = PRODUCTION_PROJECT_REF;
   const badRef = 'abcdefghijklmnopqrst';
+  const list = loadAllowlist();
 
-  for (const op of ['project_status', 'project_health']) {
-    try {
-      const r = resolveAllowedPath(op, {});
-      results.push({
-        test: `allow_${op}`,
-        pass: r.ref === goodRef && r.path.includes(goodRef) && r.method === 'GET',
-        path: r.path,
-      });
-    } catch (e) {
-      results.push({ test: `allow_${op}`, pass: false, error: String(e.message || e) });
-    }
+  results.push({
+    test: 'allowlist_health_fixed_query_matches_constant',
+    pass:
+      list.operations?.project_health?.fixedQuery === PROJECT_HEALTH_FIXED_QUERY,
+  });
+
+  try {
+    const r = resolveAllowedPath('project_status', {});
+    results.push({
+      test: 'allow_project_status',
+      pass:
+        r.ref === goodRef &&
+        r.path === `/v1/projects/${goodRef}` &&
+        r.method === 'GET' &&
+        !r.path.includes('?'),
+      path: r.path,
+    });
+  } catch (e) {
+    results.push({ test: 'allow_project_status', pass: false, error: String(e.message || e) });
+  }
+
+  try {
+    const r = resolveAllowedPath('project_health', {});
+    const expected = `/v1/projects/${goodRef}/health?${PROJECT_HEALTH_FIXED_QUERY}`;
+    results.push({
+      test: 'allow_project_health_fixed_query',
+      pass: r.ref === goodRef && r.path === expected && r.method === 'GET',
+      path: r.path,
+    });
+  } catch (e) {
+    results.push({
+      test: 'allow_project_health_fixed_query',
+      pass: false,
+      error: String(e.message || e),
+    });
+  }
+
+  try {
+    assertNotProhibited(`/v1/projects/${goodRef}/health?services=storage`);
+    results.push({ test: 'deny_agent_health_query', pass: false, error: 'expected deny' });
+  } catch (e) {
+    results.push({
+      test: 'deny_agent_health_query',
+      pass: /DENY/.test(String(e.message || e)),
+    });
+  }
+
+  try {
+    assertNotProhibited(`/v1/projects/${goodRef}?foo=bar`);
+    results.push({ test: 'deny_arbitrary_query', pass: false, error: 'expected deny' });
+  } catch (e) {
+    results.push({
+      test: 'deny_arbitrary_query',
+      pass: /DENY/.test(String(e.message || e)),
+    });
+  }
+
+  try {
+    assertNotProhibited(
+      `/v1/projects/${goodRef}/health?${PROJECT_HEALTH_FIXED_QUERY}`
+    );
+    results.push({ test: 'allow_fixed_health_query_assert', pass: true });
+  } catch (e) {
+    results.push({
+      test: 'allow_fixed_health_query_assert',
+      pass: false,
+      error: String(e.message || e),
+    });
   }
 
   try {
@@ -298,7 +375,16 @@ export function selfTest() {
       test: 'dry_run_locked_ref',
       pass: out.ref === goodRef && out.path === `/v1/projects/${goodRef}`,
     });
-    const failed = results.filter((r) => !r.pass);
-    return { ok: failed.length === 0, results, failed };
+    return invokeAllowlisted('project_health', { dryRun: true }).then((healthOut) => {
+      results.push({
+        test: 'dry_run_project_health_fixed_query',
+        pass:
+          healthOut.ref === goodRef &&
+          healthOut.path ===
+            `/v1/projects/${goodRef}/health?${PROJECT_HEALTH_FIXED_QUERY}`,
+      });
+      const failed = results.filter((r) => !r.pass);
+      return { ok: failed.length === 0, results, failed };
+    });
   });
 }

--- a/command-center/tools/supabase-diagnostics-adapter/allowlist.json
+++ b/command-center/tools/supabase-diagnostics-adapter/allowlist.json
@@ -7,7 +7,8 @@
     "B2D: project isolation is adapter-enforced via fixed production_project_ref. OAuth token is NOT claimed project-scoped.",
     "Dashboard OAuth scope for Option A is Projects Read (wire: projects:read). Do not treat Management API ids (projects_read, project_admin_read) as interchangeable Dashboard choices.",
     "Projects Read may enable additional project-related reads (network restrictions/bans, upgrade eligibility, listing). Adapter must still expose only allowlisted operations.",
-    "Health endpoint GET /v1/projects/{ref}/health verified in official Management API docs (2026-07-17)."
+    "Health endpoint GET /v1/projects/{ref}/health verified in official Management API docs (2026-07-17).",
+    "B3: project_health uses an adapter-owned fixed query services=db&services=auth&services=rest (Management API requires services). Agent-supplied or arbitrary query strings remain DENY."
   ],
   "allowed_path_prefixes": [
     "/v1/projects/{ref}"
@@ -25,9 +26,10 @@
       "status": "allowed",
       "method": "GET",
       "pathTemplate": "/v1/projects/{ref}/health",
+      "fixedQuery": "services=db&services=auth&services=rest",
       "docs": "https://supabase.com/docs/reference/api/v1-get-project-health",
       "oauth_app_scope": "projects:read",
-      "note": "Included only as verified non-sensitive health metadata under Option A allowlist"
+      "note": "Adapter appends fixedQuery only; agent cannot supply or alter the services list. Non-sensitive health metadata under Option A allowlist."
     },
     "edge_function_inventory": {
       "status": "deferred",


### PR DESCRIPTION
## Summary
- Allow only an adapter-owned fixed query for `project_health`: `services=db&services=auth&services=rest` (Management API requires `services`).
- Keep rejecting agent-supplied / arbitrary query strings; prohibited substrings unchanged.
- Update allowlist notes + self-tests for the fixed health path.

## Test plan
- [x] `node tools/supabase-diagnostics-adapter/cli.mjs --self-test` (ok)
- [x] `--dry-run project_health` resolves fixed query path
- [ ] Live `project-health` re-probe after Founder merge auth (Orchestrator/Diagnostics)

## Notes
- Base: `9741d6b742f3f3ede330aaed1421d124471d019c`.
- No OAuth scope expansion; no Edge/analytics/logging SQL.

Made with [Cursor](https://cursor.com)