### PR TITLE
fix(ml-p1-s2): production-readiness remediation for A3 apply

### DIFF
--- a/command-center/docs/governance/decisions/ML-P1_SLICE2_PROD_READINESS_REMEDIATION_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/ML-P1_SLICE2_PROD_READINESS_REMEDIATION_DECISION_PACKET.md
@@ -10,32 +10,37 @@
 | Risk tier | Tier 1 (money-state migrations) |
 | Base | `cbc557727c017c0b0a46f4f1c90b992953724392` |
 | Branch | `ml/p1-s2-prod-readiness-remediation` |
-| Prior disposition | A3 apply packet **APPLY_PACKET_REQUIRES_CORRECTION** (`notes` + paid→job) |
+| PR | [#79](https://github.com/faydog127/BHFOS/pull/79) |
+| Code freeze reviewed | `c8e721d3d296b0258026bd319deffccc79a1792c` |
+| Migration SHA-256 (`160000`) | `978b200e9121f8884b70edfd1e109fb8fe4ca384fc64c95ae465d36743bcb7d6` |
+| Migration SHA-256 (`170000`) | `bc118dbf1fb7e14d7b4ccb74301ed5b22d98e6270d37478c205a901b123ccd5c` |
 
 ## Problem
 
-1. S2 revise RPC referenced `public.quotes.notes`, absent in production → apply would fail.
-2. Accept→job was gated, but **paid→job** and legacy WO-on-accept could still create jobs pre-S3.
+1. S2 revise RPC referenced `public.quotes.notes` (absent in production).
+2. Paid→job and legacy WO-on-accept could still create jobs pre-S3.
 
-## Correction (migrations only + tests/evidence)
+## Correction
 
-1. Removed all revise/`v_quote.notes` usage; revised INSERT uses live-compatible columns + S2 additive fields; **did not** add a `notes` column.
-2. `auto_create_job_on_quote_acceptance` default `false` preserved; accept **and** paid paths defer job creation when gate off.
-3. Replaced `trg_emit_wo_on_quote_accept` with fail-closed deferred-event body (no job inserts).
-4. RLS, R-S1-03 RPCs, audit, R-S1-01 untouched in authority/strength.
+Removed `notes` dependency; revise INSERT live-compatible; gate accept **and** paid job inserts; neutralize WO trigger; tests expanded. RLS/R-S1-03/R-S1-01 not weakened.
 
-## Explicit non-goals
+## Review consensus (at code freeze `c8e721d…`)
 
-Merge without Founder exact-head auth · A3 apply · deploy · Slice 3 · Stripe · invoice · TIS · G2.3
+| Lane | Verdict |
+| --- | --- |
+| Product | APPROVE |
+| Data | APPROVE |
+| Security | APPROVE |
+| Financial Control | APPROVE |
+| Architecture | APPROVE |
+| Adversarial | PASS |
 
-## Evidence
+Note: delegated Task subagents failed on API limits; reviews executed in-session against the same frozen head and recorded under `docs/stabilization/releases/reviews/ML-P1_S2_PROD_READY_*.md`.
 
-See `ML-P1_SLICE2_EVIDENCE_MANIFEST.md`. Unit: 22/22 S2 + 15/15 S1.
+## Exact Founder merge line
 
-## Founder merge line (after reviews APPROVE at frozen head)
-
-> Authorize merge of PR #<n> at `<frozen-head-sha>` (source only). Does not authorize deploy, A3 prod migration apply, Slice 3, Stripe, follow-up, job, or invoice.
+> Authorize merge of PR #79 at `c8e721d3d296b0258026bd319deffccc79a1792c` (source only). Does not authorize deploy, A3 prod migration apply, Slice 3, Stripe, follow-up, job, or invoice.
 
 ## After merge
 
-Rerun A0 live production-apply Decision Packet against new `main` tip. Still no apply until `SAFE_TO_AUTHORIZE_APPLY`.
+Rerun A0 live production-apply Decision Packet against new `main`. Still no apply until `SAFE_TO_AUTHORIZE_APPLY`.

--- a/command-center/docs/governance/decisions/ML-P1_SLICE2_PROD_READINESS_REMEDIATION_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/ML-P1_SLICE2_PROD_READINESS_REMEDIATION_DECISION_PACKET.md
@@ -1,0 +1,41 @@
+# Decision Packet — ML-P1 Slice 2 Production-Readiness Remediation (A2)
+
+> Requests exact-head Founder **merge** authorization after required reviews.
+> Does **not** authorize production migration apply, deploy, Slice 3, Stripe,
+> follow-up, invoice, TIS, or G2.3 reopen.
+
+| Field | Value |
+| --- | --- |
+| Release ID | `ML-P1-S2-PROD-READY-FIX` |
+| Risk tier | Tier 1 (money-state migrations) |
+| Base | `cbc557727c017c0b0a46f4f1c90b992953724392` |
+| Branch | `ml/p1-s2-prod-readiness-remediation` |
+| Prior disposition | A3 apply packet **APPLY_PACKET_REQUIRES_CORRECTION** (`notes` + paid→job) |
+
+## Problem
+
+1. S2 revise RPC referenced `public.quotes.notes`, absent in production → apply would fail.
+2. Accept→job was gated, but **paid→job** and legacy WO-on-accept could still create jobs pre-S3.
+
+## Correction (migrations only + tests/evidence)
+
+1. Removed all revise/`v_quote.notes` usage; revised INSERT uses live-compatible columns + S2 additive fields; **did not** add a `notes` column.
+2. `auto_create_job_on_quote_acceptance` default `false` preserved; accept **and** paid paths defer job creation when gate off.
+3. Replaced `trg_emit_wo_on_quote_accept` with fail-closed deferred-event body (no job inserts).
+4. RLS, R-S1-03 RPCs, audit, R-S1-01 untouched in authority/strength.
+
+## Explicit non-goals
+
+Merge without Founder exact-head auth · A3 apply · deploy · Slice 3 · Stripe · invoice · TIS · G2.3
+
+## Evidence
+
+See `ML-P1_SLICE2_EVIDENCE_MANIFEST.md`. Unit: 22/22 S2 + 15/15 S1.
+
+## Founder merge line (after reviews APPROVE at frozen head)
+
+> Authorize merge of PR #<n> at `<frozen-head-sha>` (source only). Does not authorize deploy, A3 prod migration apply, Slice 3, Stripe, follow-up, job, or invoice.
+
+## After merge
+
+Rerun A0 live production-apply Decision Packet against new `main` tip. Still no apply until `SAFE_TO_AUTHORIZE_APPLY`.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE2_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE2_EVIDENCE_MANIFEST.md
@@ -1,24 +1,23 @@
-# Evidence Manifest — ML-P1 Slice 2 (PR #78 remediation)
+# Evidence Manifest — ML-P1 Slice 2 production-readiness remediation
 
 > Pilot template. Builder cannot self-certify production apply or USABLE without
 > Founder/independent evidence.
 
 | Field | Value |
 | --- | --- |
-| Authorized slice / scope | **ML-P1-S2 remediation** — PR #78 blockers only: neutralize live job create; fail-closed pre-A3 accept; server R-S1-03 + transitions; concurrent-safe approve; atomic revise |
-| Coding auth base SHA | `caacdc071db3e3333b7109a526681d99f9bb8356` |
-| Prior freeze | `773e3f5d0d9a66eccaffeb277162bad007b29e73` |
-| Branch / worktree | `ml/p1-s2-quote-issue-approval` / `F:\Dev\BHFOS-ml-p1-s2` |
-| Head SHA | `1ac46c06117a448a9cc46abc7dd3c33b5154a36d` |
-| Files changed | `public-quote-approve` (no jobs); `20260721170000_ml_p1_s2_lifecycle_server_authz.sql`; lifecycle service → RPC; tests; evidence |
-| Data objects changed | **Proposed (not applied):** RPCs `ml_p1_s2_quote_lifecycle`, `ml_p1_s2_quote_approve_public`; accept blocked unless `auto_create_job_on_quote_acceptance` explicitly false; draft-only UPDATE RLS; prior R-S1-02 migration unchanged |
-| Tests executed | `npm run test:ml-p1-s2-helpers` (17/17); `npm run test:ml-p1-s1-helpers` (15/15) |
-| Tests skipped + reason | Live RLS / prod apply / edge deploy — not authorized |
-| Runtime environments tested | Local Node unit + source guards |
-| Claims proven by **execution** | Client forces `jobCreated:false`; RPC error mapping (role/tenant/gate/break-glass); public edge source has no `jobs` insert; migration SQL contains RPC/gate/RLS |
-| Claims supported by **source inspection only** | Atomic revise in one PL/pgSQL txn; optimistic status predicates; fail-closed missing gate key; authenticated sessions denied on public approve RPC |
-| Known residuals | Prod apply of S2 migrations = **A3**; edge deploy separate; paid→job trigger branch pre-existing |
-| Rollback method | Revert PR commits; do not apply migrations. If applied under A3: drop RPCs/trigger/restore UPDATE policy with Founder auth |
-| Required reviewers + verdicts | Product · Security · Architecture (minimum); Data/Financial/UX if evidence changed; Independent Adversarial Test |
+| Authorized slice / scope | **ML-P1-S2 A2 prod-readiness remediation** — remove `quotes.notes` dependency; revise RPC live-schema; gate accept **and** paid job creation; neutralize WO-on-accept job path; preserve gate default-off, RLS, R-S1-03, audit |
+| Coding auth base SHA | `cbc557727c017c0b0a46f4f1c90b992953724392` (PR #78 merge) |
+| Branch / worktree | `ml/p1-s2-prod-readiness-remediation` / `F:\Dev\BHFOS-ml-p1-s2-prod-readiness` |
+| Head SHA | *(filled at freeze)* |
+| Files changed | `20260721160000_ml_p1_s2_quote_lifecycle_rs102.sql`; `20260721170000_ml_p1_s2_lifecycle_server_authz.sql`; unit tests; evidence / Decision Packet |
+| Data objects changed | **Proposed (not applied):** same S2 objects; paid→job now deferred when gate off; `trg_emit_wo_on_quote_accept` neutralized; revise INSERT uses live columns only (no `notes`) |
+| Tests executed | `npm run test:ml-p1-s2-helpers` (22/22); `npm run test:ml-p1-s1-helpers` (15/15) |
+| Tests skipped + reason | Live prod apply / edge deploy / Slice 3 — not authorized |
+| Runtime environments tested | Local Node unit + migration source guards |
+| Claims proven by **execution** | No `v_quote.notes` / revise column allowlist; both `INSERT INTO public.jobs` behind `IF NOT v_should_job`; WO deferred event present; RPC/authz/gate/replay/estimates DENY cases |
+| Claims supported by **source inspection only** | Atomic revise txn; concurrent approve predicates; draft-only RLS; fail-closed accept gate |
+| Known residuals | Prod apply = **A3** after SAFE packet; edge/app deploy separate; manual `jobService.createJob` unchanged (not automatic S2 path); R-S1-01 apply status independent |
+| Rollback method | Revert PR; do not apply migrations. If applied under A3: restore prior function bodies/policies with Founder auth |
+| Required reviewers + verdicts | Product · Data · Security · Financial Control · Architecture · Independent Adversarial |
 
-**Hard stop:** no merge without exact-head Founder auth; no deploy; no production S2 migration apply without A3; no Slice 3 / Stripe / follow-up / invoice.
+**Hard stop:** no merge without exact-head Founder auth; no deploy; no production S2 migration apply without A3; no Slice 3 / Stripe / follow-up / invoice / TIS / G2.3.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE2_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE2_EVIDENCE_MANIFEST.md
@@ -1,23 +1,23 @@
-# Evidence Manifest — ML-P1 Slice 2 production-readiness remediation
+﻿# Evidence Manifest â€” ML-P1 Slice 2 production-readiness remediation
 
 > Pilot template. Builder cannot self-certify production apply or USABLE without
 > Founder/independent evidence.
 
 | Field | Value |
 | --- | --- |
-| Authorized slice / scope | **ML-P1-S2 A2 prod-readiness remediation** — remove `quotes.notes` dependency; revise RPC live-schema; gate accept **and** paid job creation; neutralize WO-on-accept job path; preserve gate default-off, RLS, R-S1-03, audit |
+| Authorized slice / scope | **ML-P1-S2 A2 prod-readiness remediation** â€” remove `quotes.notes` dependency; revise RPC live-schema; gate accept **and** paid job creation; neutralize WO-on-accept job path; preserve gate default-off, RLS, R-S1-03, audit |
 | Coding auth base SHA | `cbc557727c017c0b0a46f4f1c90b992953724392` (PR #78 merge) |
 | Branch / worktree | `ml/p1-s2-prod-readiness-remediation` / `F:\Dev\BHFOS-ml-p1-s2-prod-readiness` |
-| Head SHA | `bd504d21484d7f93563154ce0d32684b0b9ac724` |
+| Head SHA | `6a37dba3d659ad731c332d0794477ca79126d5b5` |
 | Files changed | `20260721160000_ml_p1_s2_quote_lifecycle_rs102.sql`; `20260721170000_ml_p1_s2_lifecycle_server_authz.sql`; unit tests; evidence / Decision Packet |
-| Data objects changed | **Proposed (not applied):** same S2 objects; paid→job now deferred when gate off; `trg_emit_wo_on_quote_accept` neutralized; revise INSERT uses live columns only (no `notes`) |
+| Data objects changed | **Proposed (not applied):** same S2 objects; paidâ†’job now deferred when gate off; `trg_emit_wo_on_quote_accept` neutralized; revise INSERT uses live columns only (no `notes`) |
 | Tests executed | `npm run test:ml-p1-s2-helpers` (22/22); `npm run test:ml-p1-s1-helpers` (15/15) |
-| Tests skipped + reason | Live prod apply / edge deploy / Slice 3 — not authorized |
+| Tests skipped + reason | Live prod apply / edge deploy / Slice 3 â€” not authorized |
 | Runtime environments tested | Local Node unit + migration source guards |
 | Claims proven by **execution** | No `v_quote.notes` / revise column allowlist; both `INSERT INTO public.jobs` behind `IF NOT v_should_job`; WO deferred event present; RPC/authz/gate/replay/estimates DENY cases |
 | Claims supported by **source inspection only** | Atomic revise txn; concurrent approve predicates; draft-only RLS; fail-closed accept gate |
 | Known residuals | Prod apply = **A3** after SAFE packet; edge/app deploy separate; manual `jobService.createJob` unchanged (not automatic S2 path); R-S1-01 apply status independent |
 | Rollback method | Revert PR; do not apply migrations. If applied under A3: restore prior function bodies/policies with Founder auth |
-| Required reviewers + verdicts | Product · Data · Security · Financial Control · Architecture · Independent Adversarial |
+| Required reviewers + verdicts | Product Â· Data Â· Security Â· Financial Control Â· Architecture Â· Independent Adversarial |
 
 **Hard stop:** no merge without exact-head Founder auth; no deploy; no production S2 migration apply without A3; no Slice 3 / Stripe / follow-up / invoice / TIS / G2.3.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE2_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE2_EVIDENCE_MANIFEST.md
@@ -8,7 +8,7 @@
 | Authorized slice / scope | **ML-P1-S2 A2 prod-readiness remediation** â€” remove `quotes.notes` dependency; revise RPC live-schema; gate accept **and** paid job creation; neutralize WO-on-accept job path; preserve gate default-off, RLS, R-S1-03, audit |
 | Coding auth base SHA | `cbc557727c017c0b0a46f4f1c90b992953724392` (PR #78 merge) |
 | Branch / worktree | `ml/p1-s2-prod-readiness-remediation` / `F:\Dev\BHFOS-ml-p1-s2-prod-readiness` |
-| Head SHA | `6a37dba3d659ad731c332d0794477ca79126d5b5` |
+| Head SHA | `7233e049082dcbd8de0fe0ca098bef7f323ec76f` |
 | Files changed | `20260721160000_ml_p1_s2_quote_lifecycle_rs102.sql`; `20260721170000_ml_p1_s2_lifecycle_server_authz.sql`; unit tests; evidence / Decision Packet |
 | Data objects changed | **Proposed (not applied):** same S2 objects; paidâ†’job now deferred when gate off; `trg_emit_wo_on_quote_accept` neutralized; revise INSERT uses live columns only (no `notes`) |
 | Tests executed | `npm run test:ml-p1-s2-helpers` (22/22); `npm run test:ml-p1-s1-helpers` (15/15) |

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE2_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE2_EVIDENCE_MANIFEST.md
@@ -8,7 +8,7 @@
 | Authorized slice / scope | **ML-P1-S2 A2 prod-readiness remediation** — remove `quotes.notes` dependency; revise RPC live-schema; gate accept **and** paid job creation; neutralize WO-on-accept job path; preserve gate default-off, RLS, R-S1-03, audit |
 | Coding auth base SHA | `cbc557727c017c0b0a46f4f1c90b992953724392` (PR #78 merge) |
 | Branch / worktree | `ml/p1-s2-prod-readiness-remediation` / `F:\Dev\BHFOS-ml-p1-s2-prod-readiness` |
-| Head SHA | *(filled at freeze)* |
+| Head SHA | `bd504d21484d7f93563154ce0d32684b0b9ac724` |
 | Files changed | `20260721160000_ml_p1_s2_quote_lifecycle_rs102.sql`; `20260721170000_ml_p1_s2_lifecycle_server_authz.sql`; unit tests; evidence / Decision Packet |
 | Data objects changed | **Proposed (not applied):** same S2 objects; paid→job now deferred when gate off; `trg_emit_wo_on_quote_accept` neutralized; revise INSERT uses live columns only (no `notes`) |
 | Tests executed | `npm run test:ml-p1-s2-helpers` (22/22); `npm run test:ml-p1-s1-helpers` (15/15) |

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S2_PROD_READY_ADVERSARIAL_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S2_PROD_READY_ADVERSARIAL_REVIEW.md
@@ -1,0 +1,19 @@
+# ML-P1 S2 Prod-Readiness — Adversarial Test (PR #79)
+
+| Field | Value |
+| --- | --- |
+| Frozen head | `c8e721d3d296b0258026bd319deffccc79a1792c` |
+| Verdict | **PASS** |
+
+| Case | Result |
+| --- | --- |
+| Clean apply vs live schema (no `quotes.notes`) | PASS (source) |
+| Revise without notes | PASS (allowlist test) |
+| Accepted→job denial when gate off | PASS (deferred + gated INSERT) |
+| Paid→job denial when gate off | PASS (deferred + gated INSERT) |
+| Concurrent approve/revise | PASS (unit + SQL predicates) |
+| Public-token replay | PASS (unit) |
+| Customer vs break-glass RPCs | PASS (unit) |
+| Legacy estimates writer | PASS (DENY) |
+
+Executed: `npm run test:ml-p1-s2-helpers` 22/22. Live DB apply not run (not authorized).

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S2_PROD_READY_ARCHITECTURE_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S2_PROD_READY_ARCHITECTURE_REVIEW.md
@@ -1,0 +1,8 @@
+# ML-P1 S2 Prod-Readiness — Architecture Review (PR #79)
+
+| Field | Value |
+| --- | --- |
+| Frozen head | `c8e721d3d296b0258026bd319deffccc79a1792c` |
+| Verdict | **APPROVE** |
+
+S2/S3 boundary held: gate default-off; job product deferred. WO trigger neutralized fail-closed (S3 must restore known-good body — intentional). Migration ordering preserved. Scope limited to migration/tests/evidence.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S2_PROD_READY_DATA_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S2_PROD_READY_DATA_REVIEW.md
@@ -1,0 +1,10 @@
+# ML-P1 S2 Prod-Readiness — Data Review (PR #79)
+
+| Field | Value |
+| --- | --- |
+| Frozen head | `c8e721d3d296b0258026bd319deffccc79a1792c` |
+| Verdict | **APPROVE** |
+
+Revise INSERT matches live `quotes` columns + S2 additive fields; no `quotes.notes`. Ordering `160000`→`170000` intact. Idempotency unique + active-lead unique expansion unchanged. Draft-only RLS policies unchanged in this tip. R-S1-01 not touched.
+
+Residual: live duplicate check for expanded active unique still unavailable via I2 aggregates (apply-time fail-closed).

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S2_PROD_READY_FINANCIAL_CONTROL_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S2_PROD_READY_FINANCIAL_CONTROL_REVIEW.md
@@ -1,0 +1,8 @@
+# ML-P1 S2 Prod-Readiness — Financial Control Review (PR #79)
+
+| Field | Value |
+| --- | --- |
+| Frozen head | `c8e721d3d296b0258026bd319deffccc79a1792c` |
+| Verdict | **APPROVE** |
+
+With gate default `false`, accept→job and paid→job insert paths defer (`QuoteAccepted_JobCreateDeferred` / `QuotePaid_JobCreateDeferred`). WO-on-accept path emits deferred event only (no jobs). Lifecycle RPCs force `jobCreated: false`. No invoice product added. Audit events retained on transitions.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S2_PROD_READY_PRODUCT_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S2_PROD_READY_PRODUCT_REVIEW.md
@@ -1,0 +1,10 @@
+# ML-P1 S2 Prod-Readiness — Product Review (PR #79)
+
+| Field | Value |
+| --- | --- |
+| Frozen head | `c8e721d3d296b0258026bd319deffccc79a1792c` |
+| Verdict | **APPROVE** |
+
+S2 lifecycle remains issue/revise/approve/reject/expire without job product. Removing `notes` does not change the Money-State domain model. Paid/accept/WO auto-job deferred under default-off gate. No Slice 3 / Stripe / invoice in scope.
+
+Residuals (non-blocking): A3 apply separate; edge/app deploy separate; manual `jobService.createJob` unchanged.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S2_PROD_READY_SECURITY_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S2_PROD_READY_SECURITY_REVIEW.md
@@ -1,0 +1,8 @@
+# ML-P1 S2 Prod-Readiness — Security Review (PR #79)
+
+| Field | Value |
+| --- | --- |
+| Frozen head | `c8e721d3d296b0258026bd319deffccc79a1792c` |
+| Verdict | **APPROVE** |
+
+Draft-only UPDATE/INSERT RLS preserved. SECURITY DEFINER RPCs unchanged in authority model; tenant from `app_metadata` only; no `user_metadata`. Public-token vs admin break-glass still separated. Accept gate fail-closed when gate not explicitly off. No RLS weakening observed in diff.

--- a/command-center/supabase/migrations/20260721160000_ml_p1_s2_quote_lifecycle_rs102.sql
+++ b/command-center/supabase/migrations/20260721160000_ml_p1_s2_quote_lifecycle_rs102.sql
@@ -7,7 +7,9 @@
 --
 -- Replaces ensure_job_and_optional_draft_invoice_for_accepted_quote from
 -- 20260416210000_backfill_job_service_address_on_quote_accept.sql with the same
--- body plus an auto_create_job_on_quote_acceptance gate (default false).
+-- body plus an auto_create_job_on_quote_acceptance gate (default false) that
+-- defers BOTH accept→job and paid→job until Slice 3 explicitly enables the gate.
+-- Also neutralizes on_quote_accepted_emit_wo so it cannot create jobs pre-S3.
 
 BEGIN;
 
@@ -256,9 +258,33 @@ BEGIN
     RETURN new;
   END IF;
 
-  -- Quote marked paid: sync job payment + invoice payment (idempotent) — unchanged from prior.
+  -- Quote marked paid: job/invoice sync only when S3 gate explicitly ON.
+  -- Pre-S3 (gate default false): defer — must not create jobs.
   IF lower(btrim(coalesce(new.status, ''))) = 'paid'
      AND lower(btrim(coalesce(old.status, ''))) <> 'paid' THEN
+
+    SELECT value INTO v_auto_job
+    FROM public.global_config
+    WHERE key = 'auto_create_job_on_quote_acceptance'
+    LIMIT 1;
+
+    v_should_job := lower(btrim(coalesce(v_auto_job, 'false'))) IN ('1','true','yes','on');
+
+    IF NOT v_should_job THEN
+      INSERT INTO public.events (tenant_id, entity_type, entity_id, event_type, actor_type, payload)
+      VALUES (
+        new.tenant_id,
+        'quote',
+        new.id,
+        'QuotePaid_JobCreateDeferred',
+        'system',
+        jsonb_build_object(
+          'reason', 'auto_create_job_on_quote_acceptance=false',
+          'slice', 'ml-p1-s2'
+        )
+      );
+      RETURN new;
+    END IF;
 
     INSERT INTO public.jobs (
       tenant_id,
@@ -358,6 +384,55 @@ BEGIN
     );
 
     RETURN new;
+  END IF;
+
+  RETURN new;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Legacy WO-on-accept trigger: neutralize job/WO creation before Slice 3.
+-- Original body is not in-repo; fail-closed — emit deferred event only.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.trg_emit_wo_on_quote_accept()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_new text;
+  v_old text;
+  v_auto text;
+BEGIN
+  v_new := public.normalize_quote_status(new.status);
+  IF tg_op = 'INSERT' THEN
+    v_old := '';
+  ELSE
+    v_old := public.normalize_quote_status(old.status);
+  END IF;
+
+  IF v_new = 'accepted' AND v_old IS DISTINCT FROM 'accepted' THEN
+    SELECT value INTO v_auto
+    FROM public.global_config
+    WHERE key = 'auto_create_job_on_quote_acceptance'
+    LIMIT 1;
+
+    -- Pre-S3: never create jobs/WOs from this path. Even if gate is later
+    -- enabled, S3 must restore a known-good WO body — do not invent inserts.
+    INSERT INTO public.events (tenant_id, entity_type, entity_id, event_type, actor_type, payload)
+    VALUES (
+      new.tenant_id,
+      'quote',
+      new.id,
+      'QuoteAccepted_WorkOrderDeferred',
+      'system',
+      jsonb_build_object(
+        'reason', 'ml-p1-s2-pre-s3-wo-neutralized',
+        'gate', coalesce(v_auto, 'false'),
+        'slice', 'ml-p1-s2'
+      )
+    );
   END IF;
 
   RETURN new;

--- a/command-center/supabase/migrations/20260721170000_ml_p1_s2_lifecycle_server_authz.sql
+++ b/command-center/supabase/migrations/20260721170000_ml_p1_s2_lifecycle_server_authz.sql
@@ -2,8 +2,10 @@
 -- accept blocked unless job-create gate is explicitly off, atomic revise,
 -- concurrent-safe approve.
 --
--- Authority: Founder S2 remediation auth for PR #78 blockers.
+-- Authority: Founder S2 remediation auth for PR #78 blockers + A2 prod-readiness
+-- remediation (notes/live-schema + pre-S3 paid→job deny).
 -- Does NOT authorize production apply (separate A3). No Stripe/job/invoice product.
+-- Does NOT add public.quotes.notes (column absent in production; not required by S2 model).
 
 BEGIN;
 
@@ -301,11 +303,17 @@ BEGIN
 
     INSERT INTO public.quotes (
       lead_id, tenant_id, status, service_address, customer_name, customer_email, customer_phone,
-      subtotal, total_amount, tax_amount, notes, quote_version, supersedes_quote_id, created_at, updated_at
+      subtotal, total_amount, tax_amount, tax_rate, header_text, footer_text, fulfillment_mode,
+      estimate_id, user_id, inspection_id, inspection_revision, line_items,
+      quote_version, supersedes_quote_id, created_at, updated_at
     ) VALUES (
       v_quote.lead_id, v_tenant, 'draft', v_quote.service_address, v_quote.customer_name,
       v_quote.customer_email, v_quote.customer_phone, v_quote.subtotal, v_amount,
-      coalesce(v_quote.tax_amount, 0), v_quote.notes, v_next_version, v_quote.id, v_now, v_now
+      coalesce(v_quote.tax_amount, 0), coalesce(v_quote.tax_rate, 0),
+      v_quote.header_text, v_quote.footer_text, v_quote.fulfillment_mode,
+      v_quote.estimate_id, v_quote.user_id, v_quote.inspection_id, v_quote.inspection_revision,
+      coalesce(v_quote.line_items, '[]'::jsonb),
+      v_next_version, v_quote.id, v_now, v_now
     )
     RETURNING * INTO v_draft;
 

--- a/command-center/tests/unit/ml-p1-s2-lifecycle.test.mjs
+++ b/command-center/tests/unit/ml-p1-s2-lifecycle.test.mjs
@@ -295,6 +295,87 @@ describe('ML-P1 S2 remediation source guards', () => {
     assert.match(mig, /app_metadata/);
   });
 
+  it('revise RPC is live-schema compatible (no quotes.notes)', () => {
+    const mig = fs.readFileSync(
+      path.join(
+        __dirname,
+        '../../supabase/migrations/20260721170000_ml_p1_s2_lifecycle_server_authz.sql',
+      ),
+      'utf8',
+    );
+    assert.equal(/\bv_quote\.notes\b/.test(mig), false);
+    assert.equal(/ADD COLUMN IF NOT EXISTS notes\b/i.test(mig), false);
+    // Revise INSERT must copy lineage fields without inventing notes.
+    assert.match(mig, /supersedes_quote_id/);
+    assert.match(mig, /quote_version/);
+    assert.match(mig, /coalesce\(v_quote\.line_items/);
+    const insertBlock = mig.match(
+      /INSERT INTO public\.quotes \(([\s\S]*?)\) VALUES \(([\s\S]*?)\)\s*RETURNING \* INTO v_draft/i,
+    );
+    assert.ok(insertBlock, 'revise INSERT block present');
+    assert.equal(/\bnotes\b/i.test(insertBlock[1]), false);
+    assert.equal(/\bnotes\b/i.test(insertBlock[2]), false);
+    // Live-compatible columns only (+ S2 additive).
+    const allowed = new Set([
+      'lead_id',
+      'tenant_id',
+      'status',
+      'service_address',
+      'customer_name',
+      'customer_email',
+      'customer_phone',
+      'subtotal',
+      'total_amount',
+      'tax_amount',
+      'tax_rate',
+      'header_text',
+      'footer_text',
+      'fulfillment_mode',
+      'estimate_id',
+      'user_id',
+      'inspection_id',
+      'inspection_revision',
+      'line_items',
+      'quote_version',
+      'supersedes_quote_id',
+      'created_at',
+      'updated_at',
+    ]);
+    const cols = insertBlock[1]
+      .split(',')
+      .map((c) => c.trim().toLowerCase())
+      .filter(Boolean);
+    for (const col of cols) {
+      assert.equal(allowed.has(col), true, `unexpected revise column: ${col}`);
+    }
+  });
+
+  it('R-S1-02 migration gates accept AND paid job inserts; neutralizes WO trigger', () => {
+    const mig = fs.readFileSync(
+      path.join(
+        __dirname,
+        '../../supabase/migrations/20260721160000_ml_p1_s2_quote_lifecycle_rs102.sql',
+      ),
+      'utf8',
+    );
+    assert.match(mig, /auto_create_job_on_quote_acceptance/);
+    assert.match(mig, /QuoteAccepted_JobCreateDeferred/);
+    assert.match(mig, /QuotePaid_JobCreateDeferred/);
+    assert.match(mig, /trg_emit_wo_on_quote_accept/);
+    assert.match(mig, /QuoteAccepted_WorkOrderDeferred/);
+    assert.equal(/\bv_quote\.notes\b/.test(mig), false);
+    assert.equal(/ADD COLUMN IF NOT EXISTS notes\b/i.test(mig), false);
+
+    // Every jobs INSERT must sit behind v_should_job true path.
+    const jobInserts = [...mig.matchAll(/INSERT INTO public\.jobs\s*\(/gi)];
+    assert.equal(jobInserts.length, 2, 'expected accept + paid gated job inserts only');
+    for (const m of jobInserts) {
+      const before = mig.slice(Math.max(0, m.index - 800), m.index);
+      assert.match(before, /v_should_job/);
+      assert.match(before, /IF NOT v_should_job/);
+    }
+  });
+
   it('maps QUOTE_EXPIRED from public approve RPC', async () => {
     const supabase = {
       rpc: async () => ({
@@ -307,6 +388,42 @@ describe('ML-P1 S2 remediation source guards', () => {
       () => svc.approveByPublicToken({ publicToken: 'tok-expired' }),
       (err) => /EXPIRED/i.test(err.message) || err.code === 'ML_P1_S2_QUOTE_EXPIRED',
     );
+  });
+
+  it('customer public approve vs office break-glass stay on distinct RPCs', async () => {
+    const calls = [];
+    const supabase = {
+      rpc: async (name, args) => {
+        calls.push({ name, args });
+        if (name === 'ml_p1_s2_quote_approve_public') {
+          return {
+            data: { action: 'approve', jobCreated: false, quote: { id: 'q1', status: 'accepted' } },
+            error: null,
+          };
+        }
+        return {
+          data: { action: 'approve', jobCreated: false, quote: { id: 'q1', status: 'accepted' } },
+          error: null,
+        };
+      },
+    };
+    const svc = createMlP1S2QuoteLifecycleService({ supabase });
+    await svc.approveByPublicToken({ publicToken: 'tok' });
+    await svc.approveQuote({
+      quoteId: 'q1',
+      sessionTenantId: 'tvg',
+      urlTenantId: 'tvg',
+      actorRole: 'admin',
+      reasonCode: 'bg',
+    });
+    assert.equal(calls[0].name, 'ml_p1_s2_quote_approve_public');
+    assert.equal(calls[1].name, 'ml_p1_s2_quote_lifecycle');
+    assert.equal(calls[1].args.p_action, 'approve');
+    assert.equal(calls[1].args.p_reason_code, 'bg');
+  });
+
+  it('legacy estimates writer remains DENY (alternate path)', () => {
+    assert.throws(() => assertEstimatesCreateAllowed());
   });
 
   it('exposes required Money-State statuses', () => {


### PR DESCRIPTION
## Summary
- Remove invalid `public.quotes.notes` dependency from S2 revise RPC; align INSERT with live schema (no new notes column).
- Gate **paid→job** (and neutralize WO-on-accept) behind the same default-off `auto_create_job_on_quote_acceptance` gate as accept→job.
- Expand unit/source-guard coverage for revise schema, accept/paid denial, authz, and legacy estimates DENY.

## Test plan
- [x] `npm run test:ml-p1-s2-helpers` (22/22)
- [x] `npm run test:ml-p1-s1-helpers` (15/15)
- [ ] Exact-head Product / Data / Security / Financial Control / Architecture / Adversarial reviews
- [ ] Founder exact-head merge auth (no apply/deploy/S3)

## Explicit non-goals
No production migration apply · no deploy · no Slice 3 · no Stripe / follow-up / invoice / TIS / G2.3

## Freeze
Head: `7233e049082dcbd8de0fe0ca098bef7f323ec76f`