### PR TITLE
docs(governance): Founder Delegated Authority Policy

### DIFF
--- a/command-center/.cursor/rules/v1-operating-model.mdc
+++ b/command-center/.cursor/rules/v1-operating-model.mdc
@@ -21,9 +21,15 @@ of returning it to the founder. Full definitions live in (do not duplicate them)
 - Incidents + production readiness: `docs/governance/INCIDENT_AND_PRODUCTION_READINESS.md`
 - Effectiveness signals: `docs/governance/AGENT_PILOT_SCORECARD.md`
 - Founder run gate: `docs/governance/FOUNDER_RUN_READINESS.md`
+- Delegated authority (Categories A/B/C): `docs/governance/FOUNDER_DELEGATED_AUTHORITY_POLICY.md`
 - Environment acceptance: `docs/governance/ENVIRONMENT_ACCEPTANCE.md`
 - Control-plane correction lane: `docs/governance/LOW_RISK_CONTROL_PLANE_CORRECTION.md`
 - Templates: `docs/governance/templates/` (Release Baton, Decision Packet, Release Ledger, Agent Status Report)
+
+Do **not** interrupt the Founder for Category A/B work (read-only metadata,
+planning drafts, review dispatch, safe preparation). Ask only for Category C
+(merge, migration apply, deploy, new slice, financial/security/customer mutation,
+material risk, product decisions). Never bypass missing capabilities with unsafe tools.
 
 Merge remains human-authorized by default. Delegated Release Agent merge is
 allowed only under an activated `LOW-RISK_CONTROL_PLANE_CORRECTION` lane when

--- a/command-center/docs/governance/APPROVAL_THRESHOLDS.md
+++ b/command-center/docs/governance/APPROVAL_THRESHOLDS.md
@@ -17,17 +17,22 @@ The system may proceed without human interruption for:
 - local proof runs
 - artifact generation
 - structured failure packet generation
-- documentation drafts (non-canonical)
+- documentation drafts (including Decision Packets and governance drafts)
 - local test reruns
 - patch iteration within retry/cost limits
-- review synthesis for non-release decisions
+- review synthesis and review dispatch
+- Category A / B work in
+  [`FOUNDER_DELEGATED_AUTHORITY_POLICY.md`](./FOUNDER_DELEGATED_AUTHORITY_POLICY.md)
+  (repository evidence, approved read-only metadata checks, planning, safe
+  preparation, proceed-and-notify actions)
 
 ## Human approval required
 A human decider is required for:
 - production deployment in trigger domains
 - accepted risk
 - override usage
-- doctrine changes
+- doctrine changes (adoption of new standing-authority policy onto `main` counts
+  as a governance merge — Founder merge authorization still required)
 - break-glass operations
 - irreversible data mutation
 - any claim of `P0-02: PRODUCTION-VALIDATED`
@@ -35,9 +40,14 @@ A human decider is required for:
   `LOW-RISK_CONTROL_PLANE_CORRECTION` merge that meets every eligibility gate in
   `LOW_RISK_CONTROL_PLANE_CORRECTION.md` (Founder exact PR/SHA merge remains
   mandatory outside that lane, and for activating the lane itself)
+- Category C actions in
+  [`FOUNDER_DELEGATED_AUTHORITY_POLICY.md`](./FOUNDER_DELEGATED_AUTHORITY_POLICY.md)
+  (migration apply, production mutation, new implementation slice, financial /
+  security / customer-facing changes, etc.)
 - Founder terminal / OAuth / credential / dashboard / protected-launcher actions
   until `FOUNDER_RUN_READINESS` returns `FOUNDER_RUN_READY`
-  (`FOUNDER_RUN_READINESS.md`)
+  (`FOUNDER_RUN_READINESS.md`) — and such asks must not be used for Category A
+  metadata work the Orchestrator should perform on an approved path
 
 ## Delegated merge (narrow exception)
 Release Agent may omit Founder merge authorization **only** when

--- a/command-center/docs/governance/FOUNDER_DELEGATED_AUTHORITY_POLICY.md
+++ b/command-center/docs/governance/FOUNDER_DELEGATED_AUTHORITY_POLICY.md
@@ -1,0 +1,201 @@
+# Founder Delegated Authority Policy
+
+> Governance / control-plane only. Grants no production credentials and does not
+> authorize merge, migration apply, deploy, Slice 2, Stripe, TIS, or G2.3 reopen.
+>
+> Parent: [`OPERATING_MODEL_v2.2.md`](./OPERATING_MODEL_v2.2.md)  
+> Aligns with: [`APPROVAL_THRESHOLDS.md`](./APPROVAL_THRESHOLDS.md),
+> [`PRODUCTION_ACCESS_MATRIX.md`](./PRODUCTION_ACCESS_MATRIX.md),
+> [`FOUNDER_RUN_READINESS.md`](./FOUNDER_RUN_READINESS.md)
+
+**Purpose:** Protect Founder Focus. Stop interrupting the Founder for low-risk,
+non-intrusive, read-only, reversible work. The Orchestrator acts under **standing
+authority** for bounded Category A work and **proceed-and-notify** for Category B.
+Category C still requires explicit Founder authorization.
+
+---
+
+## Decision test
+
+Ask for Founder authorization **only** when one or more are true:
+
+1. Production state changes.  
+2. Customer-visible behavior changes.  
+3. Financial state changes.  
+4. Secrets are exposed, changed, or newly accessed beyond approved diagnostic use.  
+5. The action is destructive or difficult to reverse.  
+6. A new implementation scope begins.  
+7. Material unresolved risk is accepted.  
+8. A product or business decision is required.
+
+If **none** apply → proceed under standing authority (A) or proceed-and-notify (B).
+
+**Do not** turn every routine action into a Founder approval gate.  
+**Do not** confuse notification with authorization.
+
+---
+
+## Category A — Standing authority (no Founder approval)
+
+The Orchestrator may perform and coordinate these without prior Founder authorization:
+
+### Repository and evidence
+
+- Inspect repository files, code, schemas, migrations, tests, logs, and documentation  
+- Search Git history, PRs, issues, commits, and branches  
+- Verify SHA, checksum, ancestry, worktree, and PR-head state  
+- Compare reviewed and current heads  
+- Inspect existing migrations and migration history (repo + approved hosted metadata paths)  
+- Identify duplicate, obsolete, or alternate code paths  
+- Inspect configuration and dependency versions  
+- Maintain evidence indexes and status records  
+
+### Read-only verification
+
+- Run lint, build, type checks, tests, contract checks, and static analysis  
+- Run local or disposable test environments  
+- Perform bounded read-only checks against **approved** production or hosted systems  
+- Inspect **database metadata**: tables, schemas, columns, indexes, functions, triggers, RLS flags, policies, grants, migration state  
+- Inspect application, infrastructure, API, Stripe, Supabase, DNS, certificate, tunnel, and deployment **metadata**  
+- Inspect logs and health information (no unnecessary customer content)  
+- Verify availability and configuration without mutation  
+
+Read-only access **must not** retrieve unnecessary customer row data, payment details, secrets, tokens, or message content.
+
+### Planning and governance
+
+- Draft and revise planning documents  
+- Prepare Decision Packets  
+- Maintain the Release Baton  
+- Map known issues to slices  
+- Classify evidence and residual risk  
+- Update review matrices  
+- Research official documentation and proven industry patterns  
+- Reconcile planning documents with established Founder decisions  
+
+### Review coordination
+
+- Dispatch required reviewers  
+- Freeze exact PR heads  
+- Reject stale reviews  
+- Reconcile reviewer findings  
+- Require remediation when CI or reviews fail  
+- Rerun reviews after remediation  
+- Return one consolidated Founder Decision Packet  
+
+### Safe preparation
+
+- Create isolated branches and worktrees from an authorized base  
+- Install dependencies locally  
+- Generate draft migrations **without applying** them  
+- Generate read-only SQL checks  
+- Prepare rollback scripts  
+- Create fixtures and tests  
+- Prepare commands and runbooks without executing consequential actions  
+- Push corrections to an existing PR when they remain within its already-authorized scope  
+- Open a **draft** PR for already-authorized work  
+
+---
+
+## Category B — Proceed and notify (no prior approval)
+
+The Orchestrator may proceed and then report:
+
+- Creation of an isolated worktree  
+- Rerunning CI or reviews  
+- Marking a review stale  
+- Updating a stale baton  
+- Pushing bounded remediation to an already-authorized branch  
+- Opening a draft PR within authorized scope  
+- Performing a bounded read-only production posture check (approved path only)  
+- Documenting a newly discovered issue  
+- Pausing work due to a failed test, stale SHA, or unmet gate  
+- Correcting non-substantive documentation errors  
+- Reassigning reviewers when a review capability fails  
+
+Notification is **not** authorization for Category C actions.
+
+---
+
+## Category C — Explicit Founder authorization required
+
+Require Founder authorization before:
+
+- Merging any PR into `main` (except activated `LOW-RISK_CONTROL_PLANE_CORRECTION` when every eligibility gate is true)  
+- Applying any migration  
+- Deploying or changing production  
+- Inserting, updating, or deleting production data  
+- Changing RLS, grants, roles, authentication, or security policies  
+- Accessing or rotating secrets beyond approved diagnostic use  
+- Sending customer communications  
+- Initiating, capturing, refunding, voiding, or changing payments  
+- Changing pricing, taxes, fees, discounts, or financial rules  
+- Beginning a new implementation slice  
+- Materially expanding authorized scope  
+- Accepting material residual risk  
+- Deleting branches, environments, records, or customer files  
+- Committing to vendors, subscriptions, or expenses  
+- Making product-boundary or business-policy decisions  
+- Enabling autonomous customer-facing behavior  
+- Exposing new public endpoints  
+- Changing DNS or domain routing  
+- Reopening TIS, G2.3, or another explicitly frozen area  
+
+---
+
+## Guardrails
+
+1. Standing authority does **not** permit bypassing an unavailable capability through an unsafe tool (e.g. banned `execute-sql`, service-role mutation, Dashboard write).  
+2. Read-only work must use **approved** read-only paths.  
+3. Do not retrieve customer row data when metadata is sufficient.  
+4. Do not display secrets, tokens, payment data, or unnecessary PII.  
+5. Stop and escalate when a supposedly read-only action could mutate state.  
+6. Record material read-only evidence in the applicable Decision Packet.  
+7. Do not turn routine Category A/B work into Founder approval gates.  
+8. Do not confuse Category B notification with Category C authorization.  
+9. `FOUNDER_RUN_READINESS` remains mandatory before asking the Founder to run terminals, OAuth consent, credential entry, dashboards, or protected launchers — and those asks should be rare under this policy.  
+
+---
+
+## Metadata vs row data (database)
+
+| Allowed under A (approved path) | Not allowed under A |
+| --- | --- |
+| `pg_class` / RLS flags, `pg_policy`, grants, indexes, columns, migration version lists | `SELECT` of customer/payment/message rows |
+| Policy names, commands, roles, USING/WITH CHECK expressions | Dumping table contents “to see if it works” |
+| Health / project status metadata via I2 allowlist | Invoking `execute-sql` Edge Function |
+
+If no approved metadata path exists → disposition **LIVE_CHECK_UNAVAILABLE** (or equivalent). Escalate for **capability provisioning** (Category C product/governance decision), not for “Founder please run this SQL for me” as the default.
+
+---
+
+## Audit and logging
+
+For Category A/B material actions that touch hosted systems or unblock Category C:
+
+- Record path used (adapter operation, dump id, local command) — never secret values  
+- Record time (UTC), exact repo SHA, and evidence class (`SOURCE-ONLY` / `HOSTED-METADATA` / `LIVE-METADATA`)  
+- Attach summary to the Decision Packet or Release Ledger note  
+- Category B: include a short notify line in the Orchestrator status report  
+
+---
+
+## Relationship to other documents
+
+| Document | Relationship |
+| --- | --- |
+| `OPERATING_MODEL_v2.2.md` | This policy elaborates Founder Focus §6–§7 and §12 without repealing merge/deploy controls |
+| `APPROVAL_THRESHOLDS.md` | Auto-continue expanded to match Categories A/B; human approval list remains Category C |
+| `PRODUCTION_ACCESS_MATRIX.md` | Orchestrator / Diagnostics **metadata** reads are standing (A) on approved paths; customer row reads remain S/P |
+| `FOUNDER_RUN_READINESS.md` | Still gates Founder manual actions; Orchestrator must not invent Founder manual work for Category A tasks |
+
+---
+
+## Version
+
+| Field | Value |
+| --- | --- |
+| Policy id | `FOUNDER_DELEGATED_AUTHORITY` |
+| Governance | v2.2 additive |
+| Draft base | `80acb8eb9bcff8771027f76c47257de657a2103e` |
+| Status | Proposed for Founder adoption via docs merge |

--- a/command-center/docs/governance/FOUNDER_RUN_READINESS.md
+++ b/command-center/docs/governance/FOUNDER_RUN_READINESS.md
@@ -37,6 +37,23 @@ Run FOUNDER_RUN_READINESS before asking the Founder to:
 - interact with production infrastructure
 - perform any environment-specific manual action
 
+## When **not** to ask the Founder (Delegated Authority)
+
+Per [`FOUNDER_DELEGATED_AUTHORITY_POLICY.md`](./FOUNDER_DELEGATED_AUTHORITY_POLICY.md),
+do **not** invent a Founder manual action for Category A/B work, including:
+
+- read-only repository / PR / SHA verification
+- lint, build, tests, local disposable environments
+- approved read-only hosted **metadata** checks (RLS, policies, grants, health)
+- drafting Decision Packets, baton updates, review dispatch
+- preparing (not applying) migrations or rollback scripts
+
+If an approved read-only path is **unavailable**, report
+`LIVE_CHECK_UNAVAILABLE` (or equivalent) and escalate for **capability
+provisioning** — do not default to “Founder, please run this SQL/dashboard step”
+for routine metadata. Standing authority never authorizes unsafe bypass tools
+(e.g. banned `execute-sql`).
+
 ## Required readiness fields
 
 | # | Field | Machine-checkable |

--- a/command-center/docs/governance/OPERATING_MODEL_v2.2.md
+++ b/command-center/docs/governance/OPERATING_MODEL_v2.2.md
@@ -51,6 +51,7 @@ role must **consolidate and simplify** (see §7, Founder Burden stop condition).
 | [`INCIDENT_AND_PRODUCTION_READINESS.md`](./INCIDENT_AND_PRODUCTION_READINESS.md) | P0–P3 incident model, Incident Commander, drift, readiness baseline, synthetic-data rules, fire-drill plan. |
 | [`AGENT_PILOT_SCORECARD.md`](./AGENT_PILOT_SCORECARD.md) | Lightweight, agent-maintained effectiveness scorecard. |
 | [`FOUNDER_RUN_READINESS.md`](./FOUNDER_RUN_READINESS.md) | Mandatory gate before Founder terminal/OAuth/credential/dashboard actions. |
+| [`FOUNDER_DELEGATED_AUTHORITY_POLICY.md`](./FOUNDER_DELEGATED_AUTHORITY_POLICY.md) | Categories A/B/C — when Orchestrator proceeds without Founder interruption vs Category C auth. |
 | [`ENVIRONMENT_ACCEPTANCE.md`](./ENVIRONMENT_ACCEPTANCE.md) | Platform-path acceptance when OS/browser/OAuth/path behavior matters. |
 | [`LOW_RISK_CONTROL_PLANE_CORRECTION.md`](./LOW_RISK_CONTROL_PLANE_CORRECTION.md) | Bounded lane for delegated merge of low-risk control-plane corrections. |
 | [`templates/RELEASE_BATON.template.yaml`](./templates/RELEASE_BATON.template.yaml) | Machine-readable release-state artifact (per active release). |
@@ -233,6 +234,13 @@ completed, and the Ledger entry is written by an agent.
 - **One unchanged release must not produce repeated approval requests.**
 - The founder is **never asked to repeat data** already available in the brief,
   the Baton, GitHub, CI, the Ledger, or verification evidence.
+- **Delegated authority:** Routine read-only, reversible, non-destructive work
+  proceeds under standing authority per
+  [`FOUNDER_DELEGATED_AUTHORITY_POLICY.md`](./FOUNDER_DELEGATED_AUTHORITY_POLICY.md)
+  (Categories A/B). Do **not** interrupt the Founder for metadata checks,
+  planning drafts, review dispatch, or other Category A/B work. Category C
+  (merge, migration apply, deploy, new slice, financial/security mutation, etc.)
+  still requires explicit Founder authorization.
 
 ### Founder interruption protocol
 

--- a/command-center/docs/governance/PRODUCTION_ACCESS_MATRIX.md
+++ b/command-center/docs/governance/PRODUCTION_ACCESS_MATRIX.md
@@ -66,7 +66,8 @@ Roles: **PO** = Production Operator · **PD** = Production Diagnostics ·
 | Deployment (approved SHA) | R | P | R | P | P | P | S | A |
 | Rollback (predefined) | R | P | R (containment) | P | P | P | S | A |
 | Migrations | S | P | S | P | P | P | S | S |
-| Database reads | S | S | S | P | P | P | P | A |
+| Database reads (customer / payment / message **rows**) | S | S | S | P | P | P | P | A |
+| Database **metadata** only (RLS flags, policies, grants, schema objects; no row data; approved path) | R | A | R | P | P | P | P | A |
 | Database writes | S | P | S | P | P | P | P | S |
 | Environment configuration | S | P | S | P | P | P | P | S |
 | Secrets (values) | P | P | P | P | P | P | P | S |
@@ -100,11 +101,14 @@ self-authorizes; never reads secret values.**
 ### Production Diagnostics (PD)
 **Read-only by default.** May read logs, deployment status, Supabase/Edge Function
 diagnostics, auth-failure signals, database and migration **state** (read),
+**schema/RLS/policy/grant metadata** on approved paths (no customer row data),
 environment fingerprints, deployed build identity, browser/network errors, and
-health checks. May **not** deploy, write data, run migrations, change
+health checks — including Orchestrator-coordinated Category A checks per
+[`FOUNDER_DELEGATED_AUTHORITY_POLICY.md`](./FOUNDER_DELEGATED_AUTHORITY_POLICY.md).
+May **not** deploy, write data, run migrations, change
 secrets/security controls, send customer communications, or perform financial
 actions. Any repair returns to Builder or Production Operator under a **new exact
-authorization**.
+authorization**. Customer/payment/message **row** reads remain **S**.
 
 ### Production Incident Commander (IC)
 Coordination authority during an **active declared incident** (P0/P1/qualifying


### PR DESCRIPTION
## Summary
- Adds `FOUNDER_DELEGATED_AUTHORITY_POLICY.md` (Categories A / B / C + decision test).
- Wires Operating Model, Approval Thresholds, Production Access Matrix, Founder Run Readiness, and v1 operating rule to stop Founder interrupts for routine read-only/metadata work.
- Distinguishes database **metadata** (standing on approved paths) from customer **row** reads (still S).

## Explicit non-authorization
Does not merge itself without Founder line. Does not apply migrations, deploy, or begin Slice 2.

## Test plan
- [ ] Founder reviews Categories A/B/C and decision test
- [ ] Confirm Category C still covers merge / apply / deploy / new slice
- [ ] Confirm unsafe bypass of missing SQL capability remains prohibited

Made with [Cursor](https://cursor.com)