### PR TITLE
feat(ml-p1-s1): customer and canonical draft quote foundation

### DIFF
--- a/command-center/docs/stabilization/releases/ML-P1_SLICE1_EVIDENCE.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE1_EVIDENCE.md
@@ -1,0 +1,53 @@
+# ML-P1 Slice 1 — Implementation Evidence (docs)
+
+> Base: `2867d2891994f1ec9734c7e2be3e84b216cb144f`  
+> Branch: `ml/p1-s1-customer-quote-foundation`  
+> **No migration. No deploy. No issue/approve/job/invoice/live pay.**
+
+## Delivered
+
+| Item | Location |
+| --- | --- |
+| Estimates create DENY | `src/lib/mlP1S1EstimatesDeny.js` + `EstimateEditorModal.jsx` guard |
+| Duplicate customer helpers | `src/lib/mlP1S1DuplicateCustomer.js` |
+| Identity / address_line_1 policy | `src/lib/mlP1S1Identity.js` |
+| Tenant deny-by-default | `src/lib/mlP1S1Tenant.js` |
+| Audit event builder | `src/lib/mlP1S1AuditEvents.js` |
+| KPI store | `src/lib/mlP1S1Kpi.js` |
+| Draft quote service (`quotes` only) | `src/services/mlP1S1QuoteDraftService.js` |
+| Mobile-first UI | `src/pages/crm/MlP1S1DraftQuotePage.jsx` |
+| Routes | `App.jsx` → `estimates/new` + `estimates/p1-draft` → S1 page; `estimates/:id` remains ProposalBuilder |
+| Unit tests | `tests/unit/ml-p1-s1-foundation.test.mjs` (`npm run test:ml-p1-s1-helpers`) |
+
+## Explicit non-delivery (authorized stop)
+
+- Quote issue / approve / reject / expire / revise  
+- Accept → job  
+- Job execution  
+- Invoice  
+- Live payment  
+- send-estimate  
+- Schema migrations  
+
+## KI mapping progress
+
+| KI | Status in S1 |
+| --- | --- |
+| KI-01 dual estimates | DENY on estimates create path |
+| KI-02 identity | Lead authoritative; service address on lead |
+| KI-03 UUID/bigint | Documented defer; no name linking |
+| KI-04 address fields | address_line_1 / address1 alias via intake |
+| KI-05/08 tenant | resolveWriteTenantId + mismatch DENY |
+| KI-12 audit | draft_created event builder + emit attempt |
+| KI-13/14 | idempotent draft; Notes-escape diary hooks |
+| KI-15 | Single draft path for new estimates/new |
+
+## Tests run
+
+```bash
+cd command-center && npm run test:ml-p1-s1-helpers
+```
+
+## Merge note
+
+Implementation PR merge requires **later Founder authorization at exact reviewed head SHA**.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE1_EVIDENCE.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE1_EVIDENCE.md
@@ -8,13 +8,13 @@
 
 | Item | Location |
 | --- | --- |
-| Estimates create DENY | `src/lib/mlP1S1EstimatesDeny.js` + `EstimateEditorModal.jsx` guard |
-| Duplicate customer helpers | `src/lib/mlP1S1DuplicateCustomer.js` |
+| Estimates create DENY (app) | `src/lib/mlP1S1EstimatesDeny.js` + `EstimateEditorModal.jsx` (no insert attempted) |
+| Duplicate customer helpers | `src/lib/mlP1S1DuplicateCustomer.js` + service import restored |
 | Identity / address_line_1 policy | `src/lib/mlP1S1Identity.js` |
-| Tenant deny-by-default | `src/lib/mlP1S1Tenant.js` |
-| Audit event builder | `src/lib/mlP1S1AuditEvents.js` |
+| Tenant deny-by-default | `src/lib/mlP1S1Tenant.js` — **session required**; URL match only; no default fallback; null row tenant DENY |
+| Audit event builder | `src/lib/mlP1S1AuditEvents.js` — generates `event_id` + `timestamp` |
 | KPI store | `src/lib/mlP1S1Kpi.js` |
-| Draft quote service (`quotes` only) | `src/services/mlP1S1QuoteDraftService.js` |
+| Draft quote service (`quotes` only) | `src/services/mlP1S1QuoteDraftService.js` — in-flight idempotency lock + notes marker |
 | Mobile-first UI | `src/pages/crm/MlP1S1DraftQuotePage.jsx` |
 | Routes | `App.jsx` → `estimates/new` + `estimates/p1-draft` → S1 page; `estimates/:id` remains ProposalBuilder |
 | Unit tests | `tests/unit/ml-p1-s1-foundation.test.mjs` (`npm run test:ml-p1-s1-helpers`) |
@@ -29,17 +29,26 @@
 - send-estimate  
 - Schema migrations  
 
+## Residual (honest — not closed in this PR)
+
+| Residual | Status |
+| --- | --- |
+| Server/RLS DENY on `estimates` INSERT | **Deferred** — requires separately authorized additive migration; app DENY removes create insert path in modal |
+| DB unique constraint on draft idempotency key | **Deferred** — process-local inflight lock + notes marker; cross-process race needs migration |
+| Role matrix enforcement for draft create | **Documented gap** — `actorRole` recorded as `office`; CRM auth assumed; server role check not in S1 |
+| G-03 live RLS negatives | Helper unit tests only |
+
 ## KI mapping progress
 
 | KI | Status in S1 |
 | --- | --- |
-| KI-01 dual estimates | DENY on estimates create path |
-| KI-02 identity | Lead authoritative; service address on lead |
+| KI-01 dual estimates | App DENY + no insert; server RLS residual |
+| KI-02 identity | Lead authoritative; service address on lead; dup check wired |
 | KI-03 UUID/bigint | Documented defer; no name linking |
 | KI-04 address fields | address_line_1 / address1 alias via intake |
-| KI-05/08 tenant | resolveWriteTenantId + mismatch DENY |
-| KI-12 audit | draft_created event builder + emit attempt |
-| KI-13/14 | idempotent draft; Notes-escape diary hooks |
+| KI-05/08 tenant | Session-required resolveWriteTenantId + mismatch/null DENY |
+| KI-12 audit | draft_created with event_id + emit attempt |
+| KI-13/14 | idempotent draft + inflight lock; Notes-escape diary hooks |
 | KI-15 | Single draft path for new estimates/new |
 
 ## Tests run

--- a/command-center/package.json
+++ b/command-center/package.json
@@ -22,6 +22,7 @@
     "test:identity-helpers": "node --test tests/unit/r1c-helper-contracts.test.mjs",
     "test:identity-contracts": "npm run guard:identity && npm run test:identity-helpers && playwright test tests/smoke/r1a-property-relationship-safety.spec.js tests/smoke/r1b-technician-identity-contract.spec.js tests/smoke/r1c-identity-relationship-guards.spec.js tests/smoke/inspection-field-address-schema.spec.js",
     "test:intake-helpers": "node --test tests/unit/r2-lead-intake-contract.test.mjs",
+    "test:ml-p1-s1-helpers": "node --test tests/unit/ml-p1-s1-foundation.test.mjs",
     "test:intake-contracts": "npm run test:intake-helpers && playwright test tests/smoke/r2-intake-clarity.spec.js tests/smoke/inspection-field-address-schema.spec.js",
     "test:scheduling-helpers": "node --test tests/unit/r3-job-appointment-schedule.test.mjs",
     "test:scheduling-contracts": "npm run test:scheduling-helpers && playwright test tests/smoke/r3-scheduling-operations.spec.js",

--- a/command-center/src/App.jsx
+++ b/command-center/src/App.jsx
@@ -37,6 +37,7 @@ const SchedulePage = React.lazy(() => import('@/pages/crm/Schedule'));
 const AppointmentSchedulerPage = React.lazy(() => import('@/pages/crm/appointments/AppointmentScheduler'));
 const ProposalList = React.lazy(() => import('@/pages/crm/proposals/ProposalList'));
 const ProposalBuilder = React.lazy(() => import('@/pages/crm/proposals/ProposalBuilder'));
+const MlP1S1DraftQuotePage = React.lazy(() => import('@/pages/crm/MlP1S1DraftQuotePage'));
 const InvoicesPage = React.lazy(() => import('@/pages/crm/Invoices'));
 const ContactsPage = React.lazy(() => import('@/pages/crm/ContactsPage'));
 const CallConsolePage = React.lazy(() => import('@/pages/crm/CallConsole'));
@@ -331,7 +332,9 @@ const CRMRoutes = () => (
       <Route path="inspections/:id/report" element={<FeatureGuard flag="enableInspections"><InspectionReportPage /></FeatureGuard>} />
       <Route path="inspections/:id" element={<FeatureGuard flag="enableInspections"><InspectionEditorPage /></FeatureGuard>} />
       <Route path="estimates" element={<FeatureGuard flag="enableEstimates"><ProposalList /></FeatureGuard>} />
-      <Route path="estimates/new" element={<FeatureGuard flag="enableEstimates"><ProposalBuilder /></FeatureGuard>} />
+      {/* ML-P1 Slice 1: mobile-first customer + draft quote (canonical quotes only) */}
+      <Route path="estimates/p1-draft" element={<FeatureGuard flag="enableEstimates"><MlP1S1DraftQuotePage /></FeatureGuard>} />
+      <Route path="estimates/new" element={<FeatureGuard flag="enableEstimates"><MlP1S1DraftQuotePage /></FeatureGuard>} />
       <Route path="estimates/:id" element={<FeatureGuard flag="enableEstimates"><ProposalBuilder /></FeatureGuard>} />
       <Route path="quotes/*" element={<EstimateAliasRedirect />} />
       <Route path="proposals/*" element={<EstimateAliasRedirect />} />

--- a/command-center/src/components/crm/estimates/EstimateEditorModal.jsx
+++ b/command-center/src/components/crm/estimates/EstimateEditorModal.jsx
@@ -10,6 +10,8 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { formatPhoneNumber } from '@/lib/formUtils';
 import { getTenantId } from '@/lib/tenantUtils';
 import AddressAutocomplete from '@/components/AddressAutocomplete';
+import { assertEstimatesCreateAllowed } from '@/lib/mlP1S1EstimatesDeny';
+import { incrementKpi } from '@/lib/mlP1S1Kpi';
 
 const EstimateEditorModal = ({ isOpen, onClose, onEstimateCreated }) => {
   const { toast } = useToast();
@@ -266,7 +268,9 @@ const EstimateEditorModal = ({ isOpen, onClose, onEstimateCreated }) => {
         updated_at: new Date().toISOString()
       };
 
-      // 4. Insert
+      // 4. Insert — ML-P1 Slice 1: legacy estimates create is DENY (use canonical quotes)
+      assertEstimatesCreateAllowed('EstimateEditorModal.save');
+      incrementKpi('estimates_create_deny');
       const { data, error } = await supabase.from('estimates').insert(payload).select().single();
 
       if (error) throw error;

--- a/command-center/src/components/crm/estimates/EstimateEditorModal.jsx
+++ b/command-center/src/components/crm/estimates/EstimateEditorModal.jsx
@@ -268,27 +268,12 @@ const EstimateEditorModal = ({ isOpen, onClose, onEstimateCreated }) => {
         updated_at: new Date().toISOString()
       };
 
-      // 4. Insert — ML-P1 Slice 1: legacy estimates create is DENY (use canonical quotes)
+      // 4. ML-P1 Slice 1: legacy estimates create is DENY (use canonical quotes).
+      // No insert is attempted — dead insert removed. Server RLS still requires
+      // a separately authorized additive migration (see Slice 1 evidence residual).
+      void payload;
       assertEstimatesCreateAllowed('EstimateEditorModal.save');
       incrementKpi('estimates_create_deny');
-      const { data, error } = await supabase.from('estimates').insert(payload).select().single();
-
-      if (error) throw error;
-
-      toast({ title: "Success", description: "Estimate created successfully." });
-      if (onEstimateCreated) onEstimateCreated(data);
-      onClose();
-      
-      // Reset State
-      setStep(1);
-      setSelectedLead(null);
-      setLineItems([]);
-      setSearchTerm('');
-      setIsCreatingNewCustomer(false);
-      setNewCustomer({ firstName: '', lastName: '', email: '', phone: '', company: '', address: '' });
-      setAppliedDiscount(null);
-      setDiscountCode('');
-
     } catch (err) {
       console.error(err);
       toast({ variant: "destructive", title: "Error", description: err.message });

--- a/command-center/src/lib/mlP1S1AuditEvents.js
+++ b/command-center/src/lib/mlP1S1AuditEvents.js
@@ -1,0 +1,97 @@
+/**
+ * ML-P1 Slice 1 — Draft quote audit event builders (Money-State Contract minimum fields).
+ * Client may insert into `events` when RLS allows; failures must not block draft save
+ * but are recorded as incomplete for KPI audit completeness.
+ */
+
+export const ML_P1_S1_EVENT_TYPES = Object.freeze({
+  DRAFT_CREATED: 'quote.draft_created',
+  DRAFT_UPDATED: 'quote.draft_updated',
+  DRAFT_ITEMS_SET: 'quote.draft_items_set',
+  TENANT_DENY: 'security.tenant_deny',
+  ESTIMATES_CREATE_DENY: 'security.estimates_create_deny',
+  DUP_CUSTOMER_HIT: 'kpi.duplicate_customer_hit',
+});
+
+/**
+ * Build append-only event row (no secrets / tokens).
+ */
+export function buildMoneyStateAuditEvent({
+  eventId,
+  tenantId,
+  recordId,
+  recordType = 'quote',
+  actorId = null,
+  actorRole = 'office',
+  previousState = null,
+  newState = 'draft',
+  reason = null,
+  sourceAction,
+  correlationId,
+  success = true,
+  related = {},
+  eventType,
+} = {}) {
+  if (!tenantId) {
+    const err = new Error('DENY: audit event requires tenant_id');
+    err.code = 'ML_P1_S1_AUDIT_MISSING_TENANT';
+    throw err;
+  }
+  if (!recordId && success) {
+    const err = new Error('DENY: successful audit event requires record_id');
+    err.code = 'ML_P1_S1_AUDIT_MISSING_RECORD';
+    throw err;
+  }
+  if (!sourceAction || !eventType) {
+    const err = new Error('DENY: audit event requires source_action and event_type');
+    err.code = 'ML_P1_S1_AUDIT_MISSING_ACTION';
+    throw err;
+  }
+
+  const payload = {
+    event_id: eventId || null,
+    record_id: recordId || null,
+    record_type: recordType,
+    tenant_id: tenantId,
+    actor_id: actorId,
+    actor_role: actorRole,
+    previous_state: previousState,
+    new_state: newState,
+    reason: reason || null,
+    source_action: sourceAction,
+    correlation_id: correlationId || null,
+    success: Boolean(success),
+    quote_id: related.quote_id || recordId || null,
+    lead_id: related.lead_id || null,
+    // Slice 1: no job/invoice ids
+    job_id: null,
+    invoice_id: null,
+  };
+
+  return {
+    tenant_id: tenantId,
+    entity_type: recordType,
+    entity_id: recordId || correlationId || 'unknown',
+    event_type: eventType,
+    actor_type: actorRole,
+    actor_id: actorId,
+    payload,
+    created_at: new Date().toISOString(),
+  };
+}
+
+export function assertAuditPayloadComplete(payload = {}) {
+  const required = [
+    'record_type',
+    'tenant_id',
+    'actor_role',
+    'new_state',
+    'source_action',
+    'correlation_id',
+    'success',
+  ];
+  const missing = required.filter((k) => payload[k] === undefined || payload[k] === null || payload[k] === '');
+  // success may be false; still required key present
+  if (payload.success === undefined) missing.push('success');
+  return { ok: missing.length === 0, missing };
+}

--- a/command-center/src/lib/mlP1S1AuditEvents.js
+++ b/command-center/src/lib/mlP1S1AuditEvents.js
@@ -13,6 +13,11 @@ export const ML_P1_S1_EVENT_TYPES = Object.freeze({
   DUP_CUSTOMER_HIT: 'kpi.duplicate_customer_hit',
 });
 
+function newEventId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
+  return `s1-evt-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 /**
  * Build append-only event row (no secrets / tokens).
  */
@@ -48,8 +53,11 @@ export function buildMoneyStateAuditEvent({
     throw err;
   }
 
+  const resolvedEventId = eventId || newEventId();
+  const resolvedCorrelation = correlationId || newEventId();
+
   const payload = {
-    event_id: eventId || null,
+    event_id: resolvedEventId,
     record_id: recordId || null,
     record_type: recordType,
     tenant_id: tenantId,
@@ -59,8 +67,9 @@ export function buildMoneyStateAuditEvent({
     new_state: newState,
     reason: reason || null,
     source_action: sourceAction,
-    correlation_id: correlationId || null,
+    correlation_id: resolvedCorrelation,
     success: Boolean(success),
+    timestamp: new Date().toISOString(),
     quote_id: related.quote_id || recordId || null,
     lead_id: related.lead_id || null,
     // Slice 1: no job/invoice ids
@@ -71,17 +80,19 @@ export function buildMoneyStateAuditEvent({
   return {
     tenant_id: tenantId,
     entity_type: recordType,
-    entity_id: recordId || correlationId || 'unknown',
+    entity_id: recordId || resolvedCorrelation || 'unknown',
     event_type: eventType,
     actor_type: actorRole,
     actor_id: actorId,
     payload,
-    created_at: new Date().toISOString(),
+    created_at: payload.timestamp,
   };
 }
 
 export function assertAuditPayloadComplete(payload = {}) {
   const required = [
+    'event_id',
+    'record_id',
     'record_type',
     'tenant_id',
     'actor_role',
@@ -89,9 +100,11 @@ export function assertAuditPayloadComplete(payload = {}) {
     'source_action',
     'correlation_id',
     'success',
+    'timestamp',
   ];
   const missing = required.filter((k) => payload[k] === undefined || payload[k] === null || payload[k] === '');
-  // success may be false; still required key present
+  // actor_id may be null for anonymous edge cases; require key present
+  if (!Object.prototype.hasOwnProperty.call(payload, 'actor_id')) missing.push('actor_id');
   if (payload.success === undefined) missing.push('success');
   return { ok: missing.length === 0, missing };
 }

--- a/command-center/src/lib/mlP1S1DuplicateCustomer.js
+++ b/command-center/src/lib/mlP1S1DuplicateCustomer.js
@@ -1,0 +1,82 @@
+/**
+ * ML-P1 Slice 1 — Duplicate customer detection (deterministic rules).
+ * Tenant-scoped. No name-only matching as sole criterion.
+ */
+
+import { formatPhoneNumber } from './formUtils.js';
+
+const asText = (value) => (typeof value === 'string' ? value.trim() : '');
+
+export const normalizePhoneDigits = (phone) => {
+  const formatted = formatPhoneNumber(phone) || asText(phone);
+  const digits = String(formatted).replace(/\D/g, '');
+  if (digits.length >= 10) return digits.slice(-10);
+  return digits || '';
+};
+
+/**
+ * Build PostgREST `.or()` filter fragments for duplicate search.
+ * Requires at least one strong signal (phone, email, or address fragment).
+ *
+ * @param {object} input
+ * @returns {{ ok: boolean, filters: string[], reason?: string }}
+ */
+export function buildDuplicateCustomerFilters(input = {}) {
+  const phoneDigits = normalizePhoneDigits(input.phone);
+  const email = asText(input.email).toLowerCase();
+  const lastName = asText(input.last_name || input.lastName);
+  const address1 = asText(input.address1 || input.address_line_1 || '');
+  const address = asText(input.address || input.service_address || '');
+  const streetHint = address1 || address.split(',')[0] || '';
+
+  const filters = [];
+  if (phoneDigits.length === 10) {
+    filters.push(`phone.ilike.%${phoneDigits}%`);
+  }
+  if (email) {
+    filters.push(`email.ilike.${email}`);
+  }
+  // Address street is a supporting signal; last name alone is never enough.
+  if (streetHint.length >= 5) {
+    filters.push(`address.ilike.%${streetHint}%`);
+    filters.push(`property_formatted_address.ilike.%${streetHint}%`);
+  }
+  if (lastName && (phoneDigits.length === 10 || email || streetHint.length >= 5)) {
+    filters.push(`last_name.ilike.%${lastName}%`);
+  }
+
+  if (!phoneDigits && !email && streetHint.length < 5) {
+    return {
+      ok: false,
+      filters: [],
+      reason: 'Need phone, email, or service address street to check for duplicates.',
+    };
+  }
+
+  return { ok: true, filters };
+}
+
+/**
+ * Rank matches: phone > email > address.
+ */
+export function scoreDuplicateCandidate(input = {}, candidate = {}) {
+  let score = 0;
+  const phoneDigits = normalizePhoneDigits(input.phone);
+  const candPhone = normalizePhoneDigits(candidate.phone);
+  if (phoneDigits && candPhone && phoneDigits === candPhone) score += 100;
+  const email = asText(input.email).toLowerCase();
+  const candEmail = asText(candidate.email).toLowerCase();
+  if (email && candEmail && email === candEmail) score += 50;
+  const street = asText(input.address1 || input.address_line_1 || input.address).toLowerCase();
+  const candAddr = asText(
+    candidate.address || candidate.property_formatted_address || '',
+  ).toLowerCase();
+  if (street && candAddr && candAddr.includes(street.split(',')[0].slice(0, 12))) score += 20;
+  return score;
+}
+
+export function sortDuplicateCandidates(input, rows = []) {
+  return [...rows].sort(
+    (a, b) => scoreDuplicateCandidate(input, b) - scoreDuplicateCandidate(input, a),
+  );
+}

--- a/command-center/src/lib/mlP1S1EstimatesDeny.js
+++ b/command-center/src/lib/mlP1S1EstimatesDeny.js
@@ -1,0 +1,41 @@
+/**
+ * ML-P1 Slice 1 — Legacy `estimates` create DENY (KI-01).
+ * New work must use canonical `quotes` only. No migration.
+ */
+
+export const ESTIMATES_CREATE_DENY_CODE = 'ML_P1_S1_ESTIMATES_CREATE_DENIED';
+
+export const ESTIMATES_CREATE_DENY_MESSAGE =
+  'DENY: legacy estimates create is frozen on the ML-P1 path. Use canonical quotes (draft) instead.';
+
+/**
+ * @param {{ operation?: string }} [opts]
+ * @returns {{ ok: false, code: string, message: string }}
+ */
+export function denyEstimatesCreate(opts = {}) {
+  return {
+    ok: false,
+    code: ESTIMATES_CREATE_DENY_CODE,
+    message: ESTIMATES_CREATE_DENY_MESSAGE,
+    operation: opts.operation || 'estimates.insert',
+  };
+}
+
+/**
+ * Throw-style guard for call sites that prefer exceptions.
+ * @param {string} [operation]
+ */
+export function assertEstimatesCreateAllowed(operation = 'estimates.insert') {
+  const denied = denyEstimatesCreate({ operation });
+  const err = new Error(denied.message);
+  err.code = denied.code;
+  err.operation = denied.operation;
+  throw err;
+}
+
+/**
+ * True if an error is the S1 estimates DENY.
+ */
+export function isEstimatesCreateDeniedError(error) {
+  return error?.code === ESTIMATES_CREATE_DENY_CODE;
+}

--- a/command-center/src/lib/mlP1S1Identity.js
+++ b/command-center/src/lib/mlP1S1Identity.js
@@ -1,0 +1,71 @@
+/**
+ * ML-P1 Slice 1 — Identity / address join pattern (KI-03 / KI-04).
+ *
+ * Authoritative P1 customer = `leads` row (stable UUID id).
+ * Service address for P1 path = lead.address / lead.property_formatted_address,
+ * composed from structured parts using address_line_1 alias (never invent properties UUID joins).
+ *
+ * Do NOT:
+ * - join money-loop entities to properties on name
+ * - assume leads.property_id UUID equals properties.id bigint
+ * - write address1 column on hosted properties (use address_line_1 when touching properties)
+ */
+
+import { resolveIntakeAddress } from './leadIntakeContract.js';
+
+export const ML_P1_S1_CUSTOMER_ENTITY = 'lead';
+
+export const ML_P1_S1_ADDRESS_FIELD_POLICY = Object.freeze({
+  lead_freeform: ['address', 'property_formatted_address'],
+  structured_aliases: {
+    street: ['address1', 'address_line_1'],
+    street2: ['address2', 'address_line_2'],
+    city: ['city'],
+    state: ['state'],
+    zip: ['zip', 'postal_code'],
+  },
+  properties_table_street_column: 'address_line_1',
+  forbidden_properties_street_column: 'address1',
+});
+
+/**
+ * Resolve service address for quote draft from lead + optional form overrides.
+ */
+export function resolveP1ServiceAddress({ lead = null, form = null } = {}) {
+  if (form) {
+    const fromForm = resolveIntakeAddress(form);
+    if (fromForm) return fromForm;
+  }
+  if (lead) {
+    const fromLead =
+      (typeof lead.property_formatted_address === 'string' && lead.property_formatted_address.trim()) ||
+      (typeof lead.address === 'string' && lead.address.trim()) ||
+      '';
+    if (fromLead) return fromLead;
+  }
+  return '';
+}
+
+/**
+ * Assert quote payload does not use name-based customer linking.
+ */
+export function assertStableCustomerLink(quotePayload = {}) {
+  if (!quotePayload.lead_id) {
+    const err = new Error('DENY: draft quote requires stable lead_id (no name-based linking).');
+    err.code = 'ML_P1_S1_MISSING_LEAD_ID';
+    throw err;
+  }
+  if (quotePayload.property_id != null && quotePayload.property_id !== '') {
+    // Soft policy: allow opaque pointer only if caller marks it; default strip guidance.
+    // S1 does not invent property UUID/bigint joins.
+  }
+  return true;
+}
+
+export function documentUuidBigintPolicy() {
+  return {
+    status: 'DEFER_SIGNED_unification',
+    rule: 'P1 uses lead UUID as customer authority; do not join properties.id bigint to lead UUID as equality.',
+    address_column: 'address_line_1 on properties when needed; leads use freeform address fields.',
+  };
+}

--- a/command-center/src/lib/mlP1S1Kpi.js
+++ b/command-center/src/lib/mlP1S1Kpi.js
@@ -1,0 +1,66 @@
+/**
+ * ML-P1 Slice 1 — KPI instrumentation (in-memory + optional event).
+ * Baseline-first: timings are recorded; targets not invented here.
+ */
+
+const g = typeof globalThis !== 'undefined' ? globalThis : {};
+const STORE_KEY = '__ML_P1_S1_KPI_STORE__';
+
+function store() {
+  if (!g[STORE_KEY]) {
+    g[STORE_KEY] = {
+      timers: Object.create(null),
+      counters: Object.create(null),
+      notesEscapeDiary: [],
+    };
+  }
+  return g[STORE_KEY];
+}
+
+export function resetMlP1S1KpiStore() {
+  g[STORE_KEY] = {
+    timers: Object.create(null),
+    counters: Object.create(null),
+    notesEscapeDiary: [],
+  };
+}
+
+export function startKpiTimer(name) {
+  store().timers[name] = { startedAt: Date.now(), endedAt: null, ms: null };
+}
+
+export function endKpiTimer(name) {
+  const t = store().timers[name];
+  if (!t || t.startedAt == null) return null;
+  t.endedAt = Date.now();
+  t.ms = t.endedAt - t.startedAt;
+  return t.ms;
+}
+
+export function incrementKpi(name, by = 1) {
+  const c = store().counters;
+  c[name] = (c[name] || 0) + by;
+  return c[name];
+}
+
+export function recordNotesEscape({ usedExternalTool, tool, task, at = null } = {}) {
+  const entry = {
+    usedExternalTool: Boolean(usedExternalTool),
+    tool: tool || null,
+    task: task || null,
+    at: at || new Date().toISOString(),
+  };
+  store().notesEscapeDiary.push(entry);
+  if (usedExternalTool) incrementKpi('notes_escape');
+  else incrementKpi('notes_escape_clean');
+  return entry;
+}
+
+export function getKpiSnapshot() {
+  const s = store();
+  return {
+    timers: { ...s.timers },
+    counters: { ...s.counters },
+    notesEscapeDiary: [...s.notesEscapeDiary],
+  };
+}

--- a/command-center/src/lib/mlP1S1Kpi.js
+++ b/command-center/src/lib/mlP1S1Kpi.js
@@ -3,10 +3,17 @@
  * Baseline-first: timings are recorded; targets not invented here.
  */
 
-const g = typeof globalThis !== 'undefined' ? globalThis : {};
+/* Avoid globalThis (eslint no-undef under react-app). Prefer window, then Node global. */
+function rootObject() {
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+  return {};
+}
+
 const STORE_KEY = '__ML_P1_S1_KPI_STORE__';
 
 function store() {
+  const g = rootObject();
   if (!g[STORE_KEY]) {
     g[STORE_KEY] = {
       timers: Object.create(null),
@@ -18,6 +25,7 @@ function store() {
 }
 
 export function resetMlP1S1KpiStore() {
+  const g = rootObject();
   g[STORE_KEY] = {
     timers: Object.create(null),
     counters: Object.create(null),

--- a/command-center/src/lib/mlP1S1Tenant.js
+++ b/command-center/src/lib/mlP1S1Tenant.js
@@ -1,12 +1,13 @@
 /**
  * ML-P1 Slice 1 — Tenant enforcement helpers (deny-by-default).
+ * Money-State §12: missing session tenant → DENY; client URL/default override alone → DENY.
  */
 
 export const TENANT_DENY_CODE = 'ML_P1_S1_TENANT_DENY';
 
 /**
- * Resolve write tenant: session claim preferred; URL tenant must match when both present.
- * Never silently fall back across tenants.
+ * Resolve write tenant from session only. URL may confirm match; never authorizes alone.
+ * `defaultTenantId` is ignored (deny-by-default; no silent fallback).
  *
  * @param {{ sessionTenantId?: string|null, urlTenantId?: string|null, defaultTenantId?: string|null }} args
  */
@@ -15,25 +16,25 @@ export function resolveWriteTenantId({
   urlTenantId = null,
   defaultTenantId = null,
 } = {}) {
+  void defaultTenantId; // explicitly ignored — no admin/default tenant fallback
   const session = sessionTenantId && String(sessionTenantId).trim();
   const url = urlTenantId && String(urlTenantId).trim();
-  const fallback = defaultTenantId && String(defaultTenantId).trim();
 
-  if (session && url && session !== url) {
+  if (!session) {
+    const err = new Error('DENY: session tenant_id required for money-path write');
+    err.code = TENANT_DENY_CODE;
+    throw err;
+  }
+  if (url && session !== url) {
     const err = new Error('DENY: session tenant does not match URL tenant');
     err.code = TENANT_DENY_CODE;
     throw err;
   }
-  if (session) return session;
-  if (url) return url;
-  if (fallback) return fallback;
-  const err = new Error('DENY: tenant_id required for money-path write');
-  err.code = TENANT_DENY_CODE;
-  throw err;
+  return session;
 }
 
 /**
- * Assert row tenant matches write tenant.
+ * Assert row tenant matches write tenant. Null row tenant → DENY (no unscoped money rows).
  */
 export function assertTenantMatch(rowTenantId, writeTenantId) {
   if (!writeTenantId) {
@@ -41,7 +42,12 @@ export function assertTenantMatch(rowTenantId, writeTenantId) {
     err.code = TENANT_DENY_CODE;
     throw err;
   }
-  if (rowTenantId != null && String(rowTenantId) !== String(writeTenantId)) {
+  if (rowTenantId == null || String(rowTenantId).trim() === '') {
+    const err = new Error('DENY: row tenant missing');
+    err.code = TENANT_DENY_CODE;
+    throw err;
+  }
+  if (String(rowTenantId) !== String(writeTenantId)) {
     const err = new Error('DENY: cross-tenant access blocked');
     err.code = TENANT_DENY_CODE;
     throw err;

--- a/command-center/src/lib/mlP1S1Tenant.js
+++ b/command-center/src/lib/mlP1S1Tenant.js
@@ -1,0 +1,54 @@
+/**
+ * ML-P1 Slice 1 — Tenant enforcement helpers (deny-by-default).
+ */
+
+export const TENANT_DENY_CODE = 'ML_P1_S1_TENANT_DENY';
+
+/**
+ * Resolve write tenant: session claim preferred; URL tenant must match when both present.
+ * Never silently fall back across tenants.
+ *
+ * @param {{ sessionTenantId?: string|null, urlTenantId?: string|null, defaultTenantId?: string|null }} args
+ */
+export function resolveWriteTenantId({
+  sessionTenantId = null,
+  urlTenantId = null,
+  defaultTenantId = null,
+} = {}) {
+  const session = sessionTenantId && String(sessionTenantId).trim();
+  const url = urlTenantId && String(urlTenantId).trim();
+  const fallback = defaultTenantId && String(defaultTenantId).trim();
+
+  if (session && url && session !== url) {
+    const err = new Error('DENY: session tenant does not match URL tenant');
+    err.code = TENANT_DENY_CODE;
+    throw err;
+  }
+  if (session) return session;
+  if (url) return url;
+  if (fallback) return fallback;
+  const err = new Error('DENY: tenant_id required for money-path write');
+  err.code = TENANT_DENY_CODE;
+  throw err;
+}
+
+/**
+ * Assert row tenant matches write tenant.
+ */
+export function assertTenantMatch(rowTenantId, writeTenantId) {
+  if (!writeTenantId) {
+    const err = new Error('DENY: write tenant missing');
+    err.code = TENANT_DENY_CODE;
+    throw err;
+  }
+  if (rowTenantId != null && String(rowTenantId) !== String(writeTenantId)) {
+    const err = new Error('DENY: cross-tenant access blocked');
+    err.code = TENANT_DENY_CODE;
+    throw err;
+  }
+  return true;
+}
+
+export function isTenantDenyError(error) {
+  return error?.code === TENANT_DENY_CODE;
+}

--- a/command-center/src/pages/crm/MlP1S1DraftQuotePage.jsx
+++ b/command-center/src/pages/crm/MlP1S1DraftQuotePage.jsx
@@ -1,0 +1,449 @@
+/**
+ * ML-P1 Slice 1 — Mobile-first customer find/create + draft quote (canonical quotes only).
+ * Does not issue, approve, convert to job, or invoice.
+ */
+import React, { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '@/lib/customSupabaseClient';
+import { getTenantId, resolveTenantIdFromSession, tenantPath } from '@/lib/tenantUtils';
+import { DEFAULT_TENANT_ID } from '@/config/tenantDefaults';
+import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
+import { useToast } from '@/components/ui/use-toast';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  assertLeadIntakeValid,
+  buildLeadIntakeInsertPayload,
+  describeLeadIntakeDbError,
+} from '@/lib/leadIntakeContract';
+import { createMlP1S1QuoteDraftService } from '@/services/mlP1S1QuoteDraftService';
+import {
+  endKpiTimer,
+  getKpiSnapshot,
+  recordNotesEscape,
+  startKpiTimer,
+} from '@/lib/mlP1S1Kpi';
+import { ArrowLeft, Loader2, Plus, Search, UserPlus } from 'lucide-react';
+
+const draftService = createMlP1S1QuoteDraftService({ supabase });
+
+const emptyForm = () => ({
+  first_name: '',
+  last_name: '',
+  company: '',
+  phone: '',
+  email: '',
+  address1: '',
+  city: '',
+  state: '',
+  zip: '',
+});
+
+export default function MlP1S1DraftQuotePage() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const { user } = useSupabaseAuth() || {};
+  const urlTenantId = getTenantId();
+
+  const [step, setStep] = useState(1);
+  const [search, setSearch] = useState('');
+  const [searching, setSearching] = useState(false);
+  const [results, setResults] = useState([]);
+  const [selectedLead, setSelectedLead] = useState(null);
+  const [creating, setCreating] = useState(false);
+  const [form, setForm] = useState(emptyForm);
+  const [duplicates, setDuplicates] = useState([]);
+  const [lineDesc, setLineDesc] = useState('Service');
+  const [linePrice, setLinePrice] = useState('0');
+  const [saving, setSaving] = useState(false);
+  const [idemKey] = useState(() =>
+    typeof crypto !== 'undefined' && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `s1-${Date.now()}`,
+  );
+  const [lastQuoteId, setLastQuoteId] = useState(null);
+  const [tapCount, setTapCount] = useState(0);
+
+  const bumpTap = () => setTapCount((n) => n + 1);
+
+  const sessionTenantPromise = useMemo(() => resolveTenantIdFromSession(), []);
+
+  const runSearch = async () => {
+    bumpTap();
+    startKpiTimer('find_customer');
+    setSearching(true);
+    try {
+      const q = search.trim();
+      if (!q) {
+        setResults([]);
+        return;
+      }
+      const { data, error } = await supabase
+        .from('leads')
+        .select(
+          'id, tenant_id, first_name, last_name, company, phone, email, address, property_formatted_address',
+        )
+        .eq('tenant_id', urlTenantId)
+        .or(
+          `first_name.ilike.%${q}%,last_name.ilike.%${q}%,company.ilike.%${q}%,phone.ilike.%${q}%,email.ilike.%${q}%,address.ilike.%${q}%`,
+        )
+        .limit(12);
+      if (error) throw error;
+      setResults(data || []);
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Search failed',
+        description: error.message || 'Could not search customers',
+      });
+    } finally {
+      endKpiTimer('find_customer');
+      setSearching(false);
+    }
+  };
+
+  const selectLead = (lead) => {
+    bumpTap();
+    setSelectedLead(lead);
+    setDuplicates([]);
+    setStep(2);
+    recordNotesEscape({ usedExternalTool: false, task: 'select_customer' });
+  };
+
+  const createCustomer = async ({ force = false } = {}) => {
+    bumpTap();
+    startKpiTimer('create_customer');
+    setCreating(true);
+    try {
+      const sessionTenantId = await sessionTenantPromise;
+      const validation = assertLeadIntakeValid(form);
+      if (!force) {
+        const dup = await draftService.findDuplicateCustomers({
+          tenantId: urlTenantId,
+          input: form,
+        });
+        if (dup.ok && dup.matches?.length) {
+          setDuplicates(dup.matches);
+          toast({
+            title: 'Possible duplicates',
+            description: 'Select an existing customer or force-create if intentional.',
+          });
+          return;
+        }
+      }
+
+      const payload = buildLeadIntakeInsertPayload(form, {
+        tenantId: urlTenantId,
+        source: 'ml_p1_s1',
+      });
+      const { data, error } = await supabase.from('leads').insert(payload).select('*').single();
+      if (error) throw error;
+      if (sessionTenantId && data.tenant_id && sessionTenantId !== data.tenant_id) {
+        // Should not happen; surface if it does
+        toast({
+          variant: 'destructive',
+          title: 'Tenant mismatch',
+          description: 'Created lead tenant does not match session.',
+        });
+      }
+      setSelectedLead(data);
+      setDuplicates([]);
+      setStep(2);
+      recordNotesEscape({ usedExternalTool: false, task: 'create_customer' });
+      toast({ title: 'Customer created', description: 'Continue to draft quote.' });
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Could not create customer',
+        description: describeLeadIntakeDbError(error) || error.message,
+      });
+    } finally {
+      endKpiTimer('create_customer');
+      setCreating(false);
+    }
+  };
+
+  const saveDraft = async () => {
+    bumpTap();
+    if (!selectedLead) return;
+    setSaving(true);
+    try {
+      const sessionTenantId = await resolveTenantIdFromSession();
+      const price = Number(linePrice) || 0;
+      const result = await draftService.createDraftQuote({
+        lead: selectedLead,
+        form,
+        lineItems: [
+          {
+            description: lineDesc || 'Service',
+            quantity: 1,
+            unit_price: price,
+          },
+        ],
+        sessionTenantId,
+        urlTenantId,
+        defaultTenantId: DEFAULT_TENANT_ID,
+        actorId: user?.id || null,
+        actorRole: 'office',
+        idempotencyKey: idemKey,
+      });
+      setLastQuoteId(result.quote.id);
+      recordNotesEscape({ usedExternalTool: false, task: 'create_draft_quote' });
+      toast({
+        title: result.idempotent ? 'Draft reused (idempotent)' : 'Draft quote saved',
+        description: `Quote ${result.quote.id.slice(0, 8)}… — issue/approve not in Slice 1.`,
+      });
+      setStep(3);
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Draft save failed',
+        description: error.message || 'Could not save draft quote',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const kpi = getKpiSnapshot();
+
+  return (
+    <div className="mx-auto max-w-lg px-3 py-4 pb-24 space-y-4">
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => {
+            bumpTap();
+            navigate(tenantPath('/crm/estimates'));
+          }}
+          aria-label="Back"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <div>
+          <h1 className="text-lg font-semibold text-slate-900">P1 Draft Quote</h1>
+          <p className="text-xs text-slate-500">Slice 1 — customer + draft only (no issue/approve)</p>
+        </div>
+      </div>
+
+      {step === 1 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Find or create customer</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex gap-2">
+              <Input
+                placeholder="Search name, phone, address…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="text-base"
+              />
+              <Button type="button" onClick={runSearch} disabled={searching}>
+                {searching ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
+              </Button>
+            </div>
+            <ul className="divide-y rounded-md border">
+              {results.map((lead) => (
+                <li key={lead.id}>
+                  <button
+                    type="button"
+                    className="w-full text-left px-3 py-3 hover:bg-slate-50"
+                    onClick={() => selectLead(lead)}
+                  >
+                    <div className="font-medium text-slate-900">
+                      {[lead.first_name, lead.last_name].filter(Boolean).join(' ') ||
+                        lead.company ||
+                        'Customer'}
+                    </div>
+                    <div className="text-xs text-slate-500">
+                      {lead.phone} · {lead.address || lead.property_formatted_address}
+                    </div>
+                  </button>
+                </li>
+              ))}
+              {!results.length && (
+                <li className="px-3 py-4 text-sm text-slate-500">No matches yet — create below.</li>
+              )}
+            </ul>
+
+            <div className="border-t pt-4 space-y-3">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <UserPlus className="h-4 w-4" /> New customer
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <Label>First</Label>
+                  <Input
+                    value={form.first_name}
+                    onChange={(e) => setForm((f) => ({ ...f, first_name: e.target.value }))}
+                  />
+                </div>
+                <div>
+                  <Label>Last</Label>
+                  <Input
+                    value={form.last_name}
+                    onChange={(e) => setForm((f) => ({ ...f, last_name: e.target.value }))}
+                  />
+                </div>
+              </div>
+              <div>
+                <Label>Company</Label>
+                <Input
+                  value={form.company}
+                  onChange={(e) => setForm((f) => ({ ...f, company: e.target.value }))}
+                />
+              </div>
+              <div>
+                <Label>Phone</Label>
+                <Input
+                  inputMode="tel"
+                  value={form.phone}
+                  onChange={(e) => setForm((f) => ({ ...f, phone: e.target.value }))}
+                />
+              </div>
+              <div>
+                <Label>Email</Label>
+                <Input
+                  inputMode="email"
+                  value={form.email}
+                  onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))}
+                />
+              </div>
+              <div>
+                <Label>Street (address_line_1)</Label>
+                <Input
+                  value={form.address1}
+                  onChange={(e) => setForm((f) => ({ ...f, address1: e.target.value }))}
+                />
+              </div>
+              <div className="grid grid-cols-3 gap-2">
+                <div className="col-span-1">
+                  <Label>City</Label>
+                  <Input
+                    value={form.city}
+                    onChange={(e) => setForm((f) => ({ ...f, city: e.target.value }))}
+                  />
+                </div>
+                <div>
+                  <Label>ST</Label>
+                  <Input
+                    value={form.state}
+                    onChange={(e) => setForm((f) => ({ ...f, state: e.target.value }))}
+                  />
+                </div>
+                <div>
+                  <Label>ZIP</Label>
+                  <Input
+                    value={form.zip}
+                    onChange={(e) => setForm((f) => ({ ...f, zip: e.target.value }))}
+                  />
+                </div>
+              </div>
+
+              {duplicates.length > 0 && (
+                <div className="rounded-md border border-amber-300 bg-amber-50 p-3 space-y-2">
+                  <p className="text-sm font-medium text-amber-900">Possible duplicates</p>
+                  {duplicates.map((d) => (
+                    <button
+                      key={d.id}
+                      type="button"
+                      className="block w-full text-left text-sm underline"
+                      onClick={() => selectLead(d)}
+                    >
+                      {[d.first_name, d.last_name].filter(Boolean).join(' ') || d.company} —{' '}
+                      {d.phone}
+                    </button>
+                  ))}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={creating}
+                    onClick={() => createCustomer({ force: true })}
+                  >
+                    Create anyway
+                  </Button>
+                </div>
+              )}
+
+              <Button type="button" className="w-full" disabled={creating} onClick={() => createCustomer()}>
+                {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4 mr-2" />}
+                Create customer
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 2 && selectedLead && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Draft quote</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-sm text-slate-600">
+              {[selectedLead.first_name, selectedLead.last_name].filter(Boolean).join(' ') ||
+                selectedLead.company}
+            </p>
+            <p className="text-xs text-slate-500">
+              {selectedLead.address || selectedLead.property_formatted_address}
+            </p>
+            <div>
+              <Label>Line item</Label>
+              <Input value={lineDesc} onChange={(e) => setLineDesc(e.target.value)} />
+            </div>
+            <div>
+              <Label>Price</Label>
+              <Input
+                inputMode="decimal"
+                value={linePrice}
+                onChange={(e) => setLinePrice(e.target.value)}
+              />
+            </div>
+            <Button type="button" className="w-full" disabled={saving} onClick={saveDraft}>
+              {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              Save draft quote
+            </Button>
+            <Button type="button" variant="ghost" className="w-full" onClick={() => setStep(1)}>
+              Change customer
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 3 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Draft saved</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <p>Quote id: {lastQuoteId}</p>
+            <p className="text-slate-500">
+              Slice 1 stops here — issue, approve, job, and invoice are not authorized.
+            </p>
+            <p className="text-xs text-slate-400">
+              Taps this session: {tapCount}. KPI timers:{' '}
+              {JSON.stringify(
+                Object.fromEntries(
+                  Object.entries(kpi.timers || {}).map(([k, v]) => [k, v.ms]),
+                ),
+              )}
+            </p>
+            <Button
+              type="button"
+              className="w-full"
+              onClick={() => navigate(tenantPath(`/crm/estimates/${lastQuoteId}`))}
+            >
+              Open in estimates list editor (existing)
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/command-center/src/pages/crm/MlP1S1DraftQuotePage.jsx
+++ b/command-center/src/pages/crm/MlP1S1DraftQuotePage.jsx
@@ -2,11 +2,10 @@
  * ML-P1 Slice 1 — Mobile-first customer find/create + draft quote (canonical quotes only).
  * Does not issue, approve, convert to job, or invoice.
  */
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '@/lib/customSupabaseClient';
 import { getTenantId, resolveTenantIdFromSession, tenantPath } from '@/lib/tenantUtils';
-import { DEFAULT_TENANT_ID } from '@/config/tenantDefaults';
 import { useSupabaseAuth } from '@/contexts/SupabaseAuthContext';
 import { useToast } from '@/components/ui/use-toast';
 import { Button } from '@/components/ui/button';
@@ -19,6 +18,7 @@ import {
   describeLeadIntakeDbError,
 } from '@/lib/leadIntakeContract';
 import { createMlP1S1QuoteDraftService } from '@/services/mlP1S1QuoteDraftService';
+import { resolveWriteTenantId, isTenantDenyError } from '@/lib/mlP1S1Tenant';
 import {
   endKpiTimer,
   getKpiSnapshot,
@@ -68,13 +68,13 @@ export default function MlP1S1DraftQuotePage() {
 
   const bumpTap = () => setTapCount((n) => n + 1);
 
-  const sessionTenantPromise = useMemo(() => resolveTenantIdFromSession(), []);
-
   const runSearch = async () => {
     bumpTap();
     startKpiTimer('find_customer');
     setSearching(true);
     try {
+      const sessionTenantId = await resolveTenantIdFromSession();
+      const tenantId = resolveWriteTenantId({ sessionTenantId, urlTenantId });
       const q = search.trim();
       if (!q) {
         setResults([]);
@@ -85,7 +85,7 @@ export default function MlP1S1DraftQuotePage() {
         .select(
           'id, tenant_id, first_name, last_name, company, phone, email, address, property_formatted_address',
         )
-        .eq('tenant_id', urlTenantId)
+        .eq('tenant_id', tenantId)
         .or(
           `first_name.ilike.%${q}%,last_name.ilike.%${q}%,company.ilike.%${q}%,phone.ilike.%${q}%,email.ilike.%${q}%,address.ilike.%${q}%`,
         )
@@ -117,11 +117,13 @@ export default function MlP1S1DraftQuotePage() {
     startKpiTimer('create_customer');
     setCreating(true);
     try {
-      const sessionTenantId = await sessionTenantPromise;
-      const validation = assertLeadIntakeValid(form);
+      const sessionTenantId = await resolveTenantIdFromSession();
+      const tenantId = resolveWriteTenantId({ sessionTenantId, urlTenantId });
+      assertLeadIntakeValid(form);
       if (!force) {
         const dup = await draftService.findDuplicateCustomers({
-          tenantId: urlTenantId,
+          sessionTenantId,
+          urlTenantId,
           input: form,
         });
         if (dup.ok && dup.matches?.length) {
@@ -135,19 +137,11 @@ export default function MlP1S1DraftQuotePage() {
       }
 
       const payload = buildLeadIntakeInsertPayload(form, {
-        tenantId: urlTenantId,
+        tenantId,
         source: 'ml_p1_s1',
       });
       const { data, error } = await supabase.from('leads').insert(payload).select('*').single();
       if (error) throw error;
-      if (sessionTenantId && data.tenant_id && sessionTenantId !== data.tenant_id) {
-        // Should not happen; surface if it does
-        toast({
-          variant: 'destructive',
-          title: 'Tenant mismatch',
-          description: 'Created lead tenant does not match session.',
-        });
-      }
       setSelectedLead(data);
       setDuplicates([]);
       setStep(2);
@@ -156,7 +150,7 @@ export default function MlP1S1DraftQuotePage() {
     } catch (error) {
       toast({
         variant: 'destructive',
-        title: 'Could not create customer',
+        title: isTenantDenyError(error) ? 'Tenant deny' : 'Could not create customer',
         description: describeLeadIntakeDbError(error) || error.message,
       });
     } finally {
@@ -184,7 +178,6 @@ export default function MlP1S1DraftQuotePage() {
         ],
         sessionTenantId,
         urlTenantId,
-        defaultTenantId: DEFAULT_TENANT_ID,
         actorId: user?.id || null,
         actorRole: 'office',
         idempotencyKey: idemKey,

--- a/command-center/src/services/mlP1S1QuoteDraftService.js
+++ b/command-center/src/services/mlP1S1QuoteDraftService.js
@@ -13,9 +13,16 @@ import {
   ML_P1_S1_EVENT_TYPES,
 } from '../lib/mlP1S1AuditEvents.js';
 import { assertTenantMatch, resolveWriteTenantId } from '../lib/mlP1S1Tenant.js';
+import {
+  buildDuplicateCustomerFilters,
+  sortDuplicateCandidates,
+} from '../lib/mlP1S1DuplicateCustomer.js';
 import { endKpiTimer, incrementKpi, startKpiTimer } from '../lib/mlP1S1Kpi.js';
 
 const DRAFT_STATUS = 'draft';
+
+/** Process-local in-flight locks to collapse concurrent double-submit for same idem key. */
+const inflightDraftCreates = new Map();
 
 function newCorrelationId() {
   if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
@@ -69,18 +76,20 @@ export function createMlP1S1QuoteDraftService(deps) {
   /**
    * Create or return existing draft quote (idempotent).
    */
-  async function createDraftQuote({
-    lead,
-    form = null,
-    lineItems = [],
-    sessionTenantId = null,
-    urlTenantId = null,
-    defaultTenantId = null,
-    actorId = null,
-    actorRole = 'office',
-    idempotencyKey = null,
-    correlationId = null,
-  }) {
+  async function createDraftQuote(args) {
+    const {
+      lead,
+      form = null,
+      lineItems = [],
+      sessionTenantId = null,
+      urlTenantId = null,
+      defaultTenantId = null,
+      actorId = null,
+      actorRole = 'office',
+      idempotencyKey = null,
+      correlationId = null,
+    } = args || {};
+
     startKpiTimer('create_draft_quote');
 
     const tenantId = resolveWriteTenantId({
@@ -105,106 +114,122 @@ export function createMlP1S1QuoteDraftService(deps) {
 
     const corr = correlationId || newCorrelationId();
     const idem = idempotencyKey || corr;
+    const lockKey = `${tenantId}:${lead.id}:${idem}`;
 
-    const existing = await findDraftByIdempotency({
-      tenantId,
-      leadId: lead.id,
-      idempotencyKey: idem,
-    });
-    if (existing) {
-      incrementKpi('draft_idempotent_hit');
+    if (inflightDraftCreates.has(lockKey)) {
+      incrementKpi('draft_idempotent_inflight');
+      const shared = await inflightDraftCreates.get(lockKey);
       endKpiTimer('create_draft_quote');
-      return {
-        quote: existing,
-        items: [],
-        idempotent: true,
-        correlationId: corr,
-        audit: { skipped: true, reason: 'idempotent_reuse' },
-      };
+      return { ...shared, idempotent: true };
     }
 
-    const marker = `s1-idem:${idem}`;
-    const subtotal = (lineItems || []).reduce(
-      (sum, item) => sum + Number(item.quantity || 1) * Number(item.unit_price || item.price || 0),
-      0,
-    );
-
-    const quotePayload = {
-      lead_id: lead.id,
-      tenant_id: tenantId,
-      status: DRAFT_STATUS,
-      service_address: serviceAddress,
-      customer_name:
-        [lead.first_name, lead.last_name].filter(Boolean).join(' ') || lead.company || null,
-      customer_email: lead.email || null,
-      customer_phone: lead.phone || null,
-      subtotal,
-      total: subtotal,
-      tax: 0,
-      notes: marker,
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-    };
-    assertStableCustomerLink(quotePayload);
-
-    const { data: quote, error: quoteError } = await supabase
-      .from('quotes')
-      .insert([quotePayload])
-      .select('*')
-      .single();
-    if (quoteError) throw quoteError;
-
-    let items = [];
-    if (lineItems?.length) {
-      const rows = lineItems.map((item, index) => {
-        const qty = Number(item.quantity || 1);
-        const unit = Number(item.unit_price || item.price || 0);
-        return {
-          quote_id: quote.id,
-          description: item.description || item.name || `Item ${index + 1}`,
-          quantity: qty,
-          unit_price: unit,
-          total_price: qty * unit,
-        };
+    const run = (async () => {
+      const existing = await findDraftByIdempotency({
+        tenantId,
+        leadId: lead.id,
+        idempotencyKey: idem,
       });
-      const { data: insertedItems, error: itemsError } = await supabase
-        .from('quote_items')
-        .insert(rows)
-        .select('*');
-      if (itemsError) {
-        // Best-effort compensation without migration: delete draft quote
-        await supabase.from('quotes').delete().eq('id', quote.id).eq('tenant_id', tenantId);
-        throw itemsError;
+      if (existing) {
+        incrementKpi('draft_idempotent_hit');
+        return {
+          quote: existing,
+          items: [],
+          idempotent: true,
+          correlationId: corr,
+          audit: { skipped: true, reason: 'idempotent_reuse' },
+        };
       }
-      items = insertedItems || [];
+
+      const marker = `s1-idem:${idem}`;
+      const subtotal = (lineItems || []).reduce(
+        (sum, item) => sum + Number(item.quantity || 1) * Number(item.unit_price || item.price || 0),
+        0,
+      );
+
+      const quotePayload = {
+        lead_id: lead.id,
+        tenant_id: tenantId,
+        status: DRAFT_STATUS,
+        service_address: serviceAddress,
+        customer_name:
+          [lead.first_name, lead.last_name].filter(Boolean).join(' ') || lead.company || null,
+        customer_email: lead.email || null,
+        customer_phone: lead.phone || null,
+        subtotal,
+        total: subtotal,
+        tax: 0,
+        notes: marker,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+      assertStableCustomerLink(quotePayload);
+
+      const { data: quote, error: quoteError } = await supabase
+        .from('quotes')
+        .insert([quotePayload])
+        .select('*')
+        .single();
+      if (quoteError) throw quoteError;
+
+      let items = [];
+      if (lineItems?.length) {
+        const rows = lineItems.map((item, index) => {
+          const qty = Number(item.quantity || 1);
+          const unit = Number(item.unit_price || item.price || 0);
+          return {
+            quote_id: quote.id,
+            description: item.description || item.name || `Item ${index + 1}`,
+            quantity: qty,
+            unit_price: unit,
+            total_price: qty * unit,
+          };
+        });
+        const { data: insertedItems, error: itemsError } = await supabase
+          .from('quote_items')
+          .insert(rows)
+          .select('*');
+        if (itemsError) {
+          await supabase.from('quotes').delete().eq('id', quote.id).eq('tenant_id', tenantId);
+          throw itemsError;
+        }
+        items = insertedItems || [];
+      }
+
+      const auditRow = buildMoneyStateAuditEvent({
+        tenantId,
+        recordId: quote.id,
+        recordType: 'quote',
+        actorId,
+        actorRole,
+        previousState: null,
+        newState: DRAFT_STATUS,
+        sourceAction: 'ml_p1_s1.create_draft_quote',
+        correlationId: corr,
+        success: true,
+        related: { quote_id: quote.id, lead_id: lead.id },
+        eventType: ML_P1_S1_EVENT_TYPES.DRAFT_CREATED,
+      });
+      const audit = await emitAudit(auditRow);
+
+      incrementKpi('draft_created');
+
+      return {
+        quote,
+        items,
+        idempotent: false,
+        correlationId: corr,
+        audit,
+      };
+    })();
+
+    inflightDraftCreates.set(lockKey, run);
+    try {
+      const result = await run;
+      endKpiTimer('create_draft_quote');
+      return result;
+    } finally {
+      inflightDraftCreates.delete(lockKey);
     }
-
-    const auditRow = buildMoneyStateAuditEvent({
-      tenantId,
-      recordId: quote.id,
-      recordType: 'quote',
-      actorId,
-      actorRole,
-      previousState: null,
-      newState: DRAFT_STATUS,
-      sourceAction: 'ml_p1_s1.create_draft_quote',
-      correlationId: corr,
-      success: true,
-      related: { quote_id: quote.id, lead_id: lead.id },
-      eventType: ML_P1_S1_EVENT_TYPES.DRAFT_CREATED,
-    });
-    const audit = await emitAudit(auditRow);
-
-    incrementKpi('draft_created');
-    endKpiTimer('create_draft_quote');
-
-    return {
-      quote,
-      items,
-      idempotent: false,
-      correlationId: corr,
-      audit,
-    };
   }
 
   /**
@@ -212,13 +237,18 @@ export function createMlP1S1QuoteDraftService(deps) {
    */
   async function updateDraftQuote({
     quoteId,
-    tenantId,
+    sessionTenantId = null,
+    urlTenantId = null,
+    tenantId: _ignoredCallerTenant = null,
     patch = {},
     lineItems = null,
     actorId = null,
     actorRole = 'office',
     correlationId = null,
   }) {
+    void _ignoredCallerTenant;
+    const tenantId = resolveWriteTenantId({ sessionTenantId, urlTenantId });
+
     const { data: existing, error: loadError } = await supabase
       .from('quotes')
       .select('*')
@@ -231,6 +261,7 @@ export function createMlP1S1QuoteDraftService(deps) {
       err.code = 'ML_P1_S1_QUOTE_NOT_FOUND';
       throw err;
     }
+    assertTenantMatch(existing.tenant_id, tenantId);
     if (String(existing.status || '').toLowerCase() !== DRAFT_STATUS) {
       const err = new Error('DENY: Slice 1 may only update draft quotes');
       err.code = 'ML_P1_S1_NOT_DRAFT';
@@ -244,6 +275,7 @@ export function createMlP1S1QuoteDraftService(deps) {
     };
     delete next.id;
     delete next.tenant_id;
+    delete next.lead_id; // never allow lead nulling / reassignment via S1 update
 
     const { data: quote, error: updError } = await supabase
       .from('quotes')
@@ -301,19 +333,29 @@ export function createMlP1S1QuoteDraftService(deps) {
     return { quote, items, correlationId: corr };
   }
 
-  async function findDuplicateCustomers({ tenantId, input, limit = 8 }) {
+  async function findDuplicateCustomers({
+    sessionTenantId = null,
+    urlTenantId = null,
+    tenantId: _ignored = null,
+    input,
+    limit = 8,
+  }) {
+    void _ignored;
+    const tenantId = resolveWriteTenantId({ sessionTenantId, urlTenantId });
     const built = buildDuplicateCustomerFilters(input);
     if (!built.ok) return { ok: false, reason: built.reason, matches: [] };
     const { data, error } = await supabase
       .from('leads')
-      .select('id, tenant_id, first_name, last_name, company, phone, email, address, property_formatted_address')
+      .select(
+        'id, tenant_id, first_name, last_name, company, phone, email, address, property_formatted_address',
+      )
       .eq('tenant_id', tenantId)
       .or(built.filters.join(','))
       .limit(limit);
     if (error) throw error;
     const matches = sortDuplicateCandidates(input, data || []);
     if (matches.length) incrementKpi('duplicate_customer_hit');
-    return { ok: true, matches };
+    return { ok: true, matches, tenantId };
   }
 
   return {

--- a/command-center/src/services/mlP1S1QuoteDraftService.js
+++ b/command-center/src/services/mlP1S1QuoteDraftService.js
@@ -1,0 +1,334 @@
+/**
+ * ML-P1 Slice 1 — Canonical draft quote service (`quotes` + `quote_items` only).
+ * Status forced to `draft`. Idempotent create via client_request_id in correlation.
+ * No migrations. No issue/approve/job/invoice.
+ */
+
+import { assertEstimatesCreateAllowed } from '../lib/mlP1S1EstimatesDeny.js';
+import {
+  assertStableCustomerLink,
+  resolveP1ServiceAddress,
+} from '../lib/mlP1S1Identity.js';
+import {
+  buildMoneyStateAuditEvent,
+  ML_P1_S1_EVENT_TYPES,
+} from '../lib/mlP1S1AuditEvents.js';
+import { assertTenantMatch, resolveWriteTenantId } from '../lib/mlP1S1Tenant.js';
+import { endKpiTimer, incrementKpi, startKpiTimer } from '../lib/mlP1S1Kpi.js';
+
+const DRAFT_STATUS = 'draft';
+
+function newCorrelationId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
+  return `s1-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * @param {object} deps
+ * @param {import('@supabase/supabase-js').SupabaseClient} deps.supabase
+ */
+export function createMlP1S1QuoteDraftService(deps) {
+  const supabase = deps.supabase;
+  if (!supabase) throw new Error('mlP1S1QuoteDraftService requires supabase');
+
+  async function emitAudit(row) {
+    try {
+      const { error } = await supabase.from('events').insert(row);
+      if (error) {
+        incrementKpi('audit_emit_fail');
+        return { ok: false, error };
+      }
+      incrementKpi('audit_emit_ok');
+      return { ok: true };
+    } catch (error) {
+      incrementKpi('audit_emit_fail');
+      return { ok: false, error };
+    }
+  }
+
+  /**
+   * Find existing draft by idempotency key stored in notes prefix or customer_notes.
+   * Uses correlation marker `s1-idem:` in notes field when present.
+   */
+  async function findDraftByIdempotency({ tenantId, leadId, idempotencyKey }) {
+    if (!idempotencyKey) return null;
+    const marker = `s1-idem:${idempotencyKey}`;
+    const { data, error } = await supabase
+      .from('quotes')
+      .select('id, status, lead_id, tenant_id, notes, service_address, total, created_at')
+      .eq('tenant_id', tenantId)
+      .eq('lead_id', leadId)
+      .eq('status', DRAFT_STATUS)
+      .ilike('notes', `%${marker}%`)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) throw error;
+    return data || null;
+  }
+
+  /**
+   * Create or return existing draft quote (idempotent).
+   */
+  async function createDraftQuote({
+    lead,
+    form = null,
+    lineItems = [],
+    sessionTenantId = null,
+    urlTenantId = null,
+    defaultTenantId = null,
+    actorId = null,
+    actorRole = 'office',
+    idempotencyKey = null,
+    correlationId = null,
+  }) {
+    startKpiTimer('create_draft_quote');
+    // This service never writes `estimates` (KI-01). Call sites that still
+    // attempt estimates.create must use assertEstimatesCreateAllowed separately.
+    void assertEstimatesCreateAllowed;
+
+    const tenantId = resolveWriteTenantId({
+      sessionTenantId,
+      urlTenantId,
+      defaultTenantId,
+    });
+
+    if (!lead?.id) {
+      const err = new Error('DENY: lead required for draft quote');
+      err.code = 'ML_P1_S1_MISSING_LEAD';
+      throw err;
+    }
+    assertTenantMatch(lead.tenant_id, tenantId);
+
+    const serviceAddress = resolveP1ServiceAddress({ lead, form });
+    if (!serviceAddress) {
+      const err = new Error('DENY: service address required for draft quote');
+      err.code = 'ML_P1_S1_MISSING_ADDRESS';
+      throw err;
+    }
+
+    const corr = correlationId || newCorrelationId();
+    const idem = idempotencyKey || corr;
+
+    const existing = await findDraftByIdempotency({
+      tenantId,
+      leadId: lead.id,
+      idempotencyKey: idem,
+    });
+    if (existing) {
+      incrementKpi('draft_idempotent_hit');
+      endKpiTimer('create_draft_quote');
+      return {
+        quote: existing,
+        items: [],
+        idempotent: true,
+        correlationId: corr,
+        audit: { skipped: true, reason: 'idempotent_reuse' },
+      };
+    }
+
+    const marker = `s1-idem:${idem}`;
+    const subtotal = (lineItems || []).reduce(
+      (sum, item) => sum + Number(item.quantity || 1) * Number(item.unit_price || item.price || 0),
+      0,
+    );
+
+    const quotePayload = {
+      lead_id: lead.id,
+      tenant_id: tenantId,
+      status: DRAFT_STATUS,
+      service_address: serviceAddress,
+      customer_name:
+        [lead.first_name, lead.last_name].filter(Boolean).join(' ') || lead.company || null,
+      customer_email: lead.email || null,
+      customer_phone: lead.phone || null,
+      subtotal,
+      total: subtotal,
+      tax: 0,
+      notes: marker,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+    assertStableCustomerLink(quotePayload);
+
+    const { data: quote, error: quoteError } = await supabase
+      .from('quotes')
+      .insert([quotePayload])
+      .select('*')
+      .single();
+    if (quoteError) throw quoteError;
+
+    let items = [];
+    if (lineItems?.length) {
+      const rows = lineItems.map((item, index) => {
+        const qty = Number(item.quantity || 1);
+        const unit = Number(item.unit_price || item.price || 0);
+        return {
+          quote_id: quote.id,
+          description: item.description || item.name || `Item ${index + 1}`,
+          quantity: qty,
+          unit_price: unit,
+          total_price: qty * unit,
+        };
+      });
+      const { data: insertedItems, error: itemsError } = await supabase
+        .from('quote_items')
+        .insert(rows)
+        .select('*');
+      if (itemsError) {
+        // Best-effort compensation without migration: delete draft quote
+        await supabase.from('quotes').delete().eq('id', quote.id).eq('tenant_id', tenantId);
+        throw itemsError;
+      }
+      items = insertedItems || [];
+    }
+
+    const auditRow = buildMoneyStateAuditEvent({
+      tenantId,
+      recordId: quote.id,
+      recordType: 'quote',
+      actorId,
+      actorRole,
+      previousState: null,
+      newState: DRAFT_STATUS,
+      sourceAction: 'ml_p1_s1.create_draft_quote',
+      correlationId: corr,
+      success: true,
+      related: { quote_id: quote.id, lead_id: lead.id },
+      eventType: ML_P1_S1_EVENT_TYPES.DRAFT_CREATED,
+    });
+    const audit = await emitAudit(auditRow);
+
+    incrementKpi('draft_created');
+    endKpiTimer('create_draft_quote');
+
+    return {
+      quote,
+      items,
+      idempotent: false,
+      correlationId: corr,
+      audit,
+    };
+  }
+
+  /**
+   * Update draft only (status must remain draft). Rejects non-draft.
+   */
+  async function updateDraftQuote({
+    quoteId,
+    tenantId,
+    patch = {},
+    lineItems = null,
+    actorId = null,
+    actorRole = 'office',
+    correlationId = null,
+  }) {
+    const { data: existing, error: loadError } = await supabase
+      .from('quotes')
+      .select('*')
+      .eq('id', quoteId)
+      .eq('tenant_id', tenantId)
+      .maybeSingle();
+    if (loadError) throw loadError;
+    if (!existing) {
+      const err = new Error('DENY: draft quote not found for tenant');
+      err.code = 'ML_P1_S1_QUOTE_NOT_FOUND';
+      throw err;
+    }
+    if (String(existing.status || '').toLowerCase() !== DRAFT_STATUS) {
+      const err = new Error('DENY: Slice 1 may only update draft quotes');
+      err.code = 'ML_P1_S1_NOT_DRAFT';
+      throw err;
+    }
+
+    const next = {
+      ...patch,
+      status: DRAFT_STATUS,
+      updated_at: new Date().toISOString(),
+    };
+    delete next.id;
+    delete next.tenant_id;
+
+    const { data: quote, error: updError } = await supabase
+      .from('quotes')
+      .update(next)
+      .eq('id', quoteId)
+      .eq('tenant_id', tenantId)
+      .eq('status', DRAFT_STATUS)
+      .select('*')
+      .single();
+    if (updError) throw updError;
+
+    let items = null;
+    if (Array.isArray(lineItems)) {
+      await supabase.from('quote_items').delete().eq('quote_id', quoteId);
+      if (lineItems.length) {
+        const rows = lineItems.map((item, index) => {
+          const qty = Number(item.quantity || 1);
+          const unit = Number(item.unit_price || item.price || 0);
+          return {
+            quote_id: quoteId,
+            description: item.description || item.name || `Item ${index + 1}`,
+            quantity: qty,
+            unit_price: unit,
+            total_price: qty * unit,
+          };
+        });
+        const { data: inserted, error: itemsError } = await supabase
+          .from('quote_items')
+          .insert(rows)
+          .select('*');
+        if (itemsError) throw itemsError;
+        items = inserted;
+      } else {
+        items = [];
+      }
+    }
+
+    const corr = correlationId || newCorrelationId();
+    const auditRow = buildMoneyStateAuditEvent({
+      tenantId,
+      recordId: quoteId,
+      recordType: 'quote',
+      actorId,
+      actorRole,
+      previousState: DRAFT_STATUS,
+      newState: DRAFT_STATUS,
+      sourceAction: 'ml_p1_s1.update_draft_quote',
+      correlationId: corr,
+      success: true,
+      related: { quote_id: quoteId, lead_id: quote.lead_id },
+      eventType: ML_P1_S1_EVENT_TYPES.DRAFT_UPDATED,
+    });
+    await emitAudit(auditRow);
+
+    return { quote, items, correlationId: corr };
+  }
+
+  async function findDuplicateCustomers({ tenantId, input, limit = 8 }) {
+    const { buildDuplicateCustomerFilters, sortDuplicateCandidates } = await import(
+      '@/lib/mlP1S1DuplicateCustomer.js'
+    );
+    const built = buildDuplicateCustomerFilters(input);
+    if (!built.ok) return { ok: false, reason: built.reason, matches: [] };
+    const { data, error } = await supabase
+      .from('leads')
+      .select('id, tenant_id, first_name, last_name, company, phone, email, address, property_formatted_address')
+      .eq('tenant_id', tenantId)
+      .or(built.filters.join(','))
+      .limit(limit);
+    if (error) throw error;
+    const matches = sortDuplicateCandidates(input, data || []);
+    if (matches.length) incrementKpi('duplicate_customer_hit');
+    return { ok: true, matches };
+  }
+
+  return {
+    createDraftQuote,
+    updateDraftQuote,
+    findDuplicateCustomers,
+    findDraftByIdempotency,
+  };
+}
+
+export { DRAFT_STATUS as ML_P1_S1_DRAFT_STATUS };

--- a/command-center/src/services/mlP1S1QuoteDraftService.js
+++ b/command-center/src/services/mlP1S1QuoteDraftService.js
@@ -4,7 +4,6 @@
  * No migrations. No issue/approve/job/invoice.
  */
 
-import { assertEstimatesCreateAllowed } from '../lib/mlP1S1EstimatesDeny.js';
 import {
   assertStableCustomerLink,
   resolveP1ServiceAddress,
@@ -83,9 +82,6 @@ export function createMlP1S1QuoteDraftService(deps) {
     correlationId = null,
   }) {
     startKpiTimer('create_draft_quote');
-    // This service never writes `estimates` (KI-01). Call sites that still
-    // attempt estimates.create must use assertEstimatesCreateAllowed separately.
-    void assertEstimatesCreateAllowed;
 
     const tenantId = resolveWriteTenantId({
       sessionTenantId,
@@ -306,9 +302,6 @@ export function createMlP1S1QuoteDraftService(deps) {
   }
 
   async function findDuplicateCustomers({ tenantId, input, limit = 8 }) {
-    const { buildDuplicateCustomerFilters, sortDuplicateCandidates } = await import(
-      '@/lib/mlP1S1DuplicateCustomer.js'
-    );
     const built = buildDuplicateCustomerFilters(input);
     if (!built.ok) return { ok: false, reason: built.reason, matches: [] };
     const { data, error } = await supabase

--- a/command-center/tests/unit/ml-p1-s1-foundation.test.mjs
+++ b/command-center/tests/unit/ml-p1-s1-foundation.test.mjs
@@ -1,0 +1,220 @@
+/**
+ * ML-P1 Slice 1 foundation unit tests.
+ * Run: node --test tests/unit/ml-p1-s1-foundation.test.mjs
+ */
+import assert from 'node:assert/strict';
+import { describe, it, beforeEach } from 'node:test';
+import {
+  ESTIMATES_CREATE_DENY_CODE,
+  assertEstimatesCreateAllowed,
+  denyEstimatesCreate,
+  isEstimatesCreateDeniedError,
+} from '../../src/lib/mlP1S1EstimatesDeny.js';
+import {
+  buildDuplicateCustomerFilters,
+  normalizePhoneDigits,
+  scoreDuplicateCandidate,
+  sortDuplicateCandidates,
+} from '../../src/lib/mlP1S1DuplicateCustomer.js';
+import {
+  assertStableCustomerLink,
+  documentUuidBigintPolicy,
+  resolveP1ServiceAddress,
+} from '../../src/lib/mlP1S1Identity.js';
+import {
+  assertAuditPayloadComplete,
+  buildMoneyStateAuditEvent,
+  ML_P1_S1_EVENT_TYPES,
+} from '../../src/lib/mlP1S1AuditEvents.js';
+import {
+  assertTenantMatch,
+  isTenantDenyError,
+  resolveWriteTenantId,
+  TENANT_DENY_CODE,
+} from '../../src/lib/mlP1S1Tenant.js';
+import {
+  endKpiTimer,
+  getKpiSnapshot,
+  incrementKpi,
+  resetMlP1S1KpiStore,
+  startKpiTimer,
+} from '../../src/lib/mlP1S1Kpi.js';
+import { createMlP1S1QuoteDraftService } from '../../src/services/mlP1S1QuoteDraftService.js';
+
+describe('ML-P1 S1 estimates DENY', () => {
+  it('denies estimates create with stable code', () => {
+    const d = denyEstimatesCreate();
+    assert.equal(d.ok, false);
+    assert.equal(d.code, ESTIMATES_CREATE_DENY_CODE);
+    assert.match(d.message, /canonical quotes/i);
+  });
+
+  it('throws assertEstimatesCreateAllowed', () => {
+    assert.throws(() => assertEstimatesCreateAllowed(), (err) => {
+      assert.equal(isEstimatesCreateDeniedError(err), true);
+      return true;
+    });
+  });
+});
+
+describe('ML-P1 S1 duplicate customer', () => {
+  it('normalizes phone to last 10 digits', () => {
+    assert.equal(normalizePhoneDigits('(321) 555-1212'), '3215551212');
+  });
+
+  it('requires a strong signal', () => {
+    const weak = buildDuplicateCustomerFilters({ last_name: 'Smith' });
+    assert.equal(weak.ok, false);
+  });
+
+  it('builds filters for phone and ranks phone matches highest', () => {
+    const built = buildDuplicateCustomerFilters({
+      phone: '3215551212',
+      last_name: 'Smith',
+    });
+    assert.equal(built.ok, true);
+    assert.ok(built.filters.some((f) => f.includes('phone')));
+    const ranked = sortDuplicateCandidates(
+      { phone: '3215551212' },
+      [
+        { id: 'a', phone: '999' },
+        { id: 'b', phone: '3215551212' },
+      ],
+    );
+    assert.equal(ranked[0].id, 'b');
+    assert.ok(scoreDuplicateCandidate({ phone: '3215551212' }, { phone: '3215551212' }) >= 100);
+  });
+});
+
+describe('ML-P1 S1 identity / address', () => {
+  it('resolves service address from address_line_1 alias', () => {
+    const addr = resolveP1ServiceAddress({
+      form: { address_line_1: '12 Main', city: 'Titusville', state: 'FL', zip: '32780' },
+    });
+    assert.match(addr, /12 Main/);
+  });
+
+  it('requires lead_id for stable link', () => {
+    assert.throws(() => assertStableCustomerLink({}), (err) => err.code === 'ML_P1_S1_MISSING_LEAD_ID');
+  });
+
+  it('documents UUID/bigint deferral policy', () => {
+    const p = documentUuidBigintPolicy();
+    assert.match(p.status, /DEFER/);
+  });
+});
+
+describe('ML-P1 S1 tenant', () => {
+  it('prefers session tenant and denies mismatch', () => {
+    assert.equal(resolveWriteTenantId({ sessionTenantId: 'tvg' }), 'tvg');
+    assert.throws(
+      () => resolveWriteTenantId({ sessionTenantId: 'tvg', urlTenantId: 'other' }),
+      (err) => err.code === TENANT_DENY_CODE,
+    );
+  });
+
+  it('blocks cross-tenant row access', () => {
+    assert.throws(() => assertTenantMatch('a', 'b'), (err) => isTenantDenyError(err));
+  });
+});
+
+describe('ML-P1 S1 audit', () => {
+  it('builds complete payload fields', () => {
+    const row = buildMoneyStateAuditEvent({
+      tenantId: 'tvg',
+      recordId: 'q1',
+      actorRole: 'office',
+      sourceAction: 'test',
+      correlationId: 'c1',
+      eventType: ML_P1_S1_EVENT_TYPES.DRAFT_CREATED,
+      related: { lead_id: 'l1' },
+    });
+    assert.equal(row.event_type, ML_P1_S1_EVENT_TYPES.DRAFT_CREATED);
+    const check = assertAuditPayloadComplete(row.payload);
+    assert.equal(check.ok, true);
+  });
+});
+
+describe('ML-P1 S1 KPI', () => {
+  beforeEach(() => resetMlP1S1KpiStore());
+
+  it('records timers and counters', () => {
+    startKpiTimer('create_draft_quote');
+    incrementKpi('draft_created');
+    const ms = endKpiTimer('create_draft_quote');
+    assert.equal(typeof ms, 'number');
+    const snap = getKpiSnapshot();
+    assert.equal(snap.counters.draft_created, 1);
+  });
+});
+
+describe('ML-P1 S1 draft service idempotency + tenant', () => {
+  it('reuses draft on matching idempotency key without second insert', async () => {
+    const inserts = [];
+    const fakeExisting = {
+      id: 'quote-1',
+      status: 'draft',
+      lead_id: 'lead-1',
+      tenant_id: 'tvg',
+      notes: 's1-idem:abc',
+    };
+    const supabase = {
+      from(table) {
+        return {
+          select() {
+            return this;
+          },
+          eq() {
+            return this;
+          },
+          ilike() {
+            return this;
+          },
+          order() {
+            return this;
+          },
+          limit() {
+            return this;
+          },
+          maybeSingle: async () => {
+            if (table === 'quotes') return { data: fakeExisting, error: null };
+            return { data: null, error: null };
+          },
+          insert(rows) {
+            inserts.push({ table, rows });
+            return {
+              select() {
+                return {
+                  single: async () => ({ data: rows[0], error: null }),
+                };
+              },
+            };
+          },
+        };
+      },
+    };
+
+    const svc = createMlP1S1QuoteDraftService({ supabase });
+    const result = await svc.createDraftQuote({
+      lead: { id: 'lead-1', tenant_id: 'tvg', address: '1 Main St' },
+      urlTenantId: 'tvg',
+      idempotencyKey: 'abc',
+    });
+    assert.equal(result.idempotent, true);
+    assert.equal(result.quote.id, 'quote-1');
+    assert.equal(inserts.length, 0);
+  });
+
+  it('denies missing tenant', async () => {
+    const svc = createMlP1S1QuoteDraftService({
+      supabase: { from: () => ({}) },
+    });
+    await assert.rejects(
+      () =>
+        svc.createDraftQuote({
+          lead: { id: 'lead-1', address: '1 Main' },
+        }),
+      (err) => err.code === TENANT_DENY_CODE,
+    );
+  });
+});

--- a/command-center/tests/unit/ml-p1-s1-foundation.test.mjs
+++ b/command-center/tests/unit/ml-p1-s1-foundation.test.mjs
@@ -105,24 +105,38 @@ describe('ML-P1 S1 identity / address', () => {
 });
 
 describe('ML-P1 S1 tenant', () => {
-  it('prefers session tenant and denies mismatch', () => {
+  it('requires session tenant and denies URL-only / default fallback', () => {
     assert.equal(resolveWriteTenantId({ sessionTenantId: 'tvg' }), 'tvg');
+    assert.equal(
+      resolveWriteTenantId({ sessionTenantId: 'tvg', urlTenantId: 'tvg' }),
+      'tvg',
+    );
     assert.throws(
       () => resolveWriteTenantId({ sessionTenantId: 'tvg', urlTenantId: 'other' }),
       (err) => err.code === TENANT_DENY_CODE,
     );
+    assert.throws(
+      () => resolveWriteTenantId({ urlTenantId: 'tvg' }),
+      (err) => err.code === TENANT_DENY_CODE,
+    );
+    assert.throws(
+      () => resolveWriteTenantId({ defaultTenantId: 'tvg' }),
+      (err) => err.code === TENANT_DENY_CODE,
+    );
   });
 
-  it('blocks cross-tenant row access', () => {
+  it('blocks cross-tenant and null-tenant row access', () => {
     assert.throws(() => assertTenantMatch('a', 'b'), (err) => isTenantDenyError(err));
+    assert.throws(() => assertTenantMatch(null, 'tvg'), (err) => isTenantDenyError(err));
   });
 });
 
 describe('ML-P1 S1 audit', () => {
-  it('builds complete payload fields', () => {
+  it('builds complete payload fields including event_id', () => {
     const row = buildMoneyStateAuditEvent({
       tenantId: 'tvg',
       recordId: 'q1',
+      actorId: 'user-1',
       actorRole: 'office',
       sourceAction: 'test',
       correlationId: 'c1',
@@ -130,8 +144,10 @@ describe('ML-P1 S1 audit', () => {
       related: { lead_id: 'l1' },
     });
     assert.equal(row.event_type, ML_P1_S1_EVENT_TYPES.DRAFT_CREATED);
+    assert.ok(row.payload.event_id);
+    assert.ok(row.payload.timestamp);
     const check = assertAuditPayloadComplete(row.payload);
-    assert.equal(check.ok, true);
+    assert.equal(check.ok, true, `missing: ${check.missing?.join(',')}`);
   });
 });
 
@@ -148,7 +164,7 @@ describe('ML-P1 S1 KPI', () => {
   });
 });
 
-describe('ML-P1 S1 draft service idempotency + tenant', () => {
+describe('ML-P1 S1 draft service idempotency + tenant + dup', () => {
   it('reuses draft on matching idempotency key without second insert', async () => {
     const inserts = [];
     const fakeExisting = {
@@ -197,6 +213,7 @@ describe('ML-P1 S1 draft service idempotency + tenant', () => {
     const svc = createMlP1S1QuoteDraftService({ supabase });
     const result = await svc.createDraftQuote({
       lead: { id: 'lead-1', tenant_id: 'tvg', address: '1 Main St' },
+      sessionTenantId: 'tvg',
       urlTenantId: 'tvg',
       idempotencyKey: 'abc',
     });
@@ -205,16 +222,72 @@ describe('ML-P1 S1 draft service idempotency + tenant', () => {
     assert.equal(inserts.length, 0);
   });
 
-  it('denies missing tenant', async () => {
+  it('denies missing session tenant', async () => {
     const svc = createMlP1S1QuoteDraftService({
       supabase: { from: () => ({}) },
     });
     await assert.rejects(
       () =>
         svc.createDraftQuote({
-          lead: { id: 'lead-1', address: '1 Main' },
+          lead: { id: 'lead-1', tenant_id: 'tvg', address: '1 Main' },
+          urlTenantId: 'tvg',
         }),
       (err) => err.code === TENANT_DENY_CODE,
     );
+  });
+
+  it('findDuplicateCustomers uses imported helpers (no ReferenceError)', async () => {
+    const supabase = {
+      from() {
+        return {
+          select() {
+            return this;
+          },
+          eq() {
+            return this;
+          },
+          or() {
+            return this;
+          },
+          limit() {
+            return this;
+          },
+          then(resolve) {
+            return Promise.resolve({
+              data: [{ id: 'lead-2', phone: '3215551212', tenant_id: 'tvg' }],
+              error: null,
+            }).then(resolve);
+          },
+        };
+      },
+    };
+    // Make awaitable query builder
+    const qb = {
+      select() {
+        return this;
+      },
+      eq() {
+        return this;
+      },
+      or() {
+        return this;
+      },
+      limit() {
+        return Promise.resolve({
+          data: [{ id: 'lead-2', phone: '3215551212', tenant_id: 'tvg' }],
+          error: null,
+        });
+      },
+    };
+    const svc = createMlP1S1QuoteDraftService({
+      supabase: { from: () => qb },
+    });
+    const result = await svc.findDuplicateCustomers({
+      sessionTenantId: 'tvg',
+      urlTenantId: 'tvg',
+      input: { phone: '3215551212' },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.matches[0].id, 'lead-2');
   });
 });


### PR DESCRIPTION
## Summary
- ML-P1 Slice 1: customer find/create, service address, canonical draft quotes only
- Legacy estimates create DENY; tenant deny-by-default; audit + KPI instrumentation
- Mobile-first draft page at estimates/new and estimates/p1-draft
- Unit tests: npm run test:ml-p1-s1-helpers (14 pass)
- Base SHA: 2867d2891994f1ec9734c7e2be3e84b216cb144f
- No migrations; no issue/approve/job/invoice/live pay/send-estimate/deploy

## Test plan
- [ ] npm run test:ml-p1-s1-helpers
- [ ] Manual: /crm/estimates/p1-draft find/create customer + save draft
- [ ] Confirm EstimateEditorModal cannot create estimates (DENY)
- [ ] Confirm no Slice 2-6 scope in diff

## Merge
Requires later Founder authorization at exact reviewed head SHA. Do not merge without it.