### PR TITLE
docs(ml-p1): Phase 1 implementation roadmap + Slice 1 Decision Packet

### DIFF
--- a/command-center/docs/governance/RELEASE_BATON.ml-p1.yaml
+++ b/command-center/docs/governance/RELEASE_BATON.ml-p1.yaml
@@ -3,7 +3,7 @@
 # Status: planning_only. No implementation/deploy/migration authorized by this baton.
 
 release_id: "ML-P1"
-current_phase: "planning_correction"
+current_phase: "implementation_roadmap"
 governance_version: "v2.2"
 risk_tier: "Tier 3"
 status: "planning_only"
@@ -11,6 +11,9 @@ current_owner: "Orchestrator"
 release_brief_path: "command-center/docs/stabilization/releases/ML-P1_BRIEF.md"
 decision_packet_path: "command-center/docs/governance/decisions/ML-P1_DECISION_PACKET.md"
 planning_correction_packet_path: "command-center/docs/governance/decisions/ML-P1_PLANNING_CORRECTION_DECISION_PACKET.md"
+implementation_roadmap_path: "command-center/docs/stabilization/releases/ML-P1_IMPLEMENTATION_ROADMAP.md"
+slice1_decision_packet_path: "command-center/docs/governance/decisions/ML-P1_SLICE1_DECISION_PACKET.md"
+planning_correction_merge_sha: "8d8ac06b7e64f2b8e92b04c76d7d7094c631831d"
 known_issue_register_path: "command-center/docs/stabilization/releases/ML-P1_KNOWN_ISSUE_REGISTER.md"
 kpi_scorecard_path: "command-center/docs/stabilization/releases/ML-P1_KPI_SCORECARD.md"
 blocking_gates_path: "command-center/docs/stabilization/releases/ML-P1_BLOCKING_ACCEPTANCE_GATES.md"
@@ -60,8 +63,9 @@ carry_forward_hygiene:
   - "Windows node adapter exit anomaly after successful HTTP (diagnostics hygiene; KI-17)"
 
 blockers:
-  - "Founder merge auth required for planning-correction PR (exact PR + head SHA)"
-  - "Implementation not authorized until separate Founder Decision Packet after correction merge"
+  - "Founder acceptance of ML-P1 Implementation Roadmap"
+  - "Separate Founder authorization of Slice 1 Decision Packet before any coding"
+  - "Slices 2-6 not authorized; live pay / send-estimate / TIS / G2.3 reopen forbidden"
 
-next_phase: "Founder merge of planning correction → eligible to draft implementation Decision Packet (still requires separate auth)"
-next_owner: "Founder (merge auth) → Orchestrator"
+next_phase: "Founder accepts roadmap → optional docs merge → exact Slice 1 implementation auth"
+next_owner: "Founder → Orchestrator"

--- a/command-center/docs/governance/decisions/ML-P1_SLICE1_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/ML-P1_SLICE1_DECISION_PACKET.md
@@ -1,0 +1,173 @@
+# Decision Packet — ML-P1 Slice 1 Implementation
+
+> **One consolidated founder-facing decision surface.** Agent-prepared.
+> No credentials, secrets, customer data, or pasted logs.
+>
+> **Roadmap:** `ML-P1_IMPLEMENTATION_ROADMAP.md` (complete Phase 1 sequence).
+> **Baseline main:** `8d8ac06b7e64f2b8e92b04c76d7d7094c631831d`
+>
+> This packet requests **authorization to implement Slice 1 only** after the
+> roadmap is accepted. Merging this packet as docs does **not** by itself start
+> coding — Founder must authorize implementation at the named branch/base SHA
+> (and later exact head SHA for merge).
+
+---
+
+## Release
+
+| Field | Value |
+| --- | --- |
+| Release ID | `ML-P1-S1` |
+| Governance | v2.2 |
+| Risk tier | **Tier 3** (money-loop path foundation) |
+| Slice | 1 of 6 — Customer and canonical quote foundation |
+| Base SHA | `8d8ac06b7e64f2b8e92b04c76d7d7094c631831d` (or newer main if roadmap docs merge first — then rebase S1 base to that merge) |
+| Proposed branch | `ml/p1-s1-customer-quote-foundation` |
+| Proposed worktree | `F:\Dev\BHFOS-ml-p1-s1` |
+| Do not use | `F:\Dev\BHFOS` (dirty) |
+
+## Operational problem
+
+Phase 1 cannot issue/approve/convert quotes safely until customer identity,
+service address, and canonical `quotes` draft creation exist with tenant
+enforcement, audit events, and legacy `estimates` create frozen on the P1 path.
+
+## Proposed correction (Slice 1 implementation — when authorized)
+
+Implement **only** Slice 1 per roadmap §11:
+
+- Authoritative customer (lead) find/create for P1  
+- Service address selection (`address_line_1` mapping)  
+- Duplicate detection (warn/block — no silent dup)  
+- Canonical draft `quotes` + `quote_items`  
+- Stable IDs; tenant enforcement; role authorization  
+- Initial audit events; duplicate-submit protection  
+- Mobile-first customer + draft quote entry  
+- S1 KPI instrumentation  
+
+## Exact scope
+
+1. P1 customer find/create UX + server APIs (tenant-scoped).  
+2. Service address selection bound to customer/lead.  
+3. Duplicate customer detection (deterministic rules documented in PR).  
+4. Draft quote create/update/delete-draft on `quotes` / `quote_items` only.  
+5. Block/hide legacy `estimates` **create** on P1 surfaces (server DENY).  
+6. Document UUID↔bigint safe join pattern; no name-based linking.  
+7. Audit events for draft create/update with Money-State Contract minimum fields.  
+8. Idempotent draft create on double-submit.  
+9. Automated tenant negative tests for new endpoints.  
+10. Instrumentation hooks/events for S1 KPIs (times may be stopwatch initially).
+
+## Explicit non-scope
+
+- Quote issue / approve / reject / expire / revise (Slice 2)  
+- Accept → job (Slice 3)  
+- Job execution (Slice 4)  
+- Invoice (Slice 5)  
+- Live payment  
+- send-estimate  
+- Property schema unification / B-023  
+- Migrations **unless** separately authorized in an amended line below  
+- Deploy / production mutation without Production Operator auth  
+- TIS / G2.3 reopen  
+
+## Expected files and data entities (indicative)
+
+| Area | Likely touch |
+| --- | --- |
+| UI | CRM quote builder / customer find-create mobile-capable surfaces under `command-center/src/pages/crm/` (exact files in impl PR) |
+| Services | Quote/lead services; deny paths for `estimates` create |
+| AuthZ / RLS | Tenant checks on quote/lead writes |
+| Events | Draft quote audit emitter |
+| Tests | Adapter/unit/e2e for tenant deny, estimates DENY, idempotent draft |
+| Docs | Slice evidence appendix (no secrets) |
+
+**Entities:** leads (customer), service address fields, `quotes`, `quote_items`, tenants, audit/event records.
+
+## Migration request
+
+**Default: none.**
+
+If implementation discovers missing columns/constraints required for draft quotes or audit:
+
+> **Separate Founder line required:** “Authorize additive migration `<name>` for Slice 1 only.”
+
+Do not ship destructive migrations under this packet.
+
+## Required reviews
+
+| Role | Required |
+| --- | --- |
+| Product Owner | Yes |
+| UX/Field Workflow | Yes |
+| Data Guard | Yes |
+| Security Guard | Yes |
+| Architecture Guard | Yes (Tier 3 path) |
+| Financial Control | Light (no settlement) |
+| Release/Production | Only if deploy authorized later |
+
+## Acceptance gates (Slice 1)
+
+- Draft quotes created only on `quotes`; `estimates` create DENY on P1 path  
+- Customer + service address selectable; address uses correct field mapping  
+- Tenant negative tests: **0** unauthorized access  
+- Audit events present for draft create (minimum fields)  
+- Double-submit does not create duplicate drafts  
+- Mobile smoke: create/find customer + draft quote without Notes  
+- KI-01/02/04 progress evidenced; KI-03 pattern documented  
+- No issue/approve/job/invoice code paths shipped as “done”
+
+Maps to roadmap gates: G-02 (slice), G-03, G-08 (S1 critical), G-07 baseline **start**.
+
+## KPI instrumentation (Slice 1)
+
+- Time to create/find customer (stopwatch/telemetry)  
+- Time to create draft quote  
+- Taps/screens count (task analysis)  
+- Notes/text/paper escape diary (target observation)  
+- Duplicate-customer detection hits  
+- Cross-tenant deny count  
+- Audit completeness % for draft events  
+
+Targets remain `BASELINE_FIRST` except binary gates (0 unauthorized, estimates DENY).
+
+## Rollback plan
+
+1. Revert implementation PR(s).  
+2. If migration was authorized: reverse/expand-contract per migration packet.  
+3. No production data backfill without separate auth.  
+4. Feature flags preferred for UI cutover where feasible.
+
+## Authorized stopping point
+
+**Stop before** quote issue, approval, job conversion, invoice, or payment.
+
+## Criteria to authorize Slice 2
+
+- Founder accepts Slice 1 evidence  
+- S1 gates green  
+- Orchestrator prepares S2 Decision Packet from roadmap (**no full replan**)
+
+## Exact authorization requested (implementation)
+
+> **"Authorize ML-P1 Slice 1 implementation on branch
+> `ml/p1-s1-customer-quote-foundation` in worktree `F:\Dev\BHFOS-ml-p1-s1`,
+> base SHA `8d8ac06b7e64f2b8e92b04c76d7d7094c631831d` (or the roadmap-docs merge
+> SHA if that merges first — Orchestrator must state the exact base at kickoff),
+> scope limited to customer find/create, service address, canonical draft quotes
+> on `quotes` only, tenant/authz, audit, idempotent submit, mobile-first entry,
+> and S1 KPI instrumentation. Do not authorize Slice 2–6, issue/approve, job,
+> invoice, live pay, send-estimate, migrations (unless separately named), deploy,
+> TIS, or G2.3 reopen. Merge of the Slice 1 code PR still requires a later exact
+> head-SHA authorization."**
+
+## Explicit non-authorization
+
+Does **not** authorize: Slices 2–6; quote approval; jobs; invoices; live pay;
+send-estimate; deploy; unrestricted migrations; production mutation; TIS; G2.3 reopen.
+
+## Recommendation
+
+1. Founder **accepts** the complete Phase 1 Implementation Roadmap.  
+2. Founder separately **authorizes Slice 1** with the exact text above when ready to start coding.  
+3. Do **not** start implementation from roadmap acceptance alone.

--- a/command-center/docs/stabilization/releases/ML-P1_IMPLEMENTATION_ROADMAP.md
+++ b/command-center/docs/stabilization/releases/ML-P1_IMPLEMENTATION_ROADMAP.md
@@ -1,0 +1,324 @@
+# ML-P1 Implementation Roadmap
+
+> **Authoritative Phase 1 implementation sequence.** One coordinated planning pass.
+> Baseline `origin/main`: `8d8ac06b7e64f2b8e92b04c76d7d7094c631831d`
+>
+> Binds: Known-Issue Register, KPI Scorecard, Blocking Acceptance Gates,
+> Money-State Design Contract, job-state doctrine (ratified), send-estimate deferral.
+>
+> **This document does not authorize implementation.** Each slice requires a
+> separate Founder Decision Packet + exact head-SHA authorization.
+>
+> **Anti-delay:** Do not reopen full planning before each slice unless evidence
+> invalidates an assumption, a critical known issue changes, a platform constraint
+> changes, or a material security/data/financial/usability risk is discovered.
+> Otherwise prepare the next slice Decision Packet directly after prior slice acceptance.
+
+---
+
+## 0. Phase 1 end-state
+
+```
+Create/find customer
+  → create canonical quote (draft)
+  → issue quote
+  → revise or approve quote
+  → convert approved quote → job (×1)
+  → execute and complete job
+  → generate invoice (draft → issued)
+  → office + mobile end-to-end acceptance
+```
+
+**In Phase 1:** Live payment **execution** remains out. Payment-readiness constraints from the Money-State Design Contract **must** be preserved.
+
+**USABLE** requires gates G-01–G-10 (Blocking Acceptance Gates). CI green ≠ USABLE.
+
+---
+
+## 1. Full slice map
+
+| Slice | Name | Stops before |
+| --- | --- | --- |
+| **S1** | Customer + canonical quote foundation | Approval, job, invoice, pay |
+| **S2** | Quote issue, revision, approval | Job conversion, invoice, pay |
+| **S3** | Approved quote → job | Job field execution beyond init, invoice, pay |
+| **S4** | Job execution and completion | Invoice, pay |
+| **S5** | Completed job → invoice | Live pay |
+| **S6** | End-to-end UAT + Phase 1 acceptance | Post-P1 scope |
+
+### Dependency graph
+
+```
+S1 ──► S2 ──► S3 ──► S4 ──► S5 ──► S6
+ │      │      │      │      │
+ │      │      │      │      └── payment readiness (design only)
+ │      │      │      └── job-state doctrine (ratified two-layer)
+ │      │      └── KI-16 dup job / idempotent accept
+ │      └── immutability + approval audit
+ └── KI-01 canonical quotes; KI-02..04 identity/address; tenant
+```
+
+S6 depends on S1–S5 acceptance evidence. No parallel Tier-3 money-state slices without Architecture Guard exception.
+
+---
+
+## 2. Known-issue → slice mapping
+
+| KI | Disposition |
+| --- | --- |
+| KI-01 Dual estimates/quotes | **Required before S1** (path policy); **fixed during S1** (freeze legacy create on P1 path); full UI purge may continue S2 if needed |
+| KI-02 Customer/property/address lineage | **Resolved in S1** (P1 authority rules); B-023 rewrite **explicitly deferred** |
+| KI-03 UUID↔bigint | **Required before S1** (document safe join; no name linking); unification **explicitly deferred** |
+| KI-04 Address field mismatch | **Fixed during S1** (correct `address_line_1` mapping on P1 path) |
+| KI-05 Tenant / money-writer | **Required every slice** (tenant tests); money-writer inventory **proven by S5**, watched from S1 |
+| KI-06 payment_status divergence | **Designed in S4/S5** (invoice authority); **fixed during S5** |
+| KI-07 Alternate paid writers | **Proven by S5** (inventory); no paid mutation in S1–S4 |
+| KI-08 Admin auth fallback | **Fixed during each slice** touching money-state endpoints; **blocking for S1+** on new endpoints |
+| KI-09 Technician identity | **Must design S3/S4**; full auth FK **deferred**; actor on completion **S4** |
+| KI-10 tenant_id gaps on properties/techs | **Enforce via money entities S1+**; column backfill **deferred** |
+| KI-11 Follow-up fragility | **Deferred** rich UX; **S5/S6** visible failure / no silent break on P1 path |
+| KI-12 Incomplete event doctrine | **Fixed during each slice** for transitions introduced; **100% by S6** |
+| KI-13 Mobile / poor-connectivity | **S1+** idempotent submit; full offline **deferred**; proven **S4/S6** |
+| KI-14 Notes escape | **Measured S1+**; **blocking S6** (0 escape on gate trials) |
+| KI-15 Manual re-entry | **Must design S1–S5**; **0 on path by S5** |
+| KI-16 Duplicate JobCreated | **Fixed during S3** (dup jobs blocking); event hygiene **S3/S6** |
+| KI-17 Node adapter exit | **Hygiene / N/A** to money-loop product — **rejected as P1 product gate** |
+| Send-estimate | **Explicitly deferred** (not in any slice) |
+| Job-state doctrine | **Ratified**; applied **S3–S4** |
+
+---
+
+## 3. Review matrix (proportional)
+
+| Slice | Product | UX/Field | Data | Security | Architecture | Financial | Release/Prod |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| S1 | Required | Required | Required | Required | Required (Tier 3 path) | Light (no money settle) | Only if deploy |
+| S2 | Required | Required | Required | Required | Required | Required | Only if deploy |
+| S3 | Required | Light | Required | Required | Required | Required | Only if deploy |
+| S4 | Required | Required | Required | Required | Required | Light | Only if deploy |
+| S5 | Required | Required | Required | Required | Required | Required | Only if deploy |
+| S6 | Required | Required | Required | Required | Required | Required | As needed for UAT env |
+
+---
+
+## 4. KPI and instrumentation plan
+
+| Slice | Instrument now | Gates exercised |
+| --- | --- | --- |
+| S1 | Customer find/create time; estimate create time; taps; Notes escape diary; dup customer attempts; tenant deny count; audit completeness on quote draft create | G-02 (slice events), G-03, G-06 partial, G-07 baseline start |
+| S2 | Approval rate inputs; abandoned; audit on issue/approve/revise; unauthorized transition attempts | G-02, G-03, G-05 (issue/approve atomicity) |
+| S3 | Approval→job time; dup job under retry; lineage quote→job; partial tx under failure | G-01 partial, G-04 jobs, G-05, G-02 |
+| S4 | Job complete time; evidence completeness; Notes escape; failed transitions; tech help requests | G-06, G-02, G-13/14 metrics |
+| S5 | Completion→invoice time; lineage 100%; dup invoice retry; void reason coverage; writer inventory | G-01, G-04 invoices, G-05, G-09 |
+| S6 | Full scorecard baseline lock; all G-01–G-10; task-time caps published | **All blocking gates** |
+
+**Baseline-first:** no invented numeric task-time targets until S1–S6 measurement window allows lock (G-07).
+
+---
+
+## 5. Migration strategy
+
+| Slice | Migration expectation |
+| --- | --- |
+| S1 | Prefer **no** migration if enforceable in app + RLS; if quote state/audit tables missing columns, **separate migration auth** in S1 packet amendment |
+| S2 | Likely schema/constraints for quote states, version immutability, approval records — **Dedicated Founder migration auth** if required |
+| S3 | Idempotency keys / unique (quote_version→job) — migration if needed + auth |
+| S4 | Job status columns if missing for ratified two-layer model — migration if needed + auth |
+| S5 | Invoice immutability / numbering / lineage columns — migration if needed + auth |
+| S6 | None preferred (verification only) |
+
+**Rule:** No migration in a slice without explicit Founder migration line in that slice’s Decision Packet. Prefer additive, reversible migrations.
+
+---
+
+## 6. UX and field acceptance plan
+
+- Mobile-first for customer find/create, quote entry (S1), approval surfaces (S2), job execution (S4), invoice review (S5).
+- Housecall Pro = **workflow benchmark only** (states/cadence), not UI copy.
+- P1 path must be **easier than Notes** (G-06).
+- Real-device Founder + technician trials at S4 and mandatory at S6; S1/S2 office+mobile smoke.
+- Escape-to-Notes diary from S1; zero on S6 gate trials.
+
+---
+
+## 7. Security and authorization plan
+
+- Deny-by-default; least privilege; matrix from Money-State Design Contract §11.
+- Tenant on every money-entity write from S1.
+- No UI-only auth; negative cross-tenant tests each slice (G-03).
+- Secrets never in logs; audit events without token/PII payloads.
+- Single money-writer proven S5 (G-09); no paid mutation S1–S4.
+
+---
+
+## 8. Data and lineage plan
+
+```
+lead (authoritative customer for P1)
+  └─ service address (address_line_1 mapping)
+       └─ quote + quote_version + quote_items
+            └─ job (source_quote_id + version) + job scope lines
+                 └─ invoice + invoice_items (lineage ids)
+```
+
+- No name-based linking (KI-03).
+- UUID↔bigint: documented opaque/safe pattern only; no unification migration in P1 unless separately authorized as exception.
+
+---
+
+## 9. Financial-control plan
+
+- S2: issued/approved immutability; approval amount+version.
+- S5: issued invoice immutability; void/correction reason codes; reconciliation-ready fields.
+- Payment readiness (partials, webhooks, idempotent intents) designed in S5; **not executed**.
+- No alternate paid writers.
+
+---
+
+## 10. Rollback and recovery plan
+
+| Level | Action |
+| --- | --- |
+| Code | `git revert` slice PR |
+| Migration | Expand/contract or reverse migration per packet; never destructive without separate auth |
+| Partial failure | Atomic units per Money-State Contract §14; visible error; safe retry |
+| Exceptions | Owned queue by S5/S6; no silent automation failure on P1 path |
+
+---
+
+## 11. Slice definitions (complete)
+
+### SLICE 1 — Customer and canonical quote foundation
+
+| Field | Content |
+| --- | --- |
+| Business objective | Office/tech can find or create customer, select service address, create **draft** canonical quote with line items on `quotes` only |
+| Roles | Office, Manager, Admin; Technician per policy (create draft if allowed) |
+| Exact scope | Authoritative lead/customer identity for P1; service address selection; duplicate detection (warn/block); canonical `quotes` + line items; draft only; stable IDs; tenant enforcement; role authz; initial audit events; duplicate-submit protection; mobile-first entry; KPI instrumentation for S1 |
+| Non-scope | Issue/approve/reject/expire; job; invoice; live pay; send-estimate; estimates table writes; property schema unification; TIS; G2.3 |
+| Entities | `leads`/`contacts` as used today for customer; service address fields; `quotes`, `quote_items`; tenant; audit/event store |
+| KI addressed | KI-01 (path), KI-02, KI-03 (pattern), KI-04, KI-05/08 (tenant/auth on new endpoints), KI-10 (via entities), KI-12 (draft events), KI-13/14/15 (start) |
+| KI deferred | KI-03 unification, B-023, send-estimate, KI-17, KI-06/07/09 completion, KI-16 |
+| Dependencies | Planning correction merged (`8d8ac06…`) |
+| Migration | Prefer none; if required → explicit auth in S1 packet |
+| Authz | Server-side create/update draft quote; tenant required |
+| UX | Mobile-first find/create customer + draft quote; fewer taps; no Notes required for draft |
+| Audit | quote.draft_created / line_item events with minimum fields |
+| Idempotency | Duplicate submit → same draft quote id |
+| Failure | No orphan quote without tenant/customer; rollback create |
+| KPI | Time find/create customer; time create draft; taps; escape diary; tenant denies |
+| Acceptance | Draft quote on `quotes` only; legacy estimates create blocked on P1 path; tenant negatives pass; audit present; mobile smoke |
+| Blocking gates | G-02 (slice), G-03, G-08 for S1 critical KIs, start G-07 baseline |
+| Reviewers | Product, UX/Field, Data, Security, Architecture |
+| Branch/worktree | See Slice 1 Decision Packet |
+| Evidence | Screenshots/IDs (no secrets); test log; KI checklist |
+| Stop | Before issue/approve |
+| Next slice criteria | S1 Founder acceptance → prepare S2 Decision Packet (no full replan) |
+
+### SLICE 2 — Quote issue, revision, approval
+
+| Field | Content |
+| --- | --- |
+| Business objective | Issue immutable quote versions; revise; approve/reject/expire with full approval audit |
+| Roles | Office/Manager issue; Customer approve via designated method; Manager override+reason |
+| Scope | States draft/issued/approved/rejected/expired/revised; immutability; approval actor/method/ts/amount/version; revision/expiration; partial-approval **policy** (default: whole-quote approve unless packet amends); cancel/reject reasons; idempotent approve; server authz; audit; mobile + customer-facing accept behavior |
+| Non-scope | Job conversion; invoice; pay; send-estimate |
+| Entities | Quote versions, approval records, state machine |
+| KI | KI-01 remainder; KI-12; KI-08; KI-15 |
+| Deferred | send-estimate; job |
+| Migration | Likely state/version/approval tables — separate auth if needed |
+| Gates | G-02, G-03, G-05 on issue/approve |
+| Stop | Before accept→job |
+| Next | S2 accepted → S3 packet |
+
+### SLICE 3 — Approved quote → job
+
+| Field | Content |
+| --- | --- |
+| Business objective | One idempotent job from approved quote version with lineage |
+| Roles | System via accept; office trigger if allowed; no tech-created bypass |
+| Scope | Version pin; accept→job idempotency; line→scope lineage; dup job prevention; atomicity; minimal job init per ratified two-layer model; office/tech assignment fields; rollback; retry; audit+correlation |
+| Non-scope | Full field execution UI; invoice; pay; collapsing job FSM |
+| KI | KI-16 (blocking); KI-12; KI-05; KI-09 assignment fields |
+| Gates | G-01 partial, G-04 jobs, G-05, G-02 |
+| Stop | Before job execution workflow |
+| Next | S3 accepted → S4 packet |
+
+### SLICE 4 — Job execution and completion
+
+| Field | Content |
+| --- | --- |
+| Business objective | Field completes job with evidence; authorized transitions; no Notes escape |
+| Roles | Technician, Office, Manager |
+| Scope | States: scheduled, dispatched, on_my_way, arrived, started, paused (if required), completed, cancelled, no_access, rescheduled — **as authorized subset** of ratified two-layer model; tech identity; timestamps; notes/photos/findings/measurements; additional-work customer approval when required; completion evidence; mobile-first; safe retry/poor-connectivity; no dup complete; Notes-escape measurement |
+| Non-scope | Invoice; pay; full offline sync engine; copying Housecall Pro UI |
+| KI | KI-09, KI-13, KI-14, KI-06 design input, KI-12 |
+| Gates | G-06 progress, G-02, G-05 |
+| Benchmark | Housecall Pro workflow cadence only |
+| Stop | Before invoice |
+| Next | S4 accepted → S5 packet |
+
+### SLICE 5 — Completed job → invoice
+
+| Field | Content |
+| --- | --- |
+| Business objective | Invoice from approved+completed scope with full lineage; issued immutability; payment-ready |
+| Roles | Office, Manager; Admin void+reason |
+| Scope | Generate from completed scope; quote→job→invoice lineage; draft/issued; issued immutability; numbering; taxes/fees/discounts/credits/deposits/adjustments as needed for P1; void/correction reasons; partial completion; dup invoice prevention; atomicity; financial audit; reconciliation-ready; **future payment readiness without live pay** |
+| Non-scope | Live Stripe/pay execution; send-estimate |
+| KI | KI-06, KI-07, KI-11 (visible fail), KI-15, G-09 |
+| Gates | G-01, G-04 invoices, G-05, G-09, G-02 |
+| Stop | Before live pay; before claiming Phase 1 USABLE |
+| Next | S5 accepted → S6 packet |
+
+### SLICE 6 — End-to-end UAT and Phase 1 acceptance
+
+| Field | Content |
+| --- | --- |
+| Business objective | Prove office + Founder + technician mobile path USABLE under gates |
+| Roles | Founder, Technician, Office, reviewers |
+| Scope | Real-device tests; repeated-click; forced-failure; cross-tenant negatives; lineage verification; audit completeness; task-time baselines→caps; Notes escape testing; recovery/exceptions; blocking KPI review; UX/Field review disposition |
+| Non-scope | New product features; live pay; TIS; G2.3 reopen |
+| Gates | **All G-01–G-10** |
+| Stop | Phase 1 complete definition met or residual-risk acceptances signed |
+| Next | Post-P1 only under new program auth |
+
+---
+
+## 12. Phase 1 completion definition
+
+Phase 1 is **complete** when:
+
+1. S1–S5 implementation slices accepted with evidence.  
+2. S6 proves G-01–G-10 (or Founder signs residual-risk waivers per gate).  
+3. Known-Issue Register shows all `P1_BLOCKING` items fixed or signed.  
+4. Single money-writer proven; no live pay claimed as done.  
+5. send-estimate remains deferred unless a new packet includes it.  
+6. Founder declares Phase 1 USABLE — not CI alone.
+
+---
+
+## 13. Worktree / branch naming convention
+
+| Slice | Branch | Worktree |
+| --- | --- | --- |
+| S1 | `ml/p1-s1-customer-quote-foundation` | `F:\Dev\BHFOS-ml-p1-s1` |
+| S2 | `ml/p1-s2-quote-issue-approval` | `F:\Dev\BHFOS-ml-p1-s2` |
+| S3 | `ml/p1-s3-quote-to-job` | `F:\Dev\BHFOS-ml-p1-s3` |
+| S4 | `ml/p1-s4-job-execution` | `F:\Dev\BHFOS-ml-p1-s4` |
+| S5 | `ml/p1-s5-job-to-invoice` | `F:\Dev\BHFOS-ml-p1-s5` |
+| S6 | `ml/p1-s6-uat-acceptance` (docs/evidence) | `F:\Dev\BHFOS-ml-p1-s6` |
+
+Base each slice on the **then-current** `origin/main` after prior slice merge (anti-delay: no full replan).
+
+---
+
+## 14. Explicit program non-scope (all slices)
+
+- Live payment execution  
+- send-estimate  
+- TIS / Pillar 2–4  
+- G2.3 reopen  
+- Full offline sync  
+- UUID↔bigint unification migration  
+- Full property multi-tenant rewrite  


### PR DESCRIPTION
## Summary
- Complete ML-P1 Implementation Roadmap (slices S1-S6) at baseline 8d8ac06
- Slice 1 Decision Packet prepared (customer + canonical draft quotes)
- Binds Known-Issue Register, KPIs, gates, money-state contract
- Docs only — does not authorize Slice 1-6 implementation, migrations, deploy, live pay, TIS, or G2.3 reopen

## Test plan
- [ ] Docs-only diff
- [ ] Founder accepts roadmap
- [ ] Separate Founder auth required before any Slice 1 coding