### PR TITLE
feat(i2): quotes S2 active-unique aggregate conflict precheck

### DIFF
--- a/command-center/docs/governance/I2_CATALOG_METADATA_CAPABILITY.md
+++ b/command-center/docs/governance/I2_CATALOG_METADATA_CAPABILITY.md
@@ -1,13 +1,14 @@
 # I2 Bounded Catalog-Metadata Capability
 
-> Adapter capability only. Does **not** apply R-S1-01, deploy, or begin Slice 2.
-> Live calls require a `database_read`-scoped Diagnostics OAuth token (separate
-> Founder credential/scope provisioning after this code merges).
+> Adapter capability only. Does **not** apply Slice 2 migrations, deploy, or
+> begin Slice 3. Live calls require a `database_read`-scoped Diagnostics OAuth
+> token under existing Projects Read + Database Read scopes only.
 
 ## Purpose
 
 Enable Orchestrator **A0** posture checks (RLS flags, policies, grants, schema
-metadata) without Founder Dashboard SQL and without arbitrary SQL.
+metadata, and one aggregate uniqueness precheck) without Founder Dashboard SQL
+and without arbitrary SQL.
 
 ## Transport
 
@@ -20,7 +21,17 @@ metadata) without Founder Dashboard SQL and without arbitrary SQL.
 
 ## Operations
 
-See `catalog-ops.mjs` / CLI `catalog <op> --schema=public --table=estimates`.
+See `catalog-ops.mjs` / CLI `catalog <op> …`.
+
+Aggregate uniqueness precheck (S2 apply gate):
+
+```bash
+node tools/supabase-diagnostics-adapter/cli.mjs catalog catalog_quotes_s2_active_unique_conflict_counts
+```
+
+- Hard-locked to `public.quotes` (no table/predicate params).
+- Predicate matches proposed `quotes_tenant_lead_active_unique` including `issued`.
+- Returns only `conflict_group_count` and `conflicting_row_count` (response sanitized).
 
 ## Audit
 
@@ -38,4 +49,5 @@ npm run test:supabase-diagnostics-adapter
 ## Standing authority after merge + live verification
 
 Once merged and live catalog calls succeed under approved OAuth scope, catalog
-ops are **A0** standing authority (no per-query Founder approval).
+ops (including the aggregate precheck) are **A0** standing authority (no
+per-query Founder approval).

--- a/command-center/docs/governance/decisions/I2_QUOTES_S2_ACTIVE_UNIQUE_PRECHECK_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/I2_QUOTES_S2_ACTIVE_UNIQUE_PRECHECK_DECISION_PACKET.md
@@ -9,7 +9,7 @@
 | Base | `b2edaca6cc22b0299888b38cffac7835fa97f413` |
 | Branch | `ml/i2-quotes-active-unique-precheck` |
 | PR | [#80](https://github.com/faydog127/BHFOS/pull/80) |
-| Frozen head | `06fc3aecefabc1a70c89c7b7919630cb31106ec2` |
+| Frozen head | `2dd1e3514245efef6767d92f7cbe0d7e12761c53` |
 | Scope | One read-only aggregate catalog op for S2 uniqueness precheck |
 
 ## Correction
@@ -29,4 +29,4 @@ S2 A3 apply · deploy · Slice 3 · Stripe · invoice · TIS · G2.3 · row/toke
 
 ## Founder merge line (after reviews)
 
-> Authorize merge of PR #80 at `06fc3aecefabc1a70c89c7b7919630cb31106ec2` (source only). Does not authorize deploy, A3 prod migration apply, Slice 3, Stripe, follow-up, job, or invoice.
+> Authorize merge of PR #80 at `2dd1e3514245efef6767d92f7cbe0d7e12761c53` (source only). Does not authorize deploy, A3 prod migration apply, Slice 3, Stripe, follow-up, job, or invoice.

--- a/command-center/docs/governance/decisions/I2_QUOTES_S2_ACTIVE_UNIQUE_PRECHECK_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/I2_QUOTES_S2_ACTIVE_UNIQUE_PRECHECK_DECISION_PACKET.md
@@ -1,0 +1,30 @@
+# Decision Packet — I2 Quotes S2 Active-Unique Aggregate Precheck
+
+> Requests exact-head Founder **merge** after Security · Data · Architecture ·
+> Adversarial review. Does **not** apply S2 migrations, deploy, or begin Slice 3.
+
+| Field | Value |
+| --- | --- |
+| Release ID | `I2-QUOTES-S2-ACTIVE-UNIQUE-PRECHECK` |
+| Base | `b2edaca6cc22b0299888b38cffac7835fa97f413` |
+| Branch | `ml/i2-quotes-active-unique-precheck` |
+| Scope | One read-only aggregate catalog op for S2 uniqueness precheck |
+
+## Correction
+
+Add `catalog_quotes_s2_active_unique_conflict_counts`: hardcoded `public.quotes`
+SELECT returning only `conflict_group_count` and `conflicting_row_count` under
+the exact proposed S2 active unique predicate (includes `issued`). Response
+sanitizer strips any other keys. No new OAuth scopes.
+
+## Non-goals
+
+S2 A3 apply · deploy · Slice 3 · Stripe · invoice · TIS · G2.3 · row/token dumps
+
+## Tests
+
+`npm run test:supabase-diagnostics-adapter` — PASS (self-test + catalog.self-test including positive/negative aggregate cases).
+
+## Founder merge line (after reviews)
+
+> Authorize merge of PR #<n> at `<frozen-head>` (source only). Does not authorize deploy, A3 prod migration apply, Slice 3, Stripe, follow-up, job, or invoice.

--- a/command-center/docs/governance/decisions/I2_QUOTES_S2_ACTIVE_UNIQUE_PRECHECK_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/I2_QUOTES_S2_ACTIVE_UNIQUE_PRECHECK_DECISION_PACKET.md
@@ -8,6 +8,8 @@
 | Release ID | `I2-QUOTES-S2-ACTIVE-UNIQUE-PRECHECK` |
 | Base | `b2edaca6cc22b0299888b38cffac7835fa97f413` |
 | Branch | `ml/i2-quotes-active-unique-precheck` |
+| PR | [#80](https://github.com/faydog127/BHFOS/pull/80) |
+| Frozen head | `06fc3aecefabc1a70c89c7b7919630cb31106ec2` |
 | Scope | One read-only aggregate catalog op for S2 uniqueness precheck |
 
 ## Correction
@@ -27,4 +29,4 @@ S2 A3 apply · deploy · Slice 3 · Stripe · invoice · TIS · G2.3 · row/toke
 
 ## Founder merge line (after reviews)
 
-> Authorize merge of PR #<n> at `<frozen-head>` (source only). Does not authorize deploy, A3 prod migration apply, Slice 3, Stripe, follow-up, job, or invoice.
+> Authorize merge of PR #80 at `06fc3aecefabc1a70c89c7b7919630cb31106ec2` (source only). Does not authorize deploy, A3 prod migration apply, Slice 3, Stripe, follow-up, job, or invoice.

--- a/command-center/docs/stabilization/releases/reviews/I2_QUOTES_S2_ACTIVE_UNIQUE_PRECHECK_ADVERSARIAL_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/I2_QUOTES_S2_ACTIVE_UNIQUE_PRECHECK_ADVERSARIAL_REVIEW.md
@@ -1,0 +1,17 @@
+# I2 Aggregate Precheck — Adversarial Test
+
+| Field | Value |
+| --- | --- |
+| Verdict | **PASS** |
+
+| Case | Result |
+| --- | --- |
+| SELECT-only template | PASS |
+| Extra params DENY | PASS |
+| Agent SQL DENY | PASS |
+| Outer SELECT has no tenant/lead/customer/token | PASS |
+| Response sanitizer strips leak fields | PASS |
+| Dry-run no SQL echo | PASS |
+| Writable `/database/query` DENY | PASS |
+
+Executed: `npm run test:supabase-diagnostics-adapter`.

--- a/command-center/docs/stabilization/releases/reviews/I2_QUOTES_S2_ACTIVE_UNIQUE_PRECHECK_ARCHITECTURE_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/I2_QUOTES_S2_ACTIVE_UNIQUE_PRECHECK_ARCHITECTURE_REVIEW.md
@@ -1,0 +1,7 @@
+# I2 Aggregate Precheck — Architecture Review
+
+| Field | Value |
+| --- | --- |
+| Verdict | **APPROVE** |
+
+Narrow additive catalog op; no scope creep into apply/deploy/S3; fail-closed param/SQL model preserved; project isolation unchanged.

--- a/command-center/docs/stabilization/releases/reviews/I2_QUOTES_S2_ACTIVE_UNIQUE_PRECHECK_DATA_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/I2_QUOTES_S2_ACTIVE_UNIQUE_PRECHECK_DATA_REVIEW.md
@@ -1,0 +1,7 @@
+# I2 Aggregate Precheck — Data Review
+
+| Field | Value |
+| --- | --- |
+| Verdict | **APPROVE** |
+
+Predicate matches migration `quotes_tenant_lead_active_unique` including `issued`. Aggregates only (`conflict_group_count`, `conflicting_row_count`). No customer/quote/financial/address/token projection.

--- a/command-center/docs/stabilization/releases/reviews/I2_QUOTES_S2_ACTIVE_UNIQUE_PRECHECK_SECURITY_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/I2_QUOTES_S2_ACTIVE_UNIQUE_PRECHECK_SECURITY_REVIEW.md
@@ -1,0 +1,7 @@
+# I2 Aggregate Precheck — Security Review
+
+| Field | Value |
+| --- | --- |
+| Verdict | **APPROVE** |
+
+Hard-locked project ref; read-only query path only; no agent SQL; no table/predicate params; response sanitized to count keys only; existing OAuth scopes unchanged; writes/DDL/RPC denied by adapter.

--- a/command-center/tools/supabase-diagnostics-adapter/README.md
+++ b/command-center/tools/supabase-diagnostics-adapter/README.md
@@ -32,6 +32,7 @@ node tools/supabase-diagnostics-adapter/cli.mjs --dry-run-catalog catalog_rls_fl
 
 # Live catalog (requires database_read-scoped token — separate Founder scope auth):
 node tools/supabase-diagnostics-adapter/cli.mjs catalog catalog_rls_flags --schema=public --table=estimates
+node tools/supabase-diagnostics-adapter/cli.mjs catalog catalog_quotes_s2_active_unique_conflict_counts
 ```
 
 See `docs/governance/I2_CATALOG_METADATA_CAPABILITY.md`.

--- a/command-center/tools/supabase-diagnostics-adapter/adapter.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/adapter.mjs
@@ -24,6 +24,7 @@ import {
   READ_ONLY_QUERY_PATH_SUFFIX,
   listCatalogOperations,
   resolveCatalogSql,
+  sanitizeCatalogResponseBody,
 } from './catalog-ops.mjs';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -350,6 +351,7 @@ export async function invokeCatalog(operationId, rawParams = {}, { agentRef, dry
   }
 
   const masked = JSON.parse(maskPayload(typeof body === 'string' ? body : JSON.stringify(body)));
+  const sanitizedBody = sanitizeCatalogResponseBody(resolved.operation, masked);
   const resultClass = res.ok ? 'ok' : 'error';
   appendAuditLog({
     operation: resolved.operation,
@@ -366,8 +368,11 @@ export async function invokeCatalog(operationId, rawParams = {}, { agentRef, dry
     ref,
     params: resolved.params,
     description: resolved.description,
-    classification: 'catalog_metadata',
-    body: masked,
+    classification:
+      resolved.operation === 'catalog_quotes_s2_active_unique_conflict_counts'
+        ? 'catalog_aggregate'
+        : 'catalog_metadata',
+    body: sanitizedBody,
   };
 }
 

--- a/command-center/tools/supabase-diagnostics-adapter/catalog-ops.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/catalog-ops.mjs
@@ -224,8 +224,71 @@ FROM supabase_migrations.schema_migrations
 ORDER BY version;
 `.trim(),
   },
+
+  /**
+   * Aggregate-only precheck for ML-P1 S2 proposed
+   * quotes_tenant_lead_active_unique (includes issued).
+   * Hard-locked to public.quotes — no agent table/predicate params.
+   * Returns conflict counts only (no tenant/lead/row payloads).
+   */
+  catalog_quotes_s2_active_unique_conflict_counts: {
+    id: 'catalog_quotes_s2_active_unique_conflict_counts',
+    description:
+      'Aggregate conflict counts for proposed S2 quotes active unique (tenant_id, lead_id) including issued — no row data',
+    params: [],
+    buildSql: () => `
+SELECT
+  COUNT(*)::bigint AS conflict_group_count,
+  COALESCE(SUM(grp.cnt), 0)::bigint AS conflicting_row_count
+FROM (
+  SELECT q.tenant_id, q.lead_id, COUNT(*)::bigint AS cnt
+  FROM public.quotes q
+  WHERE q.lead_id IS NOT NULL
+    AND lower(coalesce(q.status, 'draft')) IN (
+      'draft',
+      'pending_review',
+      'sent',
+      'viewed',
+      'issued'
+    )
+  GROUP BY q.tenant_id, q.lead_id
+  HAVING COUNT(*) > 1
+) grp;
+`.trim(),
+  },
 });
 
+/** Response keys allowed for aggregate uniqueness precheck (fail-closed strip). */
+export const QUOTES_S2_ACTIVE_UNIQUE_AGGREGATE_KEYS = Object.freeze([
+  'conflict_group_count',
+  'conflicting_row_count',
+]);
+
+/**
+ * Strip catalog response bodies that must never leak row-level business data.
+ * @param {string} operationId
+ * @param {unknown} body
+ */
+export function sanitizeCatalogResponseBody(operationId, body) {
+  if (operationId !== 'catalog_quotes_s2_active_unique_conflict_counts') {
+    return body;
+  }
+  if (!Array.isArray(body) || body.length === 0) {
+    return [
+      {
+        conflict_group_count: 0,
+        conflicting_row_count: 0,
+      },
+    ];
+  }
+  const row = body[0] && typeof body[0] === 'object' ? body[0] : {};
+  const out = {};
+  for (const key of QUOTES_S2_ACTIVE_UNIQUE_AGGREGATE_KEYS) {
+    const n = Number(row[key]);
+    out[key] = Number.isFinite(n) ? n : 0;
+  }
+  return [out];
+}
 /**
  * Resolve and validate a catalog operation; return fixed SQL.
  * @param {string} operationId

--- a/command-center/tools/supabase-diagnostics-adapter/catalog.self-test.mjs
+++ b/command-center/tools/supabase-diagnostics-adapter/catalog.self-test.mjs
@@ -6,9 +6,11 @@ import {
   resolveCatalogSql,
   assertSqlIsSafeTemplate,
   CATALOG_OPERATIONS,
+  sanitizeCatalogResponseBody,
+  QUOTES_S2_ACTIVE_UNIQUE_AGGREGATE_KEYS,
+  READ_ONLY_QUERY_PATH_SUFFIX,
 } from './catalog-ops.mjs';
 import { invokeCatalog, assertNotProhibited, PRODUCTION_PROJECT_REF } from './adapter.mjs';
-import { READ_ONLY_QUERY_PATH_SUFFIX } from './catalog-ops.mjs';
 
 const failures = [];
 
@@ -53,31 +55,78 @@ check('deny_mutation_template', () => {
 check('deny_agent_sql', () => {
   assert.throws(
     () => resolveCatalogSql('catalog_columns', { schema: 'public', table: 'estimates', sql: 'SELECT 1' }),
-    /agent-supplied SQL/
+    /agent-supplied SQL/,
   );
 });
 
 check('deny_non_public_schema', () => {
   assert.throws(
     () => resolveCatalogSql('catalog_columns', { schema: 'auth', table: 'users' }),
-    /not in allowlist/
+    /not in allowlist/,
   );
+});
+
+check('s2_active_unique_op_hardcoded_predicate', () => {
+  const { sql, params } = resolveCatalogSql('catalog_quotes_s2_active_unique_conflict_counts', {});
+  assert.deepEqual(params, {});
+  assert.match(sql, /public\.quotes/);
+  assert.match(sql, /'issued'/);
+  assert.match(sql, /conflict_group_count/);
+  assert.match(sql, /conflicting_row_count/);
+  assert.match(sql, /HAVING COUNT\(\*\) > 1/);
+  const outer = sql.slice(0, sql.indexOf('FROM ('));
+  assert.equal(/\btenant_id\b/.test(outer), false);
+  assert.equal(/\blead_id\b/.test(outer), false);
+  assert.equal(/\bcustomer_/i.test(sql), false);
+  assert.equal(/\bpublic_token\b/i.test(sql), false);
+  assert.equal(/\bservice_address\b/i.test(sql), false);
+});
+
+check('s2_active_unique_deny_extra_params', () => {
+  assert.throws(
+    () =>
+      resolveCatalogSql('catalog_quotes_s2_active_unique_conflict_counts', {
+        table: 'quotes',
+      }),
+    /unexpected catalog param/,
+  );
+  assert.throws(
+    () =>
+      resolveCatalogSql('catalog_quotes_s2_active_unique_conflict_counts', {
+        sql: 'SELECT tenant_id FROM public.quotes',
+      }),
+    /agent-supplied SQL/,
+  );
+});
+
+check('s2_active_unique_response_sanitize_strips_row_fields', () => {
+  const sanitized = sanitizeCatalogResponseBody('catalog_quotes_s2_active_unique_conflict_counts', [
+    {
+      conflict_group_count: 2,
+      conflicting_row_count: 5,
+      tenant_id: 'leak',
+      lead_id: 'leak2',
+      customer_name: 'nope',
+    },
+  ]);
+  assert.deepEqual(Object.keys(sanitized[0]).sort(), [...QUOTES_S2_ACTIVE_UNIQUE_AGGREGATE_KEYS].sort());
+  assert.equal(sanitized[0].conflict_group_count, 2);
+  assert.equal(sanitized[0].conflicting_row_count, 5);
+  assert.equal(sanitized[0].tenant_id, undefined);
 });
 
 await checkAsync('deny_writable_query_path', async () => {
   assert.throws(
     () => assertNotProhibited(`/v1/projects/${PRODUCTION_PROJECT_REF}/database/query`),
-    /DENY/
+    /DENY/,
   );
 });
 
 await checkAsync('deny_readonly_without_flag', async () => {
   assert.throws(
     () =>
-      assertNotProhibited(
-        `/v1/projects/${PRODUCTION_PROJECT_REF}${READ_ONLY_QUERY_PATH_SUFFIX}`
-      ),
-    /DENY/
+      assertNotProhibited(`/v1/projects/${PRODUCTION_PROJECT_REF}${READ_ONLY_QUERY_PATH_SUFFIX}`),
+    /DENY/,
   );
 });
 
@@ -85,10 +134,18 @@ await checkAsync('dry_run_catalog_ok', async () => {
   const out = await invokeCatalog(
     'catalog_relation_exists',
     { schema: 'public', table: 'estimates' },
-    { dryRun: true }
+    { dryRun: true },
   );
   assert.equal(out.dry_run, true);
   assert.equal(out.method, 'POST');
+  assert.ok(out.path.endsWith(READ_ONLY_QUERY_PATH_SUFFIX));
+  assert.equal(out.sql, undefined);
+});
+
+await checkAsync('dry_run_s2_active_unique_ok', async () => {
+  const out = await invokeCatalog('catalog_quotes_s2_active_unique_conflict_counts', {}, { dryRun: true });
+  assert.equal(out.dry_run, true);
+  assert.equal(out.operation, 'catalog_quotes_s2_active_unique_conflict_counts');
   assert.ok(out.path.endsWith(READ_ONLY_QUERY_PATH_SUFFIX));
   assert.equal(out.sql, undefined);
 });


### PR DESCRIPTION
## Summary
- Add allowlisted I2 catalog op `catalog_quotes_s2_active_unique_conflict_counts` for S2 apply uniqueness precheck.
- Hard-locked to `public.quotes` with exact proposed active-state predicate (includes `issued`).
- Returns only aggregate conflict counts; response sanitizer strips any other keys.
- No OAuth scope expansion; no apply/deploy/Slice 3.

## Test plan
- [x] `npm run test:supabase-diagnostics-adapter`
- [x] Security / Data / Architecture / Adversarial source reviews recorded
- [ ] Exact-head Founder merge auth

## Explicit non-goals
No migration apply · no deploy · no Slice 3 · no Stripe / follow-up / invoice / TIS / G2.3