### PR TITLE
fix(diagnostics): allow database:read in OAuth token-store scopes

### DIFF
--- a/command-center/tools/supabase-diagnostics-adapter/README.md
+++ b/command-center/tools/supabase-diagnostics-adapter/README.md
@@ -59,7 +59,7 @@ Inventory names (values never in repo):
 - Tunnel credentials outside the repository
 - Tunnel stops after every authorize attempt; public callback closure verified
 - Windows browser launch uses approved Edge/Chrome **absolute** paths only
-- Token `scope` when **present**: fail-closed ⊆ `projects:read` only (`UNEXPECTED_SCOPE` DENY otherwise)
+- Token `scope` when **present**: fail-closed ⊆ `projects:read` + `database:read` only (`UNEXPECTED_SCOPE` DENY otherwise; `projects:read` still required)
 - Token `scope` when **omitted/empty**: platform-attested OpenAPI omission (`OAuthTokenResponse` has no `scope`; `additionalProperties: false`) — **not** unconditional OK
 - Before any durable token write: pre-store capability attestation (allowlisted `GET /v1/projects/wwyxohjnyqnegzbxtuxs` must succeed; out-of-ceiling probe e.g. `/api-keys` must not)
 - Quarantined tokens from failed attempts (including PR #58) must be replaced before B3

--- a/command-center/tools/supabase-diagnostics-adapter/allowlist.json
+++ b/command-center/tools/supabase-diagnostics-adapter/allowlist.json
@@ -6,7 +6,7 @@
   "notes": [
     "B2D: project isolation is adapter-enforced via fixed production_project_ref. OAuth token is NOT claimed project-scoped.",
     "v3: bounded catalog-metadata via POST .../database/query/read-only with adapter-owned SQL templates only. Agent SQL prohibited.",
-    "Live catalog requires OAuth database_read (separate Founder credential/scope provisioning). Adapter fails closed without it.",
+    "Live catalog requires OAuth database_read (A3: enable Database Read on Diagnostics OAuth app + re-consent; token-store ALLOWED_SCOPES = projects:read + database:read only).",
     "Writable POST .../database/query remains prohibited. execute-sql Edge Function remains prohibited."
   ],
   "allowed_path_prefixes": [

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
@@ -21,7 +21,8 @@ export const LOCAL_LISTENER_URI = `http://${CALLBACK_HOST}:${CALLBACK_PORT}${CAL
 export const REDIRECT_URI = PUBLIC_REDIRECT_URI;
 export const AUTHORIZE_URL = 'https://api.supabase.com/v1/oauth/authorize';
 export const TOKEN_URL = 'https://api.supabase.com/v1/oauth/token';
-export const ALLOWED_SCOPES = new Set(['projects:read']);
+/** Token-store ceiling: Projects Read + Database Read only (no Write / no other scopes). */
+export const ALLOWED_SCOPES = new Set(['projects:read', 'database:read']);
 
 /** Listener bind contract — host must be loopback IP only (not 0.0.0.0). */
 export const CALLBACK_BIND = Object.freeze({
@@ -311,8 +312,11 @@ export function validateCallbackRequest({
  * schema gap — not unconditional OK. Callers must run
  * `attestPreStoreCapabilities` before any durable token write.
  *
- * When present: fail-closed ⊆ ALLOWED_SCOPES (`projects:read` only). No invented
- * normalization (e.g. projects.read / rest).
+ * When present: fail-closed ⊆ ALLOWED_SCOPES (`projects:read` + `database:read`
+ * only). No invented normalization (e.g. projects.read / rest). `projects:read`
+ * remains mandatory when scope is present; `database:read` is allowed (required
+ * at the Management API for catalog read-only) but not forced here because the
+ * platform may omit the scope field entirely.
  */
 export function assertTokenScopes(scopeField) {
   if (scopeField === undefined || scopeField === null || String(scopeField).trim() === '') {

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
@@ -208,6 +208,12 @@ export async function runSelfTests() {
   } catch (e) {
     pass(results, 'unexpected_scope_rejected', e.code === 'UNEXPECTED_SCOPE');
   }
+  try {
+    assertTokenScopes('projects:read database:write');
+    pass(results, 'database_write_rejected', false);
+  } catch (e) {
+    pass(results, 'database_write_rejected', e.code === 'UNEXPECTED_SCOPE');
+  }
   const omitted = assertTokenScopes('');
   const omittedUndef = assertTokenScopes(undefined);
   pass(
@@ -220,6 +226,12 @@ export async function runSelfTests() {
       omitted.scopes.length === 0
   );
   pass(results, 'allowed_scope_ok', assertTokenScopes('projects:read').scopes.includes('projects:read'));
+  const both = assertTokenScopes('projects:read database:read');
+  pass(
+    results,
+    'allowed_scopes_projects_and_database_read',
+    both.scopes.includes('projects:read') && both.scopes.includes('database:read')
+  );
 
   // --- pre-store capability attestation (injected fetch; no live network) ---
   const allowPath = `/v1/projects/${PRODUCTION_PROJECT_REF}`;


### PR DESCRIPTION
## Summary
- Expand Diagnostics OAuth token-store `ALLOWED_SCOPES` to `projects:read` + `database:read` only (A3-authorized).
- Keep fail-closed rejection of Write and all other scopes; `projects:read` remains mandatory when scope is present.
- Self-tests cover both allowed scopes and `database:write` DENY.

## Test plan
- [x] `npm run test:supabase-diagnostics-adapter`
- [x] `npm run test:supabase-oauth-helper`
- [ ] CI green
- [ ] After merge: Founder enables Database Read on OAuth app + re-consent via `Run-SupabaseOAuthAuthorize.ps1`
- [ ] Live verify `catalog catalog_rls_flags --schema=public --table=estimates` → 200

## Explicit non-goals
R-S1-01 apply · deploy · Slice 2 · Database Write · execute-sql · service-role · secrets display

Made with [Cursor](https://cursor.com)