### PR TITLE
feat(diagnostics): bounded I2 catalog-metadata capability

### DIFF
--- a/command-center/docs/governance/I2_CATALOG_METADATA_CAPABILITY.md
+++ b/command-center/docs/governance/I2_CATALOG_METADATA_CAPABILITY.md
@@ -1,0 +1,41 @@
+# I2 Bounded Catalog-Metadata Capability
+
+> Adapter capability only. Does **not** apply R-S1-01, deploy, or begin Slice 2.
+> Live calls require a `database_read`-scoped Diagnostics OAuth token (separate
+> Founder credential/scope provisioning after this code merges).
+
+## Purpose
+
+Enable Orchestrator **A0** posture checks (RLS flags, policies, grants, schema
+metadata) without Founder Dashboard SQL and without arbitrary SQL.
+
+## Transport
+
+`POST /v1/projects/{ref}/database/query/read-only` only.
+
+- Agent never supplies SQL (`--sql` / `query` / `sql` params → DENY).
+- Writable `.../database/query` → DENY.
+- `execute-sql` Edge Function → DENY (unchanged).
+- Project ref hard-locked to `wwyxohjnyqnegzbxtuxs`.
+
+## Operations
+
+See `catalog-ops.mjs` / CLI `catalog <op> --schema=public --table=estimates`.
+
+## Audit
+
+Append-only JSONL via `I2_DIAGNOSTICS_AUDIT_LOG` or
+`%LOCALAPPDATA%\BHFOS\production-diagnostics\adapter-audit.jsonl`.
+Records: time, operation, params, result_class, http status — never tokens or
+row dumps.
+
+## Tests
+
+```bash
+npm run test:supabase-diagnostics-adapter
+```
+
+## Standing authority after merge + live verification
+
+Once merged and live catalog calls succeed under approved OAuth scope, catalog
+ops are **A0** standing authority (no per-query Founder approval).

--- a/command-center/docs/governance/decisions/I2_CATALOG_METADATA_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/I2_CATALOG_METADATA_DECISION_PACKET.md
@@ -1,0 +1,38 @@
+# Decision Packet — I2 Catalog-Metadata Capability
+
+> Requests Founder merge authorization after Security + Architecture review.
+> Does **not** apply R-S1-01, deploy, begin Slice 2, or expand OAuth scopes by itself.
+
+| Field | Value |
+| --- | --- |
+| Release ID | `I2-CATALOG-METADATA` |
+| Risk tier | Tier 2 (diagnostics capability; money_state consumers later) |
+| Base | `3283191adbca325844c204a650015d95017d09ef` |
+| Scope | Production Diagnostics adapter bounded catalog-metadata |
+
+## Proposed correction
+
+Add allowlisted catalog operations that POST only to
+`/v1/projects/{ref}/database/query/read-only` with **adapter-owned** SELECT
+templates. Agent SQL, writable query endpoint, execute-sql, row browsing, and
+mutations remain DENY.
+
+## Explicit non-goals
+
+R-S1-01 apply · deploy · Slice 2 · Stripe · secrets display · live OAuth
+`database_read` re-consent (separate Founder line after merge)
+
+## Required reviews
+
+Security Guard · Architecture Guard at exact frozen head.
+
+## Founder merge line (after reviews)
+
+> Approve merge of PR #<n> at `<frozen-head>`
+
+## After merge
+
+1. Separate Founder auth to grant/re-consent Diagnostics OAuth `database_read` if not already present.  
+2. Live verify `catalog catalog_rls_flags --schema=public --table=estimates`.  
+3. Then A0 standing authority for catalog posture checks.  
+4. Re-run R-S1-01 live posture → aim for `SAFE_TO_AUTHORIZE_APPLY` or correction.

--- a/command-center/package.json
+++ b/command-center/package.json
@@ -36,7 +36,7 @@
     "test:founder-run-readiness": "node tools/founder-run-readiness.mjs --self-test",
     "test:control-plane-lane": "node tools/control-plane-lane-activation.mjs --self-test",
     "test:cursor-role-isolation": "node tools/verify-cursor-role-isolation.mjs",
-    "test:supabase-diagnostics-adapter": "node tools/supabase-diagnostics-adapter/cli.mjs --self-test",
+    "test:supabase-diagnostics-adapter": "node tools/supabase-diagnostics-adapter/cli.mjs --self-test && node tools/supabase-diagnostics-adapter/catalog.self-test.mjs",
     "test:supabase-oauth-helper": "node tools/supabase-diagnostics-adapter/oauth-authorize.mjs --self-test",
     "test:supabase-oauth-tunnel": "node tools/supabase-diagnostics-adapter/oauth-tunnel.self-test.mjs",
     "test:supabase-oauth-launcher-preflight": "node tools/supabase-diagnostics-adapter/oauth-launcher-preflight.self-test.mjs",

--- a/command-center/tools/supabase-diagnostics-adapter/README.md
+++ b/command-center/tools/supabase-diagnostics-adapter/README.md
@@ -6,26 +6,35 @@ G2.3B-B2D.**
 
 ## Guarantees
 
-- Hard endpoint allowlist (`allowlist.json`) — initially project metadata + health only
+- Hard endpoint allowlist (`allowlist.json`) — project metadata + health + **bounded catalog**
 - Hard project-ref lock: `wwyxohjnyqnegzbxtuxs` (adapter isolation; **not** a claim that the OAuth token is project-scoped)
 - No agent-controlled URL, path, query, project ref, or HTTP method bypass
 - No function-body retrieval; Edge Function ops deferred
 - No agent-provided log SQL
-- No SQL execution / database queries
+- **No agent-supplied SQL**; catalog uses adapter-owned SELECT templates only
+- Catalog transport: `POST .../database/query/read-only` only (writable `/database/query` DENY)
 - No secrets or API-key retrieval
 - No Auth-user access
 - No function deploy/mutation
-- No migrations or configuration changes
+- No migrations apply or configuration changes
 - No project listing / org listing / network restrictions / network bans / upgrade surfaces via adapter
 - OAuth access token via `I2_SUPABASE_OAUTH_ACCESS_TOKEN` env only — never CLI argv, never returned to the agent
+- Audit log for catalog ops (operation/time/params/result_class)
 
 ## Commands
 
 ```bash
 node tools/supabase-diagnostics-adapter/cli.mjs --self-test
 npm run test:supabase-diagnostics-adapter
+
+# Dry-run catalog (no network):
+node tools/supabase-diagnostics-adapter/cli.mjs --dry-run-catalog catalog_rls_flags --schema=public --table=estimates
+
+# Live catalog (requires database_read-scoped token — separate Founder scope auth):
+node tools/supabase-diagnostics-adapter/cli.mjs catalog catalog_rls_flags --schema=public --table=estimates
 ```
 
+See `docs/governance/I2_CATALOG_METADATA_CAPABILITY.md`.
 ## Credential issuance
 
 Requires Founder Decision Packet **G2.3B-B2D Option A** after Architecture Guard

--- a/command-center/tools/supabase-diagnostics-adapter/adapter.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/adapter.mjs
@@ -17,7 +17,14 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
+import {
+  CATALOG_OPERATIONS,
+  READ_ONLY_QUERY_PATH_SUFFIX,
+  listCatalogOperations,
+  resolveCatalogSql,
+} from './catalog-ops.mjs';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const allowlistPath = path.join(here, 'allowlist.json');
@@ -106,7 +113,7 @@ export function resolveAllowedPath(operation, { agentRef } = {}) {
 }
 
 /** Paths that must never be requested. */
-export function assertNotProhibited(requestPath) {
+export function assertNotProhibited(requestPath, { allowCatalogReadOnly = false } = {}) {
   const list = loadAllowlist();
   const raw = String(requestPath);
   const qIdx = raw.indexOf('?');
@@ -121,6 +128,21 @@ export function assertNotProhibited(requestPath) {
     throw new Error('DENY: project listing prohibited');
   }
 
+  const readOnlyPath = `/v1/projects/${PRODUCTION_PROJECT_REF}${READ_ONLY_QUERY_PATH_SUFFIX}`;
+  const writableQueryPath = `/v1/projects/${PRODUCTION_PROJECT_REF}/database/query`;
+
+  if (pathOnly === writableQueryPath || pathOnly.startsWith(`${writableQueryPath}?`)) {
+    throw new Error('DENY: writable database/query endpoint is prohibited');
+  }
+
+  if (pathOnly.includes('/database')) {
+    if (allowCatalogReadOnly && pathOnly === readOnlyPath && qIdx === -1) {
+      // permitted only for catalog transport
+    } else {
+      throw new Error(`DENY: database path not permitted: ${pathOnly}`);
+    }
+  }
+
   for (const pattern of list.prohibited_path_substrings) {
     if (raw.includes(pattern)) {
       throw new Error(`DENY: prohibited path pattern "${pattern}" in ${requestPath}`);
@@ -133,6 +155,37 @@ export function assertNotProhibited(requestPath) {
       return;
     }
     throw new Error('DENY: query strings are not permitted on adapter requests');
+  }
+}
+
+/**
+ * Append audit record (no secrets, no row payloads).
+ * @param {object} entry
+ */
+export function appendAuditLog(entry) {
+  const defaultDir =
+    process.env.LOCALAPPDATA ||
+    process.env.HOME ||
+    process.env.USERPROFILE ||
+    '';
+  const fallback = defaultDir
+    ? path.join(defaultDir, 'BHFOS', 'production-diagnostics', 'adapter-audit.jsonl')
+    : '';
+  const auditPath = process.env.I2_DIAGNOSTICS_AUDIT_LOG || fallback;
+  if (!auditPath) return { audited: false, reason: 'no_audit_path' };
+
+  const line = JSON.stringify({
+    ts_utc: new Date().toISOString(),
+    caller: 'supabase-diagnostics-adapter',
+    ref: PRODUCTION_PROJECT_REF,
+    ...entry,
+  });
+  try {
+    fs.mkdirSync(path.dirname(auditPath), { recursive: true });
+    fs.appendFileSync(auditPath, `${line}\n`, { encoding: 'utf8' });
+    return { audited: true, path: auditPath };
+  } catch (e) {
+    return { audited: false, reason: String(e.message || e) };
   }
 }
 
@@ -214,6 +267,127 @@ export async function invokeAllowlisted(operation, { agentRef, dryRun = false } 
     body: JSON.parse(maskPayload(typeof body === 'string' ? body : JSON.stringify(body))),
   };
 }
+
+/**
+ * Bounded catalog-metadata invoke.
+ * Agent supplies operation id + structured params only — never SQL.
+ */
+export async function invokeCatalog(operationId, rawParams = {}, { agentRef, dryRun = false } = {}) {
+  const ref = resolveProductionProjectRef({ agentRef });
+  const apiPath = `/v1/projects/${ref}${READ_ONLY_QUERY_PATH_SUFFIX}`;
+  assertNotProhibited(apiPath, { allowCatalogReadOnly: true });
+
+  let resolved;
+  try {
+    resolved = resolveCatalogSql(operationId, rawParams, {
+      sql: rawParams.sql,
+      query: rawParams.query,
+    });
+  } catch (e) {
+    appendAuditLog({
+      operation: operationId,
+      params: sanitizeParamsForAudit(rawParams),
+      result_class: 'deny',
+      error: String(e.message || e),
+    });
+    throw e;
+  }
+
+  if (dryRun || process.env.SUPABASE_ADAPTER_DRY_RUN === '1') {
+    appendAuditLog({
+      operation: resolved.operation,
+      params: resolved.params,
+      result_class: 'dry_run',
+      path: apiPath,
+    });
+    return {
+      dry_run: true,
+      operation: resolved.operation,
+      method: 'POST',
+      path: apiPath,
+      ref,
+      params: resolved.params,
+      description: resolved.description,
+      sql_sha256: sha256Hex(resolved.sql),
+      note: 'No network call; fixed SQL not returned to reduce prompt leakage',
+    };
+  }
+
+  const token = readAccessToken();
+  if (!token) {
+    appendAuditLog({
+      operation: resolved.operation,
+      params: resolved.params,
+      result_class: 'error',
+      error: 'missing_oauth_token',
+    });
+    throw new Error(
+      'DENY: I2_SUPABASE_OAUTH_ACCESS_TOKEN not set (catalog live calls require database_read-scoped token)'
+    );
+  }
+
+  const base = (process.env.SUPABASE_MANAGEMENT_API_BASE || 'https://api.supabase.com').replace(
+    /\/$/,
+    ''
+  );
+  const url = `${base}${apiPath}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query: resolved.sql }),
+  });
+
+  const text = await res.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = { raw: maskPayload(text.slice(0, 2000)) };
+  }
+
+  const masked = JSON.parse(maskPayload(typeof body === 'string' ? body : JSON.stringify(body)));
+  const resultClass = res.ok ? 'ok' : 'error';
+  appendAuditLog({
+    operation: resolved.operation,
+    params: resolved.params,
+    result_class: resultClass,
+    http_status: res.status,
+    path: apiPath,
+  });
+
+  return {
+    operation: resolved.operation,
+    status: res.status,
+    ok: res.ok,
+    ref,
+    params: resolved.params,
+    description: resolved.description,
+    classification: 'catalog_metadata',
+    body: masked,
+  };
+}
+
+function sanitizeParamsForAudit(rawParams) {
+  const out = {};
+  for (const [k, v] of Object.entries(rawParams || {})) {
+    if (k === 'sql' || k === 'query') {
+      out[k] = '[REJECTED]';
+      continue;
+    }
+    out[k] = typeof v === 'string' ? v.slice(0, 80) : v;
+  }
+  return out;
+}
+
+function sha256Hex(text) {
+  return createHash('sha256').update(String(text), 'utf8').digest('hex');
+}
+
+export { listCatalogOperations, CATALOG_OPERATIONS };
 
 export function selfTest() {
   const results = [];
@@ -336,6 +510,7 @@ export function selfTest() {
     `/v1/projects/${goodRef}/secrets`,
     `/v1/projects/${goodRef}/api-keys`,
     `/v1/projects/${goodRef}/database/query`,
+    `/v1/projects/${goodRef}/database/migrations`,
     `/v1/projects/${goodRef}/network-restrictions`,
     `/v1/projects/${goodRef}/analytics/endpoints/logs?sql=SELECT%201`,
     '/v1/organizations/x/projects',
@@ -352,6 +527,80 @@ export function selfTest() {
       });
     }
   }
+
+  // read-only query path denied unless catalog flag set
+  try {
+    assertNotProhibited(`/v1/projects/${goodRef}${READ_ONLY_QUERY_PATH_SUFFIX}`);
+    results.push({ test: 'deny_readonly_query_without_flag', pass: false });
+  } catch (e) {
+    results.push({
+      test: 'deny_readonly_query_without_flag',
+      pass: /DENY/.test(String(e.message || e)),
+    });
+  }
+  try {
+    assertNotProhibited(`/v1/projects/${goodRef}${READ_ONLY_QUERY_PATH_SUFFIX}`, {
+      allowCatalogReadOnly: true,
+    });
+    results.push({ test: 'allow_readonly_query_with_flag', pass: true });
+  } catch (e) {
+    results.push({
+      test: 'allow_readonly_query_with_flag',
+      pass: false,
+      error: String(e.message || e),
+    });
+  }
+
+  // Catalog: deny agent SQL
+  try {
+    resolveCatalogSql('catalog_rls_flags', { schema: 'public', table: 'estimates', sql: 'SELECT 1' });
+    results.push({ test: 'deny_agent_sql_param', pass: false });
+  } catch (e) {
+    results.push({
+      test: 'deny_agent_sql_param',
+      pass: /agent-supplied SQL/i.test(String(e.message || e)),
+    });
+  }
+
+  try {
+    resolveCatalogSql('catalog_rls_flags', { schema: 'public', table: 'estimates; DROP TABLE x' });
+    results.push({ test: 'deny_ident_injection', pass: false });
+  } catch (e) {
+    results.push({
+      test: 'deny_ident_injection',
+      pass: /DENY/.test(String(e.message || e)),
+    });
+  }
+
+  try {
+    const r = resolveCatalogSql('catalog_rls_flags', { schema: 'public', table: 'estimates' });
+    results.push({
+      test: 'allow_catalog_rls_template',
+      pass: r.sql.startsWith('SELECT') && r.params.table === 'estimates',
+    });
+  } catch (e) {
+    results.push({
+      test: 'allow_catalog_rls_template',
+      pass: false,
+      error: String(e.message || e),
+    });
+  }
+
+  try {
+    resolveCatalogSql('not_a_real_op', {});
+    results.push({ test: 'deny_unknown_catalog_op', pass: false });
+  } catch (e) {
+    results.push({
+      test: 'deny_unknown_catalog_op',
+      pass: /unknown catalog/i.test(String(e.message || e)),
+    });
+  }
+
+  results.push({
+    test: 'catalog_ops_registered',
+    pass: listCatalogOperations().length >= 5,
+    count: listCatalogOperations().length,
+  });
 
   try {
     resolveAllowedPath('custom_log_sql', {});
@@ -383,8 +632,37 @@ export function selfTest() {
           healthOut.path ===
             `/v1/projects/${goodRef}/health?${PROJECT_HEALTH_FIXED_QUERY}`,
       });
-      const failed = results.filter((r) => !r.pass);
-      return { ok: failed.length === 0, results, failed };
+      return invokeCatalog('catalog_rls_flags', { schema: 'public', table: 'estimates' }, {
+        dryRun: true,
+      }).then((catOut) => {
+        results.push({
+          test: 'dry_run_catalog_rls',
+          pass:
+            catOut.dry_run === true &&
+            catOut.path === `/v1/projects/${goodRef}${READ_ONLY_QUERY_PATH_SUFFIX}` &&
+            catOut.method === 'POST' &&
+            !('sql' in catOut),
+        });
+        // deny mutation attempt via fake op name
+        return invokeCatalog('catalog_rls_flags', {
+          schema: 'public',
+          table: 'estimates',
+          query: 'DELETE FROM public.estimates',
+        }, { dryRun: true })
+          .then(() => {
+            results.push({ test: 'deny_catalog_query_param', pass: false });
+          })
+          .catch((e) => {
+            results.push({
+              test: 'deny_catalog_query_param',
+              pass: /agent-supplied SQL|DENY/i.test(String(e.message || e)),
+            });
+          })
+          .then(() => {
+            const failed = results.filter((r) => !r.pass);
+            return { ok: failed.length === 0, results, failed };
+          });
+      });
     });
   });
 }

--- a/command-center/tools/supabase-diagnostics-adapter/allowlist.json
+++ b/command-center/tools/supabase-diagnostics-adapter/allowlist.json
@@ -1,14 +1,13 @@
 {
-  "version": 2,
+  "version": 3,
   "management_api_base": "https://api.supabase.com",
   "production_project_ref": "wwyxohjnyqnegzbxtuxs",
-  "documentation_verified_at": "2026-07-17",
+  "documentation_verified_at": "2026-07-21",
   "notes": [
     "B2D: project isolation is adapter-enforced via fixed production_project_ref. OAuth token is NOT claimed project-scoped.",
-    "Dashboard OAuth scope for Option A is Projects Read (wire: projects:read). Do not treat Management API ids (projects_read, project_admin_read) as interchangeable Dashboard choices.",
-    "Projects Read may enable additional project-related reads (network restrictions/bans, upgrade eligibility, listing). Adapter must still expose only allowlisted operations.",
-    "Health endpoint GET /v1/projects/{ref}/health verified in official Management API docs (2026-07-17).",
-    "B3: project_health uses an adapter-owned fixed query services=db&services=auth&services=rest (Management API requires services). Agent-supplied or arbitrary query strings remain DENY."
+    "v3: bounded catalog-metadata via POST .../database/query/read-only with adapter-owned SQL templates only. Agent SQL prohibited.",
+    "Live catalog requires OAuth database_read (separate Founder credential/scope provisioning). Adapter fails closed without it.",
+    "Writable POST .../database/query remains prohibited. execute-sql Edge Function remains prohibited."
   ],
   "allowed_path_prefixes": [
     "/v1/projects/{ref}"
@@ -19,8 +18,7 @@
       "method": "GET",
       "pathTemplate": "/v1/projects/{ref}",
       "docs": "https://supabase.com/docs/reference/api/v1-get-project",
-      "oauth_app_scope": "projects:read",
-      "management_api_permission_ids_note": "Endpoint FGA docs may cite projects_read / related ids; those are not Dashboard OAuth scope strings"
+      "oauth_app_scope": "projects:read"
     },
     "project_health": {
       "status": "allowed",
@@ -28,8 +26,7 @@
       "pathTemplate": "/v1/projects/{ref}/health",
       "fixedQuery": "services=db&services=auth&services=rest",
       "docs": "https://supabase.com/docs/reference/api/v1-get-project-health",
-      "oauth_app_scope": "projects:read",
-      "note": "Adapter appends fixedQuery only; agent cannot supply or alter the services list. Non-sensitive health metadata under Option A allowlist."
+      "oauth_app_scope": "projects:read"
     },
     "edge_function_inventory": {
       "status": "deferred",
@@ -42,7 +39,7 @@
       "status": "unavailable",
       "method": "GET",
       "pathTemplate": "/v1/projects/{ref}/database/migrations",
-      "reason": "Official docs mark partner-gated; treat unavailable until account-level capability proven",
+      "reason": "Use catalog_migration_history (read-only SQL templates) instead of Management migrations list/apply",
       "oauth_app_scope": "database:read"
     },
     "bounded_logs": {
@@ -53,11 +50,18 @@
       "oauth_app_scope": "analytics:read"
     }
   },
+  "catalog_transport": {
+    "method": "POST",
+    "pathTemplate": "/v1/projects/{ref}/database/query/read-only",
+    "oauth_permission": "database_read",
+    "agent_sql": false,
+    "row_data": false,
+    "mutation": false
+  },
   "prohibited_path_substrings": [
     "/body",
     "/secrets",
     "/api-keys",
-    "/database",
     "/functions",
     "/analytics",
     "/network-restrictions",
@@ -74,5 +78,6 @@
   ],
   "prohibited_exact_paths": [
     "/v1/projects"
-  ]
+  ],
+  "prohibited_database_paths_except_readonly_query": true
 }

--- a/command-center/tools/supabase-diagnostics-adapter/catalog-ops.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/catalog-ops.mjs
@@ -1,0 +1,304 @@
+/**
+ * Bounded catalog-metadata operations for Production Diagnostics.
+ *
+ * Agent never supplies SQL. Only fixed templates with validated identifiers.
+ * Transport: POST /v1/projects/{ref}/database/query/read-only only.
+ */
+
+export const READ_ONLY_QUERY_PATH_SUFFIX = '/database/query/read-only';
+
+/** Allowed Postgres schema names for parameterized catalog ops. */
+export const ALLOWED_SCHEMAS = Object.freeze(['public']);
+
+/**
+ * @param {string} value
+ * @param {string} label
+ */
+export function assertSafeIdent(value, label = 'ident') {
+  const v = String(value ?? '');
+  if (!/^[a-z_][a-z0-9_]*$/i.test(v) || v.length > 63) {
+    throw new Error(`DENY: invalid ${label} (must be SQL identifier [a-z_][a-z0-9_]{0,62})`);
+  }
+  return v.toLowerCase();
+}
+
+/**
+ * @param {string} schema
+ */
+export function assertAllowedSchema(schema) {
+  const s = assertSafeIdent(schema, 'schema');
+  if (!ALLOWED_SCHEMAS.includes(s)) {
+    throw new Error(`DENY: schema "${s}" not in allowlist (${ALLOWED_SCHEMAS.join(', ')})`);
+  }
+  return s;
+}
+
+/**
+ * Reject anything that looks like agent-supplied SQL or mutation.
+ * @param {unknown} maybeSql
+ */
+export function assertNoAgentSql(maybeSql) {
+  if (maybeSql === undefined || maybeSql === null || maybeSql === '') return;
+  throw new Error('DENY: agent-supplied SQL is prohibited');
+}
+
+/**
+ * @typedef {{ schema?: string, table?: string, name?: string }} CatalogParams
+ * @typedef {{
+ *   id: string,
+ *   description: string,
+ *   params: string[],
+ *   buildSql: (p: Record<string, string>) => string,
+ * }} CatalogOp
+ */
+
+/** @type {Record<string, CatalogOp>} */
+export const CATALOG_OPERATIONS = Object.freeze({
+  catalog_relation_exists: {
+    id: 'catalog_relation_exists',
+    description: 'Does the relation exist in public schema?',
+    params: ['schema', 'table'],
+    buildSql: ({ schema, table }) => `
+SELECT EXISTS (
+  SELECT 1
+  FROM pg_catalog.pg_class c
+  JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = '${schema}'
+    AND c.relname = '${table}'
+    AND c.relkind IN ('r','p','v','m')
+) AS exists;
+`.trim(),
+  },
+
+  catalog_rls_flags: {
+    id: 'catalog_rls_flags',
+    description: 'RLS enabled and FORCE RLS flags for a table',
+    params: ['schema', 'table'],
+    buildSql: ({ schema, table }) => `
+SELECT c.relname AS table_name,
+       n.nspname AS schema_name,
+       c.relrowsecurity AS relrowsecurity,
+       c.relforcerowsecurity AS relforcerowsecurity
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = '${schema}'
+  AND c.relname = '${table}'
+  AND c.relkind IN ('r','p');
+`.trim(),
+  },
+
+  catalog_policies: {
+    id: 'catalog_policies',
+    description: 'RLS policies for a table (names, cmd, roles, permissive, exprs)',
+    params: ['schema', 'table'],
+    buildSql: ({ schema, table }) => `
+SELECT pol.polname AS policy_name,
+       CASE pol.polcmd
+         WHEN 'r' THEN 'SELECT'
+         WHEN 'a' THEN 'INSERT'
+         WHEN 'w' THEN 'UPDATE'
+         WHEN 'd' THEN 'DELETE'
+         WHEN '*' THEN 'ALL'
+         ELSE pol.polcmd::text
+       END AS command,
+       pol.polpermissive AS permissive,
+       ARRAY(
+         SELECT pg_catalog.quote_ident(r.rolname)
+         FROM pg_catalog.pg_roles r
+         WHERE r.oid = ANY (pol.polroles)
+       ) AS roles,
+       pg_catalog.pg_get_expr(pol.polqual, pol.polrelid) AS using_expr,
+       pg_catalog.pg_get_expr(pol.polwithcheck, pol.polrelid) AS with_check_expr
+FROM pg_catalog.pg_policy pol
+JOIN pg_catalog.pg_class c ON c.oid = pol.polrelid
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = '${schema}'
+  AND c.relname = '${table}'
+ORDER BY pol.polname;
+`.trim(),
+  },
+
+  catalog_grants: {
+    id: 'catalog_grants',
+    description: 'Table privileges for anon, authenticated, service_role',
+    params: ['schema', 'table'],
+    buildSql: ({ schema, table }) => `
+SELECT grantee, privilege_type, is_grantable
+FROM information_schema.role_table_grants
+WHERE table_schema = '${schema}'
+  AND table_name = '${table}'
+  AND grantee IN ('anon', 'authenticated', 'service_role', 'PUBLIC')
+ORDER BY grantee, privilege_type;
+`.trim(),
+  },
+
+  catalog_columns: {
+    id: 'catalog_columns',
+    description: 'Column names and data types (no row data)',
+    params: ['schema', 'table'],
+    buildSql: ({ schema, table }) => `
+SELECT column_name, data_type, udt_name, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = '${schema}'
+  AND table_name = '${table}'
+ORDER BY ordinal_position;
+`.trim(),
+  },
+
+  catalog_indexes: {
+    id: 'catalog_indexes',
+    description: 'Index definitions for a table',
+    params: ['schema', 'table'],
+    buildSql: ({ schema, table }) => `
+SELECT i.relname AS index_name,
+       pg_catalog.pg_get_indexdef(i.oid) AS index_def
+FROM pg_catalog.pg_class t
+JOIN pg_catalog.pg_namespace n ON n.oid = t.relnamespace
+JOIN pg_catalog.pg_index x ON x.indrelid = t.oid
+JOIN pg_catalog.pg_class i ON i.oid = x.indexrelid
+WHERE n.nspname = '${schema}'
+  AND t.relname = '${table}'
+ORDER BY i.relname;
+`.trim(),
+  },
+
+  catalog_constraints: {
+    id: 'catalog_constraints',
+    description: 'Table constraints',
+    params: ['schema', 'table'],
+    buildSql: ({ schema, table }) => `
+SELECT tc.constraint_name, tc.constraint_type
+FROM information_schema.table_constraints tc
+WHERE tc.table_schema = '${schema}'
+  AND tc.table_name = '${table}'
+ORDER BY tc.constraint_type, tc.constraint_name;
+`.trim(),
+  },
+
+  catalog_triggers: {
+    id: 'catalog_triggers',
+    description: 'Trigger names and timing for a table',
+    params: ['schema', 'table'],
+    buildSql: ({ schema, table }) => `
+SELECT t.tgname AS trigger_name,
+       pg_catalog.pg_get_triggerdef(t.oid, true) AS trigger_def
+FROM pg_catalog.pg_trigger t
+JOIN pg_catalog.pg_class c ON c.oid = t.tgrelid
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = '${schema}'
+  AND c.relname = '${table}'
+  AND NOT t.tgisinternal
+ORDER BY t.tgname;
+`.trim(),
+  },
+
+  catalog_function_signature: {
+    id: 'catalog_function_signature',
+    description: 'Function identity and volatility (definition optional bounded)',
+    params: ['schema', 'name'],
+    buildSql: ({ schema, name }) => `
+SELECT n.nspname AS schema_name,
+       p.proname AS function_name,
+       pg_catalog.pg_get_function_identity_arguments(p.oid) AS args,
+       p.prosecdef AS security_definer,
+       CASE p.provolatile
+         WHEN 'i' THEN 'IMMUTABLE'
+         WHEN 's' THEN 'STABLE'
+         WHEN 'v' THEN 'VOLATILE'
+       END AS volatility
+FROM pg_catalog.pg_proc p
+JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = '${schema}'
+  AND p.proname = '${name}'
+ORDER BY 3;
+`.trim(),
+  },
+
+  catalog_migration_history: {
+    id: 'catalog_migration_history',
+    description: 'Supabase migration version metadata (no SQL apply)',
+    params: [],
+    buildSql: () => `
+SELECT version, name
+FROM supabase_migrations.schema_migrations
+ORDER BY version;
+`.trim(),
+  },
+});
+
+/**
+ * Resolve and validate a catalog operation; return fixed SQL.
+ * @param {string} operationId
+ * @param {Record<string, unknown>} rawParams
+ * @param {{ sql?: unknown, query?: unknown }} [agentExtras] - must be empty
+ */
+export function resolveCatalogSql(operationId, rawParams = {}, agentExtras = {}) {
+  assertNoAgentSql(agentExtras.sql);
+  assertNoAgentSql(agentExtras.query);
+  assertNoAgentSql(rawParams.sql);
+  assertNoAgentSql(rawParams.query);
+
+  const op = CATALOG_OPERATIONS[operationId];
+  if (!op) {
+    throw new Error(`DENY: unknown catalog operation "${operationId}"`);
+  }
+
+  /** @type {Record<string, string>} */
+  const params = {};
+  for (const key of op.params) {
+    if (rawParams[key] === undefined || rawParams[key] === null || rawParams[key] === '') {
+      throw new Error(`DENY: catalog operation "${operationId}" requires param "${key}"`);
+    }
+    if (key === 'schema') {
+      params.schema = assertAllowedSchema(String(rawParams[key]));
+    } else if (key === 'table' || key === 'name') {
+      params[key] = assertSafeIdent(String(rawParams[key]), key);
+    } else {
+      params[key] = assertSafeIdent(String(rawParams[key]), key);
+    }
+  }
+
+  // Reject unexpected params (including sql)
+  for (const key of Object.keys(rawParams)) {
+    if (key === 'sql' || key === 'query') continue; // already denied above if set
+    if (!op.params.includes(key)) {
+      throw new Error(`DENY: unexpected catalog param "${key}"`);
+    }
+  }
+
+  const sql = op.buildSql(params);
+  assertSqlIsSafeTemplate(sql);
+  return { operation: op.id, params, sql, description: op.description };
+}
+
+/**
+ * Defense in depth: fixed templates must not contain mutation keywords as statements.
+ * @param {string} sql
+ */
+export function assertSqlIsSafeTemplate(sql) {
+  const normalized = sql.replace(/\s+/g, ' ').trim();
+  // Must be SELECT / WITH ... SELECT only
+  if (!/^(WITH\b|SELECT\b)/i.test(normalized)) {
+    throw new Error('DENY: catalog SQL templates must be SELECT-only');
+  }
+  // Ignore single-quoted literals (e.g. CASE … THEN 'DELETE')
+  const noStrings = normalized.replace(/'(?:''|[^'])*'/g, "''");
+  const banned =
+    /\b(INSERT|UPDATE|DELETE|TRUNCATE|ALTER|CREATE|DROP|GRANT|REVOKE|CALL|COPY|EXECUTE|DO)\b/i;
+  if (banned.test(noStrings)) {
+    throw new Error('DENY: mutation keyword detected in catalog SQL template');
+  }
+  if (noStrings.includes(';')) {
+    const parts = noStrings.split(';').filter((p) => p.trim());
+    if (parts.length > 1) {
+      throw new Error('DENY: multiple SQL statements prohibited');
+    }
+  }
+}
+
+/**
+ * @returns {string[]}
+ */
+export function listCatalogOperations() {
+  return Object.keys(CATALOG_OPERATIONS);
+}

--- a/command-center/tools/supabase-diagnostics-adapter/catalog.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/catalog.self-test.mjs
@@ -1,0 +1,101 @@
+/**
+ * Extra catalog negative proofs (also covered in adapter --self-test).
+ */
+import assert from 'node:assert/strict';
+import {
+  resolveCatalogSql,
+  assertSqlIsSafeTemplate,
+  CATALOG_OPERATIONS,
+} from './catalog-ops.mjs';
+import { invokeCatalog, assertNotProhibited, PRODUCTION_PROJECT_REF } from './adapter.mjs';
+import { READ_ONLY_QUERY_PATH_SUFFIX } from './catalog-ops.mjs';
+
+const failures = [];
+
+function check(name, fn) {
+  try {
+    fn();
+    console.log(`PASS ${name}`);
+  } catch (e) {
+    failures.push({ name, error: String(e.message || e) });
+    console.error(`FAIL ${name}: ${e.message || e}`);
+  }
+}
+
+async function checkAsync(name, fn) {
+  try {
+    await fn();
+    console.log(`PASS ${name}`);
+  } catch (e) {
+    failures.push({ name, error: String(e.message || e) });
+    console.error(`FAIL ${name}: ${e.message || e}`);
+  }
+}
+
+check('templates_are_select_only', () => {
+  for (const op of Object.values(CATALOG_OPERATIONS)) {
+    const params = {};
+    for (const p of op.params) {
+      params[p] = p === 'schema' ? 'public' : 'estimates';
+    }
+    if (op.params.includes('name')) params.name = 'generate_estimate_number';
+    const sql = op.buildSql(params);
+    assertSqlIsSafeTemplate(sql);
+  }
+});
+
+check('deny_mutation_template', () => {
+  assert.throws(() => assertSqlIsSafeTemplate('DELETE FROM public.estimates'), /DENY/);
+  assert.throws(() => assertSqlIsSafeTemplate('INSERT INTO public.estimates DEFAULT VALUES'), /DENY/);
+  assert.throws(() => assertSqlIsSafeTemplate('SELECT 1; DROP TABLE public.estimates'), /DENY|multiple/);
+});
+
+check('deny_agent_sql', () => {
+  assert.throws(
+    () => resolveCatalogSql('catalog_columns', { schema: 'public', table: 'estimates', sql: 'SELECT 1' }),
+    /agent-supplied SQL/
+  );
+});
+
+check('deny_non_public_schema', () => {
+  assert.throws(
+    () => resolveCatalogSql('catalog_columns', { schema: 'auth', table: 'users' }),
+    /not in allowlist/
+  );
+});
+
+await checkAsync('deny_writable_query_path', async () => {
+  assert.throws(
+    () => assertNotProhibited(`/v1/projects/${PRODUCTION_PROJECT_REF}/database/query`),
+    /DENY/
+  );
+});
+
+await checkAsync('deny_readonly_without_flag', async () => {
+  assert.throws(
+    () =>
+      assertNotProhibited(
+        `/v1/projects/${PRODUCTION_PROJECT_REF}${READ_ONLY_QUERY_PATH_SUFFIX}`
+      ),
+    /DENY/
+  );
+});
+
+await checkAsync('dry_run_catalog_ok', async () => {
+  const out = await invokeCatalog(
+    'catalog_relation_exists',
+    { schema: 'public', table: 'estimates' },
+    { dryRun: true }
+  );
+  assert.equal(out.dry_run, true);
+  assert.equal(out.method, 'POST');
+  assert.ok(out.path.endsWith(READ_ONLY_QUERY_PATH_SUFFIX));
+  assert.equal(out.sql, undefined);
+});
+
+if (failures.length) {
+  console.error(JSON.stringify({ ok: false, failures }, null, 2));
+  process.exit(1);
+}
+console.log(JSON.stringify({ ok: true, failed: [] }));
+process.exit(0);

--- a/command-center/tools/supabase-diagnostics-adapter/cli.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/cli.mjs
@@ -2,27 +2,37 @@
 import {
   selfTest,
   invokeAllowlisted,
+  invokeCatalog,
   resolveAllowedPath,
+  listCatalogOperations,
   PRODUCTION_PROJECT_REF,
 } from './adapter.mjs';
 
 const args = process.argv.slice(2);
 
 function usage() {
-  console.log(`supabase-diagnostics-adapter (G2.3B-B2D)
+  const catalogOps = listCatalogOperations().join('\n    ');
+  console.log(`supabase-diagnostics-adapter (G2.3B-B2D + catalog v3)
 
 Commands:
-  --self-test                 Run allowlist/deny proofs (no credential)
-  --dry-run <operation>       Resolve allowlisted path for locked production ref
-  project-status              Live call (requires authorized OAuth access token)
-  project-health
+  --self-test                 Run allowlist/deny/catalog proofs (no credential)
+  --dry-run <operation>       Resolve allowlisted GET path for locked production ref
+  --dry-run-catalog <op>      Dry-run catalog op (structured params; no SQL)
+  project-status              Live GET (requires OAuth access token)
+  project-health              Live GET health
+  catalog <op>                Live catalog-metadata (requires database_read-scoped token)
+
+Catalog operations (params via --schema= --table= or --name=):
+    ${catalogOps}
 
 Project ref is hard-locked to ${PRODUCTION_PROJECT_REF}.
-Agent-supplied --ref= is rejected unless it exactly matches the lock (and is unnecessary).
+Agent-supplied SQL is always DENY.
+Writable /database/query and execute-sql remain DENY.
 
-Environment (live only, after separate Founder auth + AG):
+Environment:
   I2_SUPABASE_OAUTH_ACCESS_TOKEN   Bearer token (never pass on CLI)
   SUPABASE_DIAGNOSTICS_PROJECT_REF Must be ${PRODUCTION_PROJECT_REF} when set
+  I2_DIAGNOSTICS_AUDIT_LOG         Optional audit jsonl path
   SUPABASE_ADAPTER_DRY_RUN=1       Force dry-run
 
 Never pass tokens on the command line.
@@ -32,6 +42,20 @@ Never pass tokens on the command line.
 function getAgentRef(argv) {
   const hit = argv.find((a) => a.startsWith('--ref='));
   return hit ? hit.slice('--ref='.length) : undefined;
+}
+
+function parseCatalogParams(argv) {
+  /** @type {Record<string, string>} */
+  const params = {};
+  for (const a of argv) {
+    if (a.startsWith('--schema=')) params.schema = a.slice('--schema='.length);
+    else if (a.startsWith('--table=')) params.table = a.slice('--table='.length);
+    else if (a.startsWith('--name=')) params.name = a.slice('--name='.length);
+    else if (a.startsWith('--sql=') || a.startsWith('--query=')) {
+      throw new Error('DENY: agent-supplied SQL flags are prohibited');
+    }
+  }
+  return params;
 }
 
 async function main() {
@@ -48,12 +72,38 @@ async function main() {
 
   const agentRef = getAgentRef(args);
 
+  if (args[0] === '--dry-run-catalog') {
+    const operation = args[1];
+    try {
+      const params = parseCatalogParams(args.slice(2));
+      const out = await invokeCatalog(operation, params, { agentRef, dryRun: true });
+      console.log(JSON.stringify(out, null, 2));
+      process.exit(0);
+    } catch (e) {
+      console.error(String(e.message || e));
+      process.exit(1);
+    }
+  }
+
   if (args[0] === '--dry-run') {
     const operation = args[1];
     try {
       const out = await invokeAllowlisted(operation, { agentRef, dryRun: true });
       console.log(JSON.stringify(out, null, 2));
       process.exit(0);
+    } catch (e) {
+      console.error(String(e.message || e));
+      process.exit(1);
+    }
+  }
+
+  if (args[0] === 'catalog') {
+    const operation = args[1];
+    try {
+      const params = parseCatalogParams(args.slice(2));
+      const out = await invokeCatalog(operation, params, { agentRef, dryRun: false });
+      console.log(JSON.stringify(out, null, 2));
+      process.exit(out.ok ? 0 : 1);
     } catch (e) {
       console.error(String(e.message || e));
       process.exit(1);


### PR DESCRIPTION
## Summary
- Bounded Production Diagnostics catalog-metadata ops (A0 posture checks).
- Transport: `POST /v1/projects/{ref}/database/query/read-only` only.
- Agent SQL / writable `/database/query` / `execute-sql` remain DENY.
- Audit JSONL; automated negative tests via `npm run test:supabase-diagnostics-adapter`.

## Explicit non-authorization
Does not apply R-S1-01, deploy, begin Slice 2, or re-consent OAuth scopes.

## Required before merge
- Security Guard + Architecture Guard at exact frozen head

## Test plan
- [x] `npm run test:supabase-diagnostics-adapter`
- [ ] Security review
- [ ] Architecture review
- [ ] After merge: separate Founder line for `database_read` scope if needed; live catalog verify

Made with [Cursor](https://cursor.com)