### PR TITLE
fix(deploy): restore valid root vercel.json for Vite SPA

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,1 +1,8 @@
-
+{
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Root `vercel.json` on main `1f00b84…` was whitespace-only (`\r\n`), which is not valid JSON and causes Vercel to reject deploys with `Invalid vercel.json file provided`.
- Restored the prior Vite SPA configuration: `framework`, `buildCommand`, `outputDirectory`, and catch-all SPA `rewrites`.
- Deployment-config only. No Slice 2 product, migration, Supabase, Stripe, jobs, invoices, follow-up, TIS, or G2.3 changes.

## Test plan
- [x] `JSON.parse(vercel.json)` succeeds
- [x] Root `npm run build` (Vite) exit 0; `dist/index.html` present
- [x] `command-center` `npm run build:local` exit 0 (baseline sanity)
- [x] SPA rewrite `/(.*)` → `/` present; local static fallback returns `index.html` for client routes
- [ ] Founder merge at exact frozen head only
- [ ] Deploy only after exact-head authorization (do not deploy from older SHA)

## Frozen head
`56dc35e4506e3450dbeb17ba208b6f834b82deab`

## Baseline
Application baseline: `1f00b84d5e3125bbb27c7d075390a5c6ea8aa219`

Made with [Cursor](https://cursor.com)