### PR TITLE
fix(ml-p1): R-S1-01 additive estimates INSERT DENY

### DIFF
--- a/command-center/docs/stabilization/releases/ML-P1_RS101_ESTIMATES_INSERT_DENY.md
+++ b/command-center/docs/stabilization/releases/ML-P1_RS101_ESTIMATES_INSERT_DENY.md
@@ -1,0 +1,53 @@
+# ML-P1 R-S1-01 — `estimates` INSERT DENY (server)
+
+> **Migration artifact only.** Does **not** authorize production apply, deploy,
+> Slice 2 coding, Stripe, autonomous follow-up, TIS, or G2.3 reopen.
+>
+> Base `origin/main`: `aaf8a766e1b5be758648dd6497922b0fc77399e9`  
+> Residual authority: `ML-P1_SLICE1_CLOSEOUT_AND_RESIDUAL_DISPOSITION.md`
+
+---
+
+## 1. Intent
+
+| Field | Value |
+| --- | --- |
+| Residual | **R-S1-01** |
+| Table | `public.estimates` |
+| Action | Deny **INSERT** for application roles (`authenticated`, `anon`) |
+| Why | Canonical money path: prevent deprecated `estimates` writes; enforce `quotes`; prevent alternate money writer |
+| Not | Tenant isolation / cross-tenant G-03 |
+
+---
+
+## 2. Migration
+
+| Field | Value |
+| --- | --- |
+| File | `command-center/supabase/migrations/20260721120000_ml_p1_rs101_deny_estimates_insert.sql` |
+| Style | Additive RESTRICTIVE RLS `WITH CHECK (false)` on INSERT |
+| Destructive ops | None (no table/column/data mutation) |
+| Out of scope | SELECT/UPDATE/DELETE policy changes; Slice 2 app; Stripe; follow-up |
+
+---
+
+## 3. Review and merge gates
+
+| Gate | Status |
+| --- | --- |
+| Security Guard review | **Required** before Founder merge authorization |
+| Architecture Guard review | **Required** before Founder merge authorization |
+| Founder merge at exact frozen head | Required after both reviews clear |
+| Production apply / deploy | **Not authorized** by this PR alone |
+| Slice 2 coding | **Not authorized** |
+
+---
+
+## 4. Rollback (if ever applied)
+
+Drop the two named policies:
+
+- `ml_p1_rs101_deny_estimates_insert_authenticated`
+- `ml_p1_rs101_deny_estimates_insert_anon`
+
+Do not use rollback without separate Founder authorization.

--- a/command-center/supabase/migrations/20260721120000_ml_p1_rs101_deny_estimates_insert.sql
+++ b/command-center/supabase/migrations/20260721120000_ml_p1_rs101_deny_estimates_insert.sql
@@ -1,0 +1,48 @@
+-- ML-P1 residual R-S1-01
+-- Deny new public.estimates INSERT writes for application roles.
+--
+-- Authority: Founder authorization to implement additive R-S1-01 migration only.
+-- Base: aaf8a766e1b5be758648dd6497922b0fc77399e9
+--
+-- Purpose (canonical money path only — not tenant isolation):
+--   1) Prevent deprecated estimates create writes
+--   2) Enforce canonical quotes path
+--   3) Prevent an alternate money writer
+--
+-- Additive / non-destructive:
+--   - No DROP TABLE / DROP COLUMN / DELETE / UPDATE of rows
+--   - No FORCE ROW LEVEL SECURITY
+--   - Does not alter SELECT / UPDATE / DELETE policies
+--   - Does not touch quotes, Stripe, follow-up, Slice 2 app code, TIS, or G2.3
+--
+-- Mechanism:
+--   RESTRICTIVE INSERT policies WITH CHECK (false) for authenticated and anon.
+--   Restrictive policies are AND-combined with any permissive policies, so an
+--   existing permissive INSERT/ALL policy cannot override this DENY.
+--
+-- Apply-to-production / deploy is NOT authorized by landing this file on main.
+
+BEGIN;
+
+ALTER TABLE public.estimates ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "ml_p1_rs101_deny_estimates_insert_authenticated"
+  ON public.estimates;
+DROP POLICY IF EXISTS "ml_p1_rs101_deny_estimates_insert_anon"
+  ON public.estimates;
+
+CREATE POLICY "ml_p1_rs101_deny_estimates_insert_authenticated"
+  ON public.estimates
+  AS RESTRICTIVE
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (false);
+
+CREATE POLICY "ml_p1_rs101_deny_estimates_insert_anon"
+  ON public.estimates
+  AS RESTRICTIVE
+  FOR INSERT
+  TO anon
+  WITH CHECK (false);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Additive R-S1-01 migration: RESTRICTIVE RLS `WITH CHECK (false)` denies `INSERT` on `public.estimates` for `authenticated` and `anon`.
- Enforces canonical `quotes` money path and prevents an alternate money writer (not tenant isolation).
- Evidence/authority note: `ML-P1_RS101_ESTIMATES_INSERT_DENY.md`.

## Base
`aaf8a766e1b5be758648dd6497922b0fc77399e9` (PR #68 merge / current main at kickoff).

## Explicit non-authorization
- No production apply / deploy
- No Slice 2 coding
- No Stripe, follow-up, TIS, or G2.3 reopen
- No destructive schema/data changes

## Required before Founder merge authorization
1. **Security Guard** review at exact frozen head
2. **Architecture Guard** review at exact frozen head
3. Separate Founder merge line at that exact SHA

## Test plan
- [ ] Security Guard: INSERT DENY for app roles; service_role/admin path not silently broken; no privilege escalation
- [ ] Architecture Guard: scope = R-S1-01 only; RESTRICTIVE additive pattern; no Slice 2 / Stripe / follow-up drift
- [ ] CI green on PR
- [ ] Confirm diff is migration + authority note only

Made with [Cursor](https://cursor.com)