### PR TITLE
fix(diagnostics): dual pre-store OAuth attestation for projects+database read

### DIFF
--- a/command-center/docs/governance/decisions/I2_OAUTH_DUAL_ATTEST_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/I2_OAUTH_DUAL_ATTEST_DECISION_PACKET.md
@@ -1,0 +1,32 @@
+# Decision Packet — I2 Dual OAuth Pre-Store Attestation
+
+> A1 remediation under A3 Diagnostics OAuth Database Read authorization.
+> Does **not** apply R-S1-01, deploy, begin Slice 2, or expand OAuth scopes.
+
+| Field | Value |
+| --- | --- |
+| Release ID | `I2-OAUTH-DUAL-ATTEST` |
+| Risk tier | Tier 2 (diagnostics token-store hardening) |
+| Base | `ceecbd7780c92ecf3093fc71cdd5063a130f0b59` |
+| Scope | Production Diagnostics OAuth helper attestation only |
+
+## Proposed correction
+
+1. UX: consent copy states **Projects Read + Database Read only**.
+2. Pre-store attestation stores tokens only when both succeed:
+   - allowlisted `project_status` (Projects Read / `project_admin_read`);
+   - bounded `catalog_relation_exists` POST read-only (Database Read / `database_read`).
+3. Safe failure reports: capability name, HTTP status, platform permission — no secrets.
+4. When token `scope` is present: require both `projects:read` and `database:read`; reject Write and others.
+
+## Explicit non-goals
+
+R-S1-01 apply · deploy · Slice 2 · Database Write · execute-sql · service-role · secrets display · broader scopes
+
+## Required reviews
+
+Security Guard · Architecture Guard at exact frozen head.
+
+## Founder re-consent
+
+Only after merge + Dashboard confirms both scopes + diagnostics worktree pinned to new main SHA.

--- a/command-center/tools/supabase-diagnostics-adapter/README.md
+++ b/command-center/tools/supabase-diagnostics-adapter/README.md
@@ -59,9 +59,9 @@ Inventory names (values never in repo):
 - Tunnel credentials outside the repository
 - Tunnel stops after every authorize attempt; public callback closure verified
 - Windows browser launch uses approved Edge/Chrome **absolute** paths only
-- Token `scope` when **present**: fail-closed ⊆ `projects:read` + `database:read` only (`UNEXPECTED_SCOPE` DENY otherwise; `projects:read` still required)
-- Token `scope` when **omitted/empty**: platform-attested OpenAPI omission (`OAuthTokenResponse` has no `scope`; `additionalProperties: false`) — **not** unconditional OK
-- Before any durable token write: pre-store capability attestation (allowlisted `GET /v1/projects/wwyxohjnyqnegzbxtuxs` must succeed; out-of-ceiling probe e.g. `/api-keys` must not)
+- Token `scope` when **present**: fail-closed ⊆ `projects:read` + `database:read` only; **both** required (`UNEXPECTED_SCOPE` / `MISSING_*` DENY otherwise)
+- Token `scope` when **omitted/empty**: platform-attested OpenAPI omission — dual pre-store attestation required (projects GET + bounded catalog POST) before any durable token write
+- Pre-store attestation fails closed unless both Projects Read (`project_admin_read`) and Database Read (`database_read`) succeed; safe failure reports capability + HTTP status + platform permission name only
 - Quarantined tokens from failed attempts (including PR #58) must be replaced before B3
 
 ```bash

--- a/command-center/tools/supabase-diagnostics-adapter/allowlist.json
+++ b/command-center/tools/supabase-diagnostics-adapter/allowlist.json
@@ -6,7 +6,7 @@
   "notes": [
     "B2D: project isolation is adapter-enforced via fixed production_project_ref. OAuth token is NOT claimed project-scoped.",
     "v3: bounded catalog-metadata via POST .../database/query/read-only with adapter-owned SQL templates only. Agent SQL prohibited.",
-    "Live catalog requires OAuth database_read (A3: enable Database Read on Diagnostics OAuth app + re-consent; token-store ALLOWED_SCOPES = projects:read + database:read only).",
+    "Live catalog / token-store require dual attestation: Projects Read (project_admin_read via project_status) AND Database Read (database_read via bounded catalog). ALLOWED_SCOPES = projects:read + database:read only.",
     "Writable POST .../database/query remains prohibited. execute-sql Edge Function remains prohibited."
   ],
   "allowed_path_prefixes": [

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-authorize.mjs
@@ -48,6 +48,7 @@ import {
   writeTokenSecretsToEnvFile,
   wipeTransient,
   formatStatusResult,
+  formatAttestationFailure,
   redactSecrets,
   parseEnvFile,
   buildBrowserLaunchSpec,
@@ -198,7 +199,7 @@ async function runAuthorizeExchange() {
     console.log(`Public redirect: ${PUBLIC_REDIRECT_URI}`);
     console.log(`Local listener: ${LOCAL_LISTENER_URI}`);
     console.log(`Callback path: ${CALLBACK_PATH}`);
-    console.log('Opening browser for Founder consent (Projects Read only)…');
+    console.log('Opening browser for Founder consent (Projects Read + Database Read only)…');
     console.log('browser opened');
 
     const callbackPromise = waitForCallback({ expectedState: transient.state });
@@ -333,8 +334,18 @@ async function authorizeMain() {
     console.log('public callback closed');
     console.log(tunnel.status('complete'));
   } catch (e) {
-    const safe = redactSecrets(e && e.message ? e.message : String(e));
-    console.error(safe);
+    if (e && e.capability) {
+      console.error(
+        formatAttestationFailure({
+          capability: e.capability,
+          httpStatus: e.httpStatus,
+          platformPermission: e.platformPermission,
+        })
+      );
+    } else {
+      const safe = redactSecrets(e && e.message ? e.message : String(e));
+      console.error(safe);
+    }
     console.log(
       formatStatusResult({
         completed: false,

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.mjs
@@ -59,11 +59,55 @@ const SECRET_NAMES = {
 export { SECRET_NAMES };
 
 export class OAuthHelperError extends Error {
-  constructor(message, code = 'OAUTH_HELPER_DENY') {
+  /**
+   * @param {string} message
+   * @param {string} [code]
+   * @param {{ capability?: string, httpStatus?: number|string, platformPermission?: string|null }} [details]
+   */
+  constructor(message, code = 'OAUTH_HELPER_DENY', details = undefined) {
     super(message);
     this.name = 'OAuthHelperError';
     this.code = code;
+    if (details && typeof details === 'object') {
+      if (details.capability) this.capability = details.capability;
+      if (details.httpStatus !== undefined) this.httpStatus = details.httpStatus;
+      if (details.platformPermission !== undefined) {
+        this.platformPermission = details.platformPermission;
+      }
+    }
   }
+}
+
+/**
+ * Extract platform FGA permission name from a Management API error body.
+ * Never returns token material.
+ * @param {unknown} bodyText
+ * @returns {string|null}
+ */
+export function extractPlatformPermission(bodyText) {
+  const s = typeof bodyText === 'string' ? bodyText : '';
+  const m = s.match(/missing required scopes?\s*\(([^)]+)\)/i);
+  if (!m) return null;
+  const first = String(m[1])
+    .split(/[\s,]+/)
+    .map((p) => p.trim())
+    .filter(Boolean)[0];
+  return first || null;
+}
+
+/**
+ * Safe, non-secret attestation failure line for console / Founder reports.
+ * @param {{ capability: string, httpStatus?: number|string, platformPermission?: string|null }} info
+ */
+export function formatAttestationFailure(info) {
+  const capability = String(info.capability || 'unknown');
+  const httpStatus =
+    info.httpStatus === undefined || info.httpStatus === null ? 'n/a' : String(info.httpStatus);
+  const perm =
+    info.platformPermission && String(info.platformPermission).trim()
+      ? String(info.platformPermission).trim()
+      : 'unavailable';
+  return `DENY: pre-store attestation failed capability=${capability} http=${httpStatus} platform_permission=${perm}`;
 }
 
 /** Base64url without padding (PKCE / OAuth). */
@@ -313,10 +357,9 @@ export function validateCallbackRequest({
  * `attestPreStoreCapabilities` before any durable token write.
  *
  * When present: fail-closed ⊆ ALLOWED_SCOPES (`projects:read` + `database:read`
- * only). No invented normalization (e.g. projects.read / rest). `projects:read`
- * remains mandatory when scope is present; `database:read` is allowed (required
- * at the Management API for catalog read-only) but not forced here because the
- * platform may omit the scope field entirely.
+ * only). No invented normalization (e.g. projects.read / rest). Both
+ * `projects:read` and `database:read` are mandatory when scope is present.
+ * When omitted, dual pre-store capability attestation is required instead.
  */
 export function assertTokenScopes(scopeField) {
   if (scopeField === undefined || scopeField === null || String(scopeField).trim() === '') {
@@ -346,6 +389,12 @@ export function assertTokenScopes(scopeField) {
       'MISSING_PROJECTS_READ'
     );
   }
+  if (!parts.includes('database:read')) {
+    throw new OAuthHelperError(
+      'DENY: token response scope must include database:read',
+      'MISSING_DATABASE_READ'
+    );
+  }
   return { omitted: false, scopes: parts, platformAttestedOmission: false };
 }
 
@@ -361,11 +410,14 @@ export function attestationOutOfCeilingPath(ref = PRODUCTION_PROJECT_REF) {
  * Pre-store capability attestation with the ephemeral access token.
  * Required before any durable env/token write (especially when scope is omitted).
  *
- * - Allowlisted GET /v1/projects/{production_ref} must succeed
- * - At least one out-of-ceiling probe (api-keys) must NOT succeed
- * Fail → do not store tokens.
+ * Both must succeed (fail-closed; no store on either failure):
+ * - Allowlisted GET /v1/projects/{production_ref} → Projects Read / project_admin_read
+ * - Bounded catalog POST .../database/query/read-only (adapter-owned SELECT) →
+ *   Database Read / database_read
+ * - Out-of-ceiling probe (api-keys) must NOT succeed
  *
- * Reuses adapter allowlist/deny helpers; fetch is injected (no live network in tests).
+ * Reuses adapter allowlist/deny + catalog templates; fetch is injected (no live
+ * network in tests). Never logs tokens or row payloads.
  */
 export async function attestPreStoreCapabilities(
   accessToken,
@@ -373,6 +425,7 @@ export async function attestPreStoreCapabilities(
     fetchImpl = globalThis.fetch,
     resolveAllowedPathFn,
     assertNotProhibitedFn,
+    resolveCatalogSqlFn,
     managementApiBase = 'https://api.supabase.com',
   } = {}
 ) {
@@ -388,10 +441,15 @@ export async function attestPreStoreCapabilities(
 
   let resolveAllowedPath = resolveAllowedPathFn;
   let assertNotProhibited = assertNotProhibitedFn;
+  let resolveCatalogSql = resolveCatalogSqlFn;
+  const catalogOps = await import('./catalog-ops.mjs');
   if (!resolveAllowedPath || !assertNotProhibited) {
     const adapter = await import('./adapter.mjs');
     resolveAllowedPath = resolveAllowedPath || adapter.resolveAllowedPath;
     assertNotProhibited = assertNotProhibited || adapter.assertNotProhibited;
+  }
+  if (!resolveCatalogSql) {
+    resolveCatalogSql = catalogOps.resolveCatalogSql;
   }
 
   const { method, path: allowPath, ref } = resolveAllowedPath('project_status', {});
@@ -399,6 +457,29 @@ export async function attestPreStoreCapabilities(
     throw new OAuthHelperError(
       'DENY: attestation allowlisted path mismatch',
       'ATTEST_ALLOW_PATH'
+    );
+  }
+
+  const catalogPath = `/v1/projects/${ref}${catalogOps.READ_ONLY_QUERY_PATH_SUFFIX}`;
+  try {
+    assertNotProhibited(catalogPath, { allowCatalogReadOnly: true });
+  } catch {
+    throw new OAuthHelperError(
+      'DENY: attestation catalog path rejected by allowlist',
+      'ATTEST_CATALOG_PATH'
+    );
+  }
+
+  let catalogResolved;
+  try {
+    catalogResolved = resolveCatalogSql('catalog_relation_exists', {
+      schema: 'public',
+      table: 'estimates',
+    });
+  } catch {
+    throw new OAuthHelperError(
+      'DENY: attestation catalog template resolution failed',
+      'ATTEST_CATALOG_TEMPLATE'
     );
   }
 
@@ -425,20 +506,75 @@ export async function attestPreStoreCapabilities(
     Accept: 'application/json',
   };
 
+  async function readBodySafe(res) {
+    if (!res || typeof res.text !== 'function') return '';
+    try {
+      const t = await res.text();
+      return typeof t === 'string' ? t.slice(0, 500) : '';
+    } catch {
+      return '';
+    }
+  }
+
   let allowRes;
   try {
     allowRes = await fetchImpl(`${base}${allowPath}`, { method, headers });
   } catch {
     throw new OAuthHelperError(
-      'DENY: pre-store capability attestation failed (allowlisted GET unreachable)',
-      'ATTEST_ALLOW_FAILED'
+      formatAttestationFailure({
+        capability: 'projects_read',
+        httpStatus: 'unreachable',
+        platformPermission: null,
+      }),
+      'ATTEST_ALLOW_FAILED',
+      { capability: 'projects_read', httpStatus: 'unreachable', platformPermission: null }
     );
   }
   if (!allowRes || !allowRes.ok) {
     const status = allowRes && typeof allowRes.status === 'number' ? allowRes.status : 'n/a';
+    const body = await readBodySafe(allowRes);
+    const platformPermission = extractPlatformPermission(body);
     throw new OAuthHelperError(
-      `DENY: pre-store capability attestation failed (allowlisted GET HTTP ${status})`,
-      'ATTEST_ALLOW_FAILED'
+      formatAttestationFailure({
+        capability: 'projects_read',
+        httpStatus: status,
+        platformPermission,
+      }),
+      'ATTEST_ALLOW_FAILED',
+      { capability: 'projects_read', httpStatus: status, platformPermission }
+    );
+  }
+
+  let catalogRes;
+  try {
+    catalogRes = await fetchImpl(`${base}${catalogPath}`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: catalogResolved.sql }),
+    });
+  } catch {
+    throw new OAuthHelperError(
+      formatAttestationFailure({
+        capability: 'database_read',
+        httpStatus: 'unreachable',
+        platformPermission: null,
+      }),
+      'ATTEST_CATALOG_FAILED',
+      { capability: 'database_read', httpStatus: 'unreachable', platformPermission: null }
+    );
+  }
+  if (!catalogRes || !catalogRes.ok) {
+    const status = catalogRes && typeof catalogRes.status === 'number' ? catalogRes.status : 'n/a';
+    const body = await readBodySafe(catalogRes);
+    const platformPermission = extractPlatformPermission(body);
+    throw new OAuthHelperError(
+      formatAttestationFailure({
+        capability: 'database_read',
+        httpStatus: status,
+        platformPermission,
+      }),
+      'ATTEST_CATALOG_FAILED',
+      { capability: 'database_read', httpStatus: status, platformPermission }
     );
   }
 
@@ -460,8 +596,11 @@ export async function attestPreStoreCapabilities(
 
   return {
     allowlistedOk: true,
+    catalogOk: true,
     outOfCeilingDenied: true,
     allowPath,
+    catalogPath,
+    catalogOperation: catalogResolved.operation,
     probePath,
   };
 }

--- a/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/oauth-helper.self-test.mjs
@@ -28,6 +28,8 @@ import {
   assertTokenScopes,
   attestPreStoreCapabilities,
   attestationOutOfCeilingPath,
+  extractPlatformPermission,
+  formatAttestationFailure,
   computeExpiryIso,
   writeTokenSecretsToEnvFile,
   wipeTransient,
@@ -42,6 +44,7 @@ import {
   resolveWindowsBrowserExecutable,
   callbackListenArgs,
 } from './oauth-helper.mjs';
+import { READ_ONLY_QUERY_PATH_SUFFIX, resolveCatalogSql } from './catalog-ops.mjs';
 
 function pass(results, test, ok, detail) {
   results.push({ test, pass: Boolean(ok), ...(detail ? { detail: String(detail).slice(0, 120) } : {}) });
@@ -214,6 +217,18 @@ export async function runSelfTests() {
   } catch (e) {
     pass(results, 'database_write_rejected', e.code === 'UNEXPECTED_SCOPE');
   }
+  try {
+    assertTokenScopes('projects:read');
+    pass(results, 'projects_read_without_database_read_denied', false);
+  } catch (e) {
+    pass(results, 'projects_read_without_database_read_denied', e.code === 'MISSING_DATABASE_READ');
+  }
+  try {
+    assertTokenScopes('database:read');
+    pass(results, 'database_read_without_projects_read_denied', false);
+  } catch (e) {
+    pass(results, 'database_read_without_projects_read_denied', e.code === 'MISSING_PROJECTS_READ');
+  }
   const omitted = assertTokenScopes('');
   const omittedUndef = assertTokenScopes(undefined);
   pass(
@@ -225,16 +240,40 @@ export async function runSelfTests() {
       Array.isArray(omitted.scopes) &&
       omitted.scopes.length === 0
   );
-  pass(results, 'allowed_scope_ok', assertTokenScopes('projects:read').scopes.includes('projects:read'));
   const both = assertTokenScopes('projects:read database:read');
   pass(
     results,
     'allowed_scopes_projects_and_database_read',
     both.scopes.includes('projects:read') && both.scopes.includes('database:read')
   );
+  pass(
+    results,
+    'extract_platform_permission',
+    extractPlatformPermission(
+      'OAuth token missing required scopes (project_admin_read) for GET /v1/projects/x'
+    ) === 'project_admin_read'
+  );
+  pass(
+    results,
+    'format_attestation_failure_safe',
+    formatAttestationFailure({
+      capability: 'projects_read',
+      httpStatus: 403,
+      platformPermission: 'project_admin_read',
+    }) ===
+      'DENY: pre-store attestation failed capability=projects_read http=403 platform_permission=project_admin_read' &&
+      !/eyJ|Bearer|access_token|refresh_token/i.test(
+        formatAttestationFailure({
+          capability: 'database_read',
+          httpStatus: 403,
+          platformPermission: 'database_read',
+        })
+      )
+  );
 
   // --- pre-store capability attestation (injected fetch; no live network) ---
   const allowPath = `/v1/projects/${PRODUCTION_PROJECT_REF}`;
+  const catalogPath = `/v1/projects/${PRODUCTION_PROJECT_REF}${READ_ONLY_QUERY_PATH_SUFFIX}`;
   const probePath = attestationOutOfCeilingPath();
   pass(
     results,
@@ -248,46 +287,151 @@ export async function runSelfTests() {
     ref: PRODUCTION_PROJECT_REF,
     operation: 'project_status',
   });
-  const mockAssertProhibited = (p) => {
-    if (String(p).includes('/api-keys')) {
+  const mockAssertProhibited = (p, opts = {}) => {
+    const s = String(p);
+    if (s.includes('/api-keys')) {
       throw new Error(`DENY: prohibited path pattern "/api-keys" in ${p}`);
     }
+    if (s.includes('/database/query') && !s.endsWith('/database/query/read-only')) {
+      throw new Error(`DENY: writable database query prohibited`);
+    }
+    if (s.endsWith('/database/query/read-only') && !opts.allowCatalogReadOnly) {
+      throw new Error('DENY: catalog read-only requires allowCatalogReadOnly');
+    }
   };
+  const mockResolveCatalog = (op, params) => resolveCatalogSql(op, params);
+  const jsonRes = (ok, status, body = '') => ({
+    ok,
+    status,
+    text: async () => body,
+  });
 
   try {
     await attestPreStoreCapabilities('tok_ephemeral_attest_ok', {
-      fetchImpl: async (url) => {
-        if (String(url).endsWith(allowPath)) return { ok: true, status: 200 };
-        if (String(url).endsWith(probePath)) return { ok: false, status: 403 };
-        return { ok: false, status: 404 };
+      fetchImpl: async (url, init) => {
+        const u = String(url);
+        if (u.endsWith(allowPath) && (!init || init.method === 'GET' || !init.method)) {
+          return jsonRes(true, 200);
+        }
+        if (u.endsWith(catalogPath) && init && init.method === 'POST') {
+          const body = typeof init.body === 'string' ? init.body : '';
+          if (!body.includes('"query"') || /INSERT|UPDATE|DELETE/i.test(body)) {
+            return jsonRes(false, 400, 'bad catalog body');
+          }
+          return jsonRes(true, 201);
+        }
+        if (u.endsWith(probePath)) return jsonRes(false, 403);
+        return jsonRes(false, 404);
       },
       resolveAllowedPathFn: mockResolveAllowed,
       assertNotProhibitedFn: mockAssertProhibited,
+      resolveCatalogSqlFn: mockResolveCatalog,
     });
-    pass(results, 'attestation_allow_ok_probe_denied', true);
+    pass(results, 'attestation_dual_ok_probe_denied', true);
   } catch (e) {
-    pass(results, 'attestation_allow_ok_probe_denied', false, e && e.message);
+    pass(results, 'attestation_dual_ok_probe_denied', false, e && e.message);
   }
 
   try {
-    await attestPreStoreCapabilities('tok_ephemeral_attest_allow_fail', {
-      fetchImpl: async (url) => {
-        if (String(url).endsWith(allowPath)) return { ok: false, status: 401 };
-        return { ok: false, status: 403 };
+    await attestPreStoreCapabilities('tok_ephemeral_projects_only', {
+      fetchImpl: async (url, init) => {
+        const u = String(url);
+        if (u.endsWith(allowPath)) return jsonRes(true, 200);
+        if (u.endsWith(catalogPath)) {
+          return jsonRes(
+            false,
+            403,
+            'OAuth token missing required scopes (database_read) for POST catalog'
+          );
+        }
+        return jsonRes(false, 403);
       },
       resolveAllowedPathFn: mockResolveAllowed,
       assertNotProhibitedFn: mockAssertProhibited,
+      resolveCatalogSqlFn: mockResolveCatalog,
+    });
+    pass(results, 'attestation_projects_without_database_denied', false);
+  } catch (e) {
+    pass(
+      results,
+      'attestation_projects_without_database_denied',
+      e.code === 'ATTEST_CATALOG_FAILED' &&
+        e.capability === 'database_read' &&
+        e.platformPermission === 'database_read' &&
+        e.httpStatus === 403
+    );
+  }
+
+  try {
+    await attestPreStoreCapabilities('tok_ephemeral_database_only', {
+      fetchImpl: async (url) => {
+        const u = String(url);
+        if (u.endsWith(allowPath)) {
+          return jsonRes(
+            false,
+            403,
+            'OAuth token missing required scopes (project_admin_read) for GET project'
+          );
+        }
+        if (u.endsWith(catalogPath)) return jsonRes(true, 201);
+        return jsonRes(false, 403);
+      },
+      resolveAllowedPathFn: mockResolveAllowed,
+      assertNotProhibitedFn: mockAssertProhibited,
+      resolveCatalogSqlFn: mockResolveCatalog,
+    });
+    pass(results, 'attestation_database_without_projects_denied', false);
+  } catch (e) {
+    pass(
+      results,
+      'attestation_database_without_projects_denied',
+      e.code === 'ATTEST_ALLOW_FAILED' &&
+        e.capability === 'projects_read' &&
+        e.platformPermission === 'project_admin_read' &&
+        e.httpStatus === 403
+    );
+  }
+
+  let writeCalledAfterFail = false;
+  try {
+    await attestPreStoreCapabilities('tok_ephemeral_attest_allow_fail', {
+      fetchImpl: async (url) => {
+        if (String(url).endsWith(allowPath)) return jsonRes(false, 401);
+        return jsonRes(false, 403);
+      },
+      resolveAllowedPathFn: mockResolveAllowed,
+      assertNotProhibitedFn: mockAssertProhibited,
+      resolveCatalogSqlFn: mockResolveCatalog,
+    });
+    writeCalledAfterFail = true;
+    writeTokenSecretsToEnvFile({
+      filePath: path.join(os.tmpdir(), 'should-not-write.env'),
+      existingMap: {},
+      accessToken: 'should-not-store',
+      refreshToken: 'should-not-store',
+      tokenExpiry: new Date().toISOString(),
+      writeFileSync: () => {
+        writeCalledAfterFail = true;
+      },
+      renameSync: () => {},
+      mkdirSync: () => {},
     });
     pass(results, 'attestation_allow_fail_no_store', false);
   } catch (e) {
-    pass(results, 'attestation_allow_fail_no_store', e.code === 'ATTEST_ALLOW_FAILED');
+    pass(
+      results,
+      'attestation_allow_fail_no_store',
+      e.code === 'ATTEST_ALLOW_FAILED' && writeCalledAfterFail === false
+    );
+    pass(results, 'token_material_absent_after_failed_attestation', writeCalledAfterFail === false);
   }
 
   try {
     await attestPreStoreCapabilities('tok_ephemeral_attest_ceiling', {
-      fetchImpl: async () => ({ ok: true, status: 200 }),
+      fetchImpl: async () => jsonRes(true, 200),
       resolveAllowedPathFn: mockResolveAllowed,
       assertNotProhibitedFn: mockAssertProhibited,
+      resolveCatalogSqlFn: mockResolveCatalog,
     });
     pass(results, 'attestation_ceiling_breach_denied', false);
   } catch (e) {


### PR DESCRIPTION
## Summary
- Pre-store attestation requires both `project_status` (Projects Read / `project_admin_read`) and bounded `catalog_relation_exists` (Database Read / `database_read`) before any durable token write.
- Safe failure reports capability + HTTP status + platform permission only (no secrets).
- Present token scopes must include both `projects:read` and `database:read`; Write and other scopes remain DENY.
- UX copy: Projects Read + Database Read only.

## Test plan
- [x] `npm run test:supabase-oauth-helper`
- [x] `npm run test:supabase-diagnostics-adapter`
- [ ] CI green
- [ ] Security Guard + Architecture Guard at frozen head
- [ ] After merge: pin diagnostics worktree; Founder re-consent only after Dashboard confirms both scopes

## Explicit non-goals
R-S1-01 apply · deploy · Slice 2 · Database Write · execute-sql · service-role · broader scopes

Decision packet: `command-center/docs/governance/decisions/I2_OAUTH_DUAL_ATTEST_DECISION_PACKET.md`

Made with [Cursor](https://cursor.com)