### PR TITLE
ML-P1 planning docs: Money Loop Phase 1 lock focus

### DIFF
--- a/command-center/docs/governance/RELEASE_BATON.g2-3.yaml
+++ b/command-center/docs/governance/RELEASE_BATON.g2-3.yaml
@@ -1,47 +1,33 @@
 ---
-# Release Baton — BHFOS Operating Model v2.2
+# Release Baton — G2.3 (CLOSED)
+# G2.3 Stabilization Exit Review: minimum safe baseline met at 6bc8db4…
+# Next program: ML-P1 planning — see RELEASE_BATON.ml-p1.yaml
 
 release_id: "G2.3"
-current_phase: "G2.3B-B2D"
+current_phase: "closed"
 governance_version: "v2.2"
 risk_tier: "Tier 3"
-status: "in_progress"
-current_owner: "Architecture Guard (OAuth helper) → Founder (App create + helper run after AG)"
+status: "closed"
+current_owner: "none"
 decision_packet_path: "command-center/docs/governance/decisions/G2.3B-B2D_DECISION_PACKET.md"
-founder_steps_path: "command-center/docs/governance/cursor-environments/production-diagnostics/SUPABASE_OAUTH_FOUNDER_STEPS.md"
 
-completed_phase: "G2.3B-B2C"
-g2_3b_b1_merge_sha: "9cd1084aeeaa3a72936fc7abdc4317804af4208c"
-g2_3b_b2c_merge_sha: "9ba22c28a9f878bb760428d8ffe7e2c072c55141"
-g2_3b_b2c_approved_head_sha: "818f12d2832f7034de7e27e7ba2cd8f4fcbf416a"
-g2_3b_b2c_pr: 54
-base_sha: "9ba22c28a9f878bb760428d8ffe7e2c072c55141"
-pr_number: 56
-head_sha: ""
+completed_phase: "G2.3B-B3"
+g2_3_exit_review: "complete_minimum_safe_baseline"
+exit_baseline_sha: "6bc8db4f46bb604c0a3e4c9631985e8314616a8d"
+g2_3b_b3_pr: 63
+g2_3b_b3_merge_sha: "6bc8db4f46bb604c0a3e4c9631985e8314616a8d"
 
-check_status: "pending_pr56_oauth_helper_head"
-architecture_guard_status: "required_on_oauth_helper_before_founder_run"
-owner_checkpoint: "b2d_option_a_authorized_oauth_helper_awaiting_ag_before_founder_run"
+reopen_authorization: "none — G2.3 reopen forbidden under ML-P1 planning auth"
+b4_b5_status: "deferred"
+hostinger_i2_status: "READ_ONLY_CAPABILITY_UNAVAILABLE_deferred"
+issue_55_status: "deferred"
 
-b2c_authorization: "granted + merged"
-b2c_app_authorization: "granted + Founder provisioning complete (attested)"
-merge_authorization_b2c: "granted — merge commit 9ba22c28a9f878bb760428d8ffe7e2c072c55141"
-supabase_credential_authorization: "granted-by-Founder — G2.3B-B2D Option A (Projects Read / projects:read only; adapter ref lock; residual token-scope risk acknowledged)"
-hostinger_credential_authorization: "none"
-merge_authorization_pr56: "none — awaiting AG on OAuth helper + Founder exact head-SHA auth"
+carry_forward_to_ml_p1:
+  - "Release Baton hygiene refresh (this closeout)"
+  - "Windows node adapter exit-code anomaly after successful HTTP (diagnostics; not money-loop core)"
 
-github_i2_status: "app_provisioned_launcher_on_main_live_connection_is_b3"
-hostinger_i2_status: "READ_ONLY_CAPABILITY_UNAVAILABLE"
-supabase_i2_status: "option_a_authorized_helper_implemented_tokens_not_issued_in_repo"
-repo_visibility_flag: "PUBLIC — issue #55 deferred"
-issue_55_status: "deferred_until_g2_3_v1_operational"
+next_phase: "ML-P1 planning_only"
+next_owner: "Orchestrator"
+next_baton_path: "command-center/docs/governance/RELEASE_BATON.ml-p1.yaml"
 
-blockers:
-  - "Protected OAuth helper: Architecture Guard APPROVE_FOR_FINAL_DECISION_PACKET required before Founder runs authorize command"
-  - "Founder: create OAuth app (Projects Read only) + place Client ID/secret in Diagnostics env; then one helper command + browser consent"
-  - "PR #56 merge authorization required to land closeout + helper on main"
-  - "Live connection proof: B3 (separate auth) — not authorized by Option A"
-  - "Hostinger I2: READ_ONLY_CAPABILITY_UNAVAILABLE (Diagnostics)"
-
-next_phase: "Architecture Guard on OAuth helper → Founder helper run → names-only attestation"
-next_owner: "Architecture Guard"
+blockers: []

--- a/command-center/docs/governance/RELEASE_BATON.ml-p1.yaml
+++ b/command-center/docs/governance/RELEASE_BATON.ml-p1.yaml
@@ -1,0 +1,45 @@
+---
+# Release Baton — Money Loop Phase 1 (ML-P1)
+# Status: planning_only. No implementation/deploy/migration authorized by this baton.
+
+release_id: "ML-P1"
+current_phase: "planning"
+governance_version: "v2.2"
+risk_tier: "Tier 3"
+status: "planning_only"
+current_owner: "Orchestrator"
+release_brief_path: "command-center/docs/stabilization/releases/ML-P1_BRIEF.md"
+decision_packet_path: "command-center/docs/governance/decisions/ML-P1_DECISION_PACKET.md"
+
+prior_release: "G2.3"
+prior_release_exit: "complete_minimum_safe_baseline"
+g2_3_reopen: "forbidden"
+baseline_sha: "6bc8db4f46bb604c0a3e4c9631985e8314616a8d"
+base_sha: "6bc8db4f46bb604c0a3e4c9631985e8314616a8d"
+pr_number: null
+head_sha: ""
+
+check_status: "pending_planning_pr"
+architecture_guard_status: "not_required_for_planning_docs"
+uat_status: "NOT_APPLICABLE"
+owner_checkpoint: "planning_transition_authorized"
+
+merge_authorization: "none"
+deployment_authorization: "none"
+migration_authorization: "none"
+production_test_authorization: "none"
+implementation_authorization: "none — separate Founder auth required"
+
+canonical_loop: "lead → quote → accept → job → invoice → payment → receipt"
+phase_1_focus: "Appendix A evidence formalization; DR ratify/defer (job-state, send-estimate); quote→pay lock bound"
+
+carry_forward_hygiene:
+  - "Release Baton refresh (G2.3 closed → ML-P1 planning_only)"
+  - "Windows node adapter exit anomaly after successful HTTP (diagnostics hygiene; no B3 re-run required)"
+
+blockers:
+  - "Founder merge auth required for planning-docs PR (exact PR + head SHA)"
+  - "Implementation not authorized until separate Founder Decision Packet"
+
+next_phase: "Founder merge of planning docs → separate auth for Phase 1 implementation slices"
+next_owner: "Founder (merge auth) → Orchestrator"

--- a/command-center/docs/governance/RELEASE_BATON.ml-p1.yaml
+++ b/command-center/docs/governance/RELEASE_BATON.ml-p1.yaml
@@ -16,10 +16,10 @@ prior_release_exit: "complete_minimum_safe_baseline"
 g2_3_reopen: "forbidden"
 baseline_sha: "6bc8db4f46bb604c0a3e4c9631985e8314616a8d"
 base_sha: "6bc8db4f46bb604c0a3e4c9631985e8314616a8d"
-pr_number: null
-head_sha: ""
+pr_number: 64
+head_sha: ""  # GitHub authoritative — record exact head at Founder merge auth
 
-check_status: "pending_planning_pr"
+check_status: "pending_ci"
 architecture_guard_status: "not_required_for_planning_docs"
 uat_status: "NOT_APPLICABLE"
 owner_checkpoint: "planning_transition_authorized"

--- a/command-center/docs/governance/decisions/ML-P1_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/ML-P1_DECISION_PACKET.md
@@ -17,7 +17,7 @@
 - **Prior program:** `G2.3` — Stabilization Exit Review complete (minimum safe baseline); **closed, no reopen**
 - **Risk tier:** **Tier 3** (money-loop / financial domain) — this packet authorizes **planning docs only**
 - **Pinned baseline SHA:** `6bc8db4f46bb604c0a3e4c9631985e8314616a8d`
-- **PR and approved SHA:** `#<fill after PR open>` @ `<fill after PR open>` (base `origin/main` `6bc8db4f46bb604c0a3e4c9631985e8314616a8d`)
+- **PR and approved SHA:** `#64` @ `<exact head SHA at Founder merge auth — GitHub authoritative>` (base `origin/main` `6bc8db4f46bb604c0a3e4c9631985e8314616a8d`)
 
 ## Operational problem
 G2.3 reached a minimum safe diagnostics baseline, but the Money Loop remains

--- a/command-center/docs/governance/decisions/ML-P1_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/ML-P1_DECISION_PACKET.md
@@ -1,0 +1,112 @@
+# Decision Packet — ML-P1 Money Loop Phase 1 (Planning Ratification)
+
+> **One consolidated founder-facing decision surface.** Agent-prepared. Content
+> rules: no credentials, no secrets, no customer data, no pasted logs. Derived from
+> `templates/DECISION_PACKET.template.md` and
+> `command-center/docs/stabilization/releases/ML-P1_BRIEF.md`.
+>
+> This packet requests **planning ratification only**. It does **not** authorize
+> money-loop product/code implementation, migrations, deployment, production
+> mutation, live Stripe/pay, G2.3 reopen, or B3 re-run. Any later implementation
+> requires a **separate Founder authorization** naming exact scope, PR, and head SHA.
+
+---
+
+## Release
+- **Release ID / governance version:** `ML-P1` / `v2.2`
+- **Prior program:** `G2.3` — Stabilization Exit Review complete (minimum safe baseline); **closed, no reopen**
+- **Risk tier:** **Tier 3** (money-loop / financial domain) — this packet authorizes **planning docs only**
+- **Pinned baseline SHA:** `6bc8db4f46bb604c0a3e4c9631985e8314616a8d`
+- **PR and approved SHA:** `#<fill after PR open>` @ `<fill after PR open>` (base `origin/main` `6bc8db4f46bb604c0a3e4c9631985e8314616a8d`)
+
+## Operational problem
+G2.3 reached a minimum safe diagnostics baseline, but the Money Loop remains
+**without a ratified Phase 1 planning boundary**. Appendix A is still unlocked
+(`IN PROGRESS`): evidence formalization, job-state DR ratification, and
+`send-estimate` include-or-defer are open. Without a Tier 3 Decision Packet that
+separates **planning** from **implementation**, agents risk either stalling or
+silently starting money-loop product work under an implied authorization.
+
+## Proposed correction (planning only)
+Authorize merge of the ML-P1 **planning document set**:
+- `ML-P1_BRIEF.md` — Phase 1 lock focus, canonical loop, outcomes, out of scope
+- `ML-P1_DECISION_PACKET.md` — this packet
+- Release Baton hygiene: close `RELEASE_BATON.g2-3.yaml`; open
+  `RELEASE_BATON.ml-p1.yaml` at `planning_only`
+
+**No product code. No migrations. No deploy. No live pay.**
+
+## What changes
+- Repository records a pinned Phase 1 planning / lock boundary on baseline
+  `6bc8db4…`.
+- Canonical loop is binding for Phase 1:
+  **lead → quote → accept → job → invoice → payment → receipt**.
+- Phase 1 intended outcomes are listed: Appendix A evidence formalization; DR
+  ratify/defer (job-state, send-estimate); quote→pay lock bound; Pillar 1 gaps
+  later unless required.
+- G2.3 baton closed; ML-P1 baton active at `planning_only`.
+- Carry-forward hygiene named: Release Baton refresh; Windows node adapter exit
+  anomaly (not core loop).
+
+## What does NOT change
+- No money-loop runtime/product behavior.
+- No credentials, production access, deploy, migration, or financial action.
+- No G2.3 reopen (B4/B5, Hostinger I2, issue #55).
+- No B3 re-run requirement.
+- No implied authorization for later implementation PRs.
+
+## Evidence (already gathered — do not re-request from the founder)
+- **Check results:** docs-only PR — required GitHub checks per repo defaults; no
+  application workflow change.
+- **Review results:** Architecture Guard **not required** for this planning-docs
+  PR. Required when later money-loop behavior changes are proposed.
+- **UAT result:** `NOT_APPLICABLE` (no deployed workflow change).
+- **Migration status:** `none`.
+- **G2.3 exit:** minimum safe baseline accepted at `6bc8db4…` (B3 status/health
+  live proof prior; not re-run here).
+
+## Deployment plan
+**No deployment.**
+
+## Rollback plan
+Clean `git revert` of the planning PR. Repository-only; zero runtime/data/
+credential/production impact. Rollback point = pre-merge `main` SHA
+`6bc8db4f46bb604c0a3e4c9631985e8314616a8d`.
+
+## Known limitations
+- Appendix A remains unlocked until separately authorized formalization work
+  completes and DRs are ratified or deferred.
+- Local/SOURCE GREEN ≠ production USABLE.
+- Duplicate `JobCreated` remains a residual note; in-scope for Phase 1
+  implementation only if it blocks quote→pay / A-LOCK evidence.
+- Windows node exit anomaly is hygiene, not Phase 1 product scope.
+- This packet’s Tier 3 label reflects domain criticality; **authority granted
+  here is planning-only**, not implementation.
+
+## Recommendation
+**Authorize ML-P1 planning ratification and merge of the exact planning-docs PR
+at the named head SHA.** Do **not** authorize implementation, migration, deploy,
+or live pay under this packet.
+
+## Exact authorization requested
+> **The single yes/no the founder answers:**
+> **"Authorize merge of the ML-P1 planning-docs PR at the exact head SHA named
+> on the Release Baton / PR (baseline `6bc8db4…`), ratifying Money Loop Phase 1
+> planning / lock focus only."**
+
+## Explicit non-authorization
+This authorization does **NOT** authorize:
+
+- Money-loop product/code implementation
+- Appendix A lock declaration as complete (planning only)
+- Migrations / schema / production data changes
+- Deploy / Edge Function deploy / Hostinger mutation
+- Live Stripe or live payment runs
+- G2.3 reopen or B3 re-run
+- Pillar 1 gap closure, Pillar 2–4, or TIS work
+- Any later implementation PR (requires a **new** Decision Packet + Founder auth
+  naming exact PR + head SHA)
+
+_Deployment, migration, financial, destructive, security-control, credential-
+provisioning, and customer-communication actions each require their **own**
+separate explicit authorization and are not implied by any approval above._

--- a/command-center/docs/stabilization/releases/ML-P1_BRIEF.md
+++ b/command-center/docs/stabilization/releases/ML-P1_BRIEF.md
@@ -1,0 +1,185 @@
+# Release Brief — Money Loop Phase 1 (ML-P1) Planning / Lock Focus
+
+> **Orchestrator / Builder planning output. Planning-only phase. No product
+> implementation in this phase.**
+>
+> This brief locks the Money Loop Phase 1 planning surface after the G2.3
+> Stabilization Exit Review (minimum safe baseline met at `6bc8db4…`). It does
+> **not** authorize money-loop product/code changes, migrations, deploy,
+> production mutation, live Stripe/pay, G2.3 reopen, or B3 re-run.
+>
+> Implementation of any Phase 1 lock/formalization work requires a **separate**
+> Founder authorization naming exact scope, PR, and head SHA.
+
+---
+
+## 0. Release header
+
+| Field | Value |
+| --- | --- |
+| Release name | **ML-P1 — Money Loop Phase 1 (Planning / Lock Focus)** |
+| Governance version pinned | **BHFOS Operating Model v2.2** |
+| Release type | Planning / lock-boundary ratification (docs-first) |
+| Base `origin/main` SHA (pinned baseline) | `6bc8db4f46bb604c0a3e4c9631985e8314616a8d` |
+| G2.3 exit | **Complete** — minimum safe baseline (B2D Named Tunnel + B3 read-only adapter); no reopen |
+| Planning worktree | `F:\Dev\BHFOS-ml-p1-plan` |
+| Planning branch | `ml/p1-planning` |
+| Risk tier | **Tier 3** (money-loop / financial domain) — planning ratification only under this brief |
+| Application deployment required | **No** |
+| Migration execution required | **No** |
+| Credential / live pay | **None** |
+| Independent workflow UAT | **NOT_APPLICABLE** for this planning PR |
+
+---
+
+## 1. Purpose
+
+Establish the **planning and lock boundary** for Money Loop Phase 1 so later
+implementation can close Appendix A evidence and quote→pay lock without silent
+scope expansion, without reopening G2.3, and without treating Pillar 1 polish as
+Phase 1 by default.
+
+**North Star:** one canonical money loop, evidence-backed lock, Founder Focus
+preserved (Founder approves boundaries; agents do authorized mechanical work).
+
+---
+
+## 2. Preconditions verified (read-only)
+
+| Check | Result |
+| --- | --- |
+| Pinned baseline SHA | `6bc8db4f46bb604c0a3e4c9631985e8314616a8d` |
+| G2.3 Stabilization Exit Review | Minimum safe baseline **met**; G2.3 **closed** (no reopen) |
+| B3 live connection | Accepted at baseline (project status/health HTTP 200); **no B3 re-run required** for this planning phase |
+| Planning worktree / branch | `F:\Dev\BHFOS-ml-p1-plan` / `ml/p1-planning` — clean, on baseline before planning edits |
+| Dirty worktree `F:\Dev\BHFOS` | **Not used** |
+| Founder auth for this phase | Transition to Money Loop Phase 1 **planning only** authorized at baseline `6bc8db4…` |
+
+---
+
+## 3. Canonical money loop (binding)
+
+Phase 1 planning binds to this canonical loop (Appendix A.2 /
+`03_inventory_ui_money_loop.md`; Pillar 1 Quote→Accept→Job→Invoice→Payment→Completion):
+
+```
+lead → quote → accept → job (×1) → invoice → payment → receipt/close
+```
+
+**Invariants (planning constraints for later implementation):**
+
+1. Accept ⇒ job is **idempotent** (one job per acceptance path).
+2. **Single money writer** — no alternate “paid” path outside the canonical payment writer.
+3. Events + stable IDs required for lock evidence (per Appendix A minimum event doctrine when ratified).
+4. Phase 1 lock focus is **quote→pay** (accept through payment/receipt), not a full Pillar 1 rewrite.
+
+---
+
+## 4. Current proof state (honest labels)
+
+| Area | Label | Notes |
+| --- | --- | --- |
+| Core loop / smoke / flow-trace | **SOURCE / LOCAL GREEN** | `EV-2026-03-18_money-loop-smoke`, flow-trace; A_LOCK automation items largely GREEN locally |
+| Public pay (UAT-006) | **LIVE Resolved** | Residual: duplicate `JobCreated` noted; non-blocking for UAT-006 |
+| Appendix A lock package | **IN PROGRESS / unlocked** | Formal evidence pack, truth-pass docs, DR ratification still open (`lock/appendix-a/index.md`) |
+| DRs: job-state / send-estimate | **OPEN** | Job-state draft for ratification; send-estimate **Pending** include-or-defer |
+| Pillar 1 gaps | **OPEN — later unless required** | Completion gate, alternate path cleanup, broader prod validation — not Phase 1 default |
+| Phase 0 board | **NOT_READY** (context) | Does not authorize scope expansion; Phase 1 stays on lock/evidence boundary |
+
+---
+
+## 5. Phase 1 outcomes (planning-bound)
+
+These are the **intended Phase 1 outcomes** once separately authorized for
+implementation. This planning brief / packet does **not** execute them.
+
+1. **Appendix A evidence formalization** — complete the lock-package evidence
+   surface (smoke, automation, manual UX, snapshots/summary) so A-LOCK is
+   documentary-real, not implied by local GREEN alone.
+2. **DR ratification or explicit defer** —
+   - `DR-2026-03-18_job-state-doctrine` (ratify live two-layer model as A-equivalent, or record alternate),
+   - `DR-2026-03-18_send-estimate-scope` (**include in A-LOCK** or **explicitly defer** out of implicit scope).
+3. **Quote→pay lock bound** — Phase 1 implementation (when authorized) stays
+   inside quote→accept→job→invoice→payment→receipt; no silent expansion into
+   Pillar 2–4 or TIS.
+4. **Pillar 1 gaps listed as later** unless a gap is proven required to close
+   quote→pay / A-LOCK (e.g. duplicate `JobCreated` only if it blocks lock
+   evidence). Default later: completion-gate hardening, alternate estimate-path
+   cleanup, broader production validation campaigns.
+5. **G2.3 carry-forward hygiene tracked separately** (Section 7) — not core
+   money-loop product work.
+
+---
+
+## 6. Explicit out of scope (this planning phase and default Phase 1)
+
+Must **not**, and this brief authorizes **none** of:
+
+- Money-loop **product/code implementation** (CRM/public UI, edge functions, RPCs)
+- Migrations / schema changes / production data mutation
+- Deploy / Hostinger upload / Edge Function deploy
+- Live Stripe charges or live pay runs
+- G2.3 reopen (B4/B5, Hostinger I2, issue #55, formal Improvement Register)
+- B3 re-run as a Phase 1 prerequisite
+- Pillar 2–4 / TIS work
+- Quote-path cleanup, completion-gate product work, or field-commit redesign
+  **unless** later Founder-authorized as required for quote→pay lock
+- Production USABLE certification claims from planning docs alone
+
+---
+
+## 7. G2.3 exit complete — carry-forward hygiene
+
+G2.3 Stabilization Exit Review: **minimum safe baseline met**; program **closed**.
+
+| Carry-forward | Class | Phase 1 treatment |
+| --- | --- | --- |
+| Release Baton refresh (repo baton stale vs live G2.3 closeout) | Hygiene | Close G2.3 baton; open ML-P1 baton at `planning_only` |
+| Windows node adapter exit anomaly (HTTP OK; process sometimes exits `-1073740791` after success) | Hygiene / diagnostics | Track for fix-or-defer during Money Loop era; **not** core loop behavior; **no B3 re-run required** for planning |
+
+These items must not expand Phase 1 into a diagnostics reopen.
+
+---
+
+## 8. Planning artifacts (this PR)
+
+| Artifact | Path | Role |
+| --- | --- | --- |
+| This brief | `command-center/docs/stabilization/releases/ML-P1_BRIEF.md` | Planning / lock boundary |
+| Decision Packet | `command-center/docs/governance/decisions/ML-P1_DECISION_PACKET.md` | Tier 3 planning ratification |
+| G2.3 Baton close | `command-center/docs/governance/RELEASE_BATON.g2-3.yaml` | Close G2.3; point next to ML-P1 |
+| ML-P1 Baton | `command-center/docs/governance/RELEASE_BATON.ml-p1.yaml` | Active baton; `status: planning_only` |
+
+---
+
+## 9. Authorization model
+
+| Action | Authorized by this planning PR? |
+| --- | --- |
+| Merge planning docs (exact PR + head SHA) | **Yes — after Founder merge auth** |
+| Ratify planning boundary / Phase 1 outcomes list | **Yes — Decision Packet** |
+| Implement Appendix A formalization / DR edits in repo | **No — separate Founder auth** |
+| Product/code, migration, deploy, live pay | **No — separate Founder auth each** |
+| Reopen G2.3 | **No** |
+
+Architecture Guard: **not required** for this docs-only planning PR.
+`review:gate` trigger domains apply when money-loop **behavior** changes are
+later proposed — not by planning docs alone.
+
+---
+
+## 10. Stop conditions
+
+Halt and escalate if: worktree/branch/SHA mismatch vs baseline; any step would
+implement product code, migrate, deploy, mutate production, run live pay, or
+reopen G2.3; Phase 1 scope silently expands into Pillar 1 polish / TIS / Pillar
+2–4; planning docs claim gate USABLE/PASS without evidence.
+
+---
+
+## 11. Confirmation of non-action (planning authoring)
+
+This brief authorizes **repository planning documents only**. No production
+access, credential use, deploy, migration, financial action, customer
+communication, or money-loop product implementation is performed under this
+brief.


### PR DESCRIPTION
## Summary
- Add `ML-P1_BRIEF.md` pinning Money Loop Phase 1 planning/lock focus to baseline `6bc8db4` (canonical loop lead→quote→accept→job→invoice→payment→receipt).
- Add Tier 3 `ML-P1_DECISION_PACKET.md` for **planning ratification only** — implementation/migration/deploy/live pay require separate Founder auth.
- Close `RELEASE_BATON.g2-3.yaml` (G2.3 exit complete) and open `RELEASE_BATON.ml-p1.yaml` at `planning_only`, with carry-forward hygiene (baton refresh; Windows node adapter exit anomaly).

## Explicit non-scope
- No money-loop product/code implementation
- No migrations, deploy, production mutation, live Stripe/pay, G2.3 reopen, or B3 re-run

## Test plan
- [ ] Docs-only review: brief + decision packet + batons are consistent with baseline SHA and planning_only status
- [ ] Confirm no application/runtime files in the PR diff
- [ ] Founder merge auth for planning docs only (exact PR + head SHA)
