### PR TITLE
ML-P1 Slice 3: canonical quote→job writer (A2 coding)

### DIFF
--- a/command-center/docs/governance/decisions/ML-P1_SLICE3_PR84_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/ML-P1_SLICE3_PR84_DECISION_PACKET.md
@@ -27,8 +27,8 @@ Merge authorization only. **A3 apply / Hostinger deploy / Slice 4 remain separat
 | Branch / worktree | `ml/p1-s3-quote-to-job` / `F:\Dev\BHFOS-ml-p1-s3` |
 | Coding auth base | `ef2470715ddf90c34a77416183eb5b2421bd6373` |
 | Prior freeze (remediated) | `7fde2f4f2811b9074a1be2816b2b7ad3d4889656` |
-| **Code freeze (lanes)** | `dce50d19cffec132bc2eec12eaadfdbe665ded1c` |
-| **PR tip (includes this packet)** | `ae18a05aa8f9d7562d6e5191615296b1e4fd13bf` |
+| **Frozen code head (all lanes)** | `dce50d19cffec132bc2eec12eaadfdbe665ded1c` |
+| **Merge tip rule** | PR #84 head on `ml/p1-s3-quote-to-job` must be a descendant of the frozen code head; only governance/docs commits may follow |
 
 ## Operational problem
 
@@ -103,13 +103,13 @@ See `command-center/docs/stabilization/releases/ML-P1_SLICE3_PILOT_M1_M5.md` —
 
 ## Recommendation
 
-**Authorize merge of PR #84 at tip `ae18a05aa8f9d7562d6e5191615296b1e4fd13bf`** (code freeze `dce50d19cffec132bc2eec12eaadfdbe665ded1c` + this packet).
+**Authorize merge of PR #84** when tip is a descendant of frozen code head `dce50d19cffec132bc2eec12eaadfdbe665ded1c` with no further product/SQL/edge changes.
 
 Do **not** apply migration or deploy under this packet. Next Founder line (separate): **A3** production apply + edge deploy + post-apply verification, then only later Slice 4 field execution.
 
 ## Exact authorization requested
 
-> **Yes — merge auth only** for PR #84 at exact tip `ae18a05aa8f9d7562d6e5191615296b1e4fd13bf` (reviewed code freeze `dce50d19cffec132bc2eec12eaadfdbe665ded1c`).
+> **Yes — merge auth only** for PR #84 at a tip descending from exact code freeze `dce50d19cffec132bc2eec12eaadfdbe665ded1c`.
 
 Optional follow-on (yes/no; not authorized by this packet):
 

--- a/command-center/docs/governance/decisions/ML-P1_SLICE3_PR84_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/ML-P1_SLICE3_PR84_DECISION_PACKET.md
@@ -1,0 +1,115 @@
+# Decision Packet — ML-P1 Slice 3 A2 Review (PR #84)
+
+> **One consolidated founder-facing decision surface.** Agent-prepared.
+> No credentials, secrets, customer data, or pasted logs.
+>
+> All review lanes evaluated the same frozen head below.
+> **Do not merge, deploy, apply S3 migrations, or begin Slice 4 under this packet alone.**
+
+---
+
+## Disposition
+
+# **SLICE3_READY_FOR_MERGE_AUTH**
+
+Merge authorization only. **A3 apply / Hostinger deploy / Slice 4 remain separately locked.**
+
+---
+
+## Release
+
+| Field | Value |
+| --- | --- |
+| Release ID | `ML-P1-S3` |
+| Governance | v2.2 + Reduced AI Development Assurance Pilot |
+| Risk tier | **Tier 3** (money-state) |
+| PR | [#84](https://github.com/faydog127/BHFOS/pull/84) |
+| Branch / worktree | `ml/p1-s3-quote-to-job` / `F:\Dev\BHFOS-ml-p1-s3` |
+| Coding auth base | `ef2470715ddf90c34a77416183eb5b2421bd6373` |
+| Prior freeze (remediated) | `7fde2f4f2811b9074a1be2816b2b7ad3d4889656` |
+| **Frozen PR head** | `dce50d19cffec132bc2eec12eaadfdbe665ded1c` |
+
+## Operational problem
+
+Slice 3 must deliver **approved/accepted quote → exactly one canonical job** with idempotency, lineage, authorization, trigger neutralization, and minimum office UI status — stopping before field execution.
+
+## What landed at freeze (SOURCE / unit EXECUTED)
+
+- Migration `20260721200000_ml_p1_s3_canonical_job_writer.sql` — **not applied to prod**
+- Canonical writer `ml_p1_s3_ensure_job_for_accepted_quote` + `jobs.source_quote_version`
+- Approve RPCs call writer in-txn; S2 gate belt dropped; accept/paid triggers deferred-only
+- Fail-closed `public-quote-approve` (no approve-without-job fallback)
+- `quote-update-status` + kanban accept/create DENY; jobs INSERT RLS `quote_id IS NULL`
+- Lifecycle UI job status + `ensure_job` repair; ProposalList → lifecycle
+- Evidence Manifest + Pilot M1–M5 + unit/source-guard suites
+
+## Migration checksum (frozen tree)
+
+| File | SHA-256 |
+| --- | --- |
+| `command-center/supabase/migrations/20260721200000_ml_p1_s3_canonical_job_writer.sql` | `B618AF707546150773784B71728BE75CE27C0A2B6D7814CF43EEFD41626579B1` |
+
+## Hard stops held
+
+No merge without Founder auth on this packet · no deploy · no production S3 migration apply (needs **A3**) · no Slice 4 · no Stripe · no invoice product · no autonomous follow-up product · no TIS / G2.3 reopen · `auto_create_job_on_quote_acceptance` **not** set true
+
+## Evidence (executed vs source-only vs production-unverified)
+
+| Claim | Level |
+| --- | --- |
+| Unit + source guards (36/36) including WRITER_REQUIRED, kanban DENY, tenant mismatch raises, writer wiring | **EXECUTED** (local Node) |
+| Same-txn approve+job; `FOR UPDATE`; unique `quote_id`; trigger never inserts; conflict recovery tenant re-check | **SOURCE-ONLY** |
+| Clean-apply on production Supabase `wwyxohjnyqnegzbxtuxs` | **PRODUCTION-UNVERIFIED** (A3) |
+| Live concurrent dual-approve race / live public-token → job | **PRODUCTION-UNVERIFIED** |
+| Edge function runtime deploy of remediated `public-quote-approve` / `kanban-move` / `quote-update-status` | **PRODUCTION-UNVERIFIED** |
+
+**Rollback (pre-apply):** close/revert PR. **Post-A3:** forward-fix restore prior function bodies/policies under new Founder auth; never flip auto-job flag to re-enable trigger create.
+
+## Reconciled reviews @ `dce50d19cffec132bc2eec12eaadfdbe665ded1c`
+
+| Role | Verdict |
+| --- | --- |
+| Product | **APPROVE** (accept→one job; stop before field; sent/viewed office path restored via lifecycle) |
+| Data | **APPROVE** (additive column; unique retained; clean-apply deferred to A3) |
+| Security | **APPROVE** (prior highs/mediums closed at freeze; residual R-S3-01 service_role / UPDATE attach documented) |
+| Financial Control | **APPROVE** (money re-pin on ensure; no invoice/Stripe; fail-closed address) |
+| Architecture | **APPROVE** (single writer; triggers neutralized; flag flip ignored) |
+| UX/Field | **APPROVE** (job status + ensure repair; no field scheduling expansion) |
+| Independent Adversarial Test | **PASS** after remediation (prior FAIL items closed; residuals below) |
+
+### Review cycle notes
+
+**At prior freeze `7fde2f4…` — remediation required:**
+
+1. Public approve fallback could approve without job after gate removal (**HIGH**) — **CLOSED** (`ML_P1_S3_WRITER_REQUIRED`)
+2. Kanban `getOrCreateJobForQuote` insert + status accept (**HIGH**) — **CLOSED**
+3. sent/viewed Accept → lifecycle dead-end (**HIGH**) — **CLOSED** (approve from sent/viewed)
+4. Writer idempotent trust without tenant/money pin (**MEDIUM**) — **CLOSED** (+ conflict-path tenant re-check)
+5. Ensure-job UI unreachable / stale state — **CLOSED**
+
+### Non-blocking residuals
+
+| ID | Note |
+| --- | --- |
+| R-S3-01 | `service_role` can still insert/update jobs; authenticated UPDATE can still set `quote_id` (INSERT blocked when `quote_id` set) |
+| R-S3-02 | No full line-item copy table; totals + `source_quote_version` pin only |
+| R-S3-04 | Office break-glass path does not call `closeFollowUpTasks` (public path does) |
+| R-S3-05 | Live DB concurrency / clean-apply not executed at A2 |
+
+## Pilot M1–M5
+
+See `command-center/docs/stabilization/releases/ML-P1_SLICE3_PILOT_M1_M5.md` — all **PASS (source)** with production-unverified apply/concurrency.
+
+## Recommendation
+
+**Authorize merge of PR #84 at `dce50d19cffec132bc2eec12eaadfdbe665ded1c`.**
+
+Do **not** apply migration or deploy under this packet. Next Founder line (separate): **A3** production apply + edge deploy + post-apply verification, then only later Slice 4 field execution.
+
+## Exact authorization requested
+
+> **Yes — merge auth only** for PR #84 at exact head `dce50d19cffec132bc2eec12eaadfdbe665ded1c`.
+
+Optional follow-on (yes/no; not authorized by this packet):
+
+> Authorize ML-P1 Slice 3 **A3** production migration apply + function deploy + I2 post-apply verification against `wwyxohjnyqnegzbxtuxs` / `app.bhfos.com`. Still no Slice 4 / Stripe / invoice / follow-up product / TIS / G2.3.

--- a/command-center/docs/governance/decisions/ML-P1_SLICE3_PR84_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/ML-P1_SLICE3_PR84_DECISION_PACKET.md
@@ -27,7 +27,8 @@ Merge authorization only. **A3 apply / Hostinger deploy / Slice 4 remain separat
 | Branch / worktree | `ml/p1-s3-quote-to-job` / `F:\Dev\BHFOS-ml-p1-s3` |
 | Coding auth base | `ef2470715ddf90c34a77416183eb5b2421bd6373` |
 | Prior freeze (remediated) | `7fde2f4f2811b9074a1be2816b2b7ad3d4889656` |
-| **Frozen PR head** | `dce50d19cffec132bc2eec12eaadfdbe665ded1c` |
+| **Code freeze (lanes)** | `dce50d19cffec132bc2eec12eaadfdbe665ded1c` |
+| **PR tip (includes this packet)** | `ae18a05aa8f9d7562d6e5191615296b1e4fd13bf` |
 
 ## Operational problem
 
@@ -102,13 +103,13 @@ See `command-center/docs/stabilization/releases/ML-P1_SLICE3_PILOT_M1_M5.md` —
 
 ## Recommendation
 
-**Authorize merge of PR #84 at `dce50d19cffec132bc2eec12eaadfdbe665ded1c`.**
+**Authorize merge of PR #84 at tip `ae18a05aa8f9d7562d6e5191615296b1e4fd13bf`** (code freeze `dce50d19cffec132bc2eec12eaadfdbe665ded1c` + this packet).
 
 Do **not** apply migration or deploy under this packet. Next Founder line (separate): **A3** production apply + edge deploy + post-apply verification, then only later Slice 4 field execution.
 
 ## Exact authorization requested
 
-> **Yes — merge auth only** for PR #84 at exact head `dce50d19cffec132bc2eec12eaadfdbe665ded1c`.
+> **Yes — merge auth only** for PR #84 at exact tip `ae18a05aa8f9d7562d6e5191615296b1e4fd13bf` (reviewed code freeze `dce50d19cffec132bc2eec12eaadfdbe665ded1c`).
 
 Optional follow-on (yes/no; not authorized by this packet):
 

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE3_A2_CODING_EVIDENCE.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE3_A2_CODING_EVIDENCE.md
@@ -3,6 +3,8 @@
 > Coding authorized on branch `ml/p1-s3-quote-to-job` from main tip
 > `ef2470715ddf90c34a77416183eb5b2421bd6373`.
 >
+> **Code freeze (lanes):** `dce50d19cffec132bc2eec12eaadfdbe665ded1c`
+>
 > **Does not authorize** migration apply, Hostinger deploy, Slice 4+, Stripe,
 > invoices, autonomous follow-up, TIS, or G2.3 reopen.
 
@@ -11,27 +13,30 @@
 | Item | Path / note |
 | --- | --- |
 | Migration | `command-center/supabase/migrations/20260721200000_ml_p1_s3_canonical_job_writer.sql` |
+| SHA-256 @ code freeze | `B618AF707546150773784B71728BE75CE27C0A2B6D7814CF43EEFD41626579B1` |
 | Canonical writer | `public.ml_p1_s3_ensure_job_for_accepted_quote(...)` |
-| Lineage | `jobs.source_quote_version` |
+| Lineage | `jobs.source_quote_version` + money re-pin on ensure |
 | Trigger neutralize | `ensure_job…` accepted/paid → deferred events only (no job INSERT) |
 | Belt retired | `DROP trg_ml_p1_s2_require_job_gate_off_on_accept` |
-| Approve wire | `ml_p1_s2_quote_lifecycle` + `ml_p1_s2_quote_approve_public` call writer in-txn |
-| Edge | `quote-update-status` DENY accept/approve; `public-quote-approve` drops gate, passes `job_id`/`job_created` |
-| UI | Lifecycle job status; ProposalList Accept → lifecycle route |
+| Approve wire | lifecycle + public approve call writer in-txn; `ensure_job` repair |
+| Edge | `quote-update-status` DENY; `public-quote-approve` WRITER_REQUIRED if RPC missing; kanban no insert/accept |
+| UI | Lifecycle job status + ensure repair; ProposalList → lifecycle |
 | Client | `jobCreated` / `jobId` surfaced from RPC |
-| Tests | `tests/unit/ml-p1-s3-job-writer.test.mjs` (+ S2 suite updates) |
+| Tests | 36/36 unit/source-guard |
+| Decision Packet | `docs/governance/decisions/ML-P1_SLICE3_PR84_DECISION_PACKET.md` |
 
 ## Explicit non-actions
 
 - Did **not** set `auto_create_job_on_quote_acceptance=true`
 - Did **not** apply migration to production
-- Did **not** deploy frontend
-- Stop before field execution / invoice / Stripe / follow-up
+- Did **not** deploy frontend/edge
+- Stop before field execution / invoice / Stripe / follow-up product
 
 ## Residual (documented)
 
 | ID | Note |
 | --- | --- |
-| R-S3-01 | Orphan / non-canonical client job inserts not fully blocked by RLS in this slice |
-| R-S3-02 | Full line-item copy table omitted; invoice slice reads pinned quote version |
-| R-S3-03 | Admin repair RPC for approved-without-job drift not shipped (optional) |
+| R-S3-01 | service_role / jobs UPDATE can still attach quote_id; authenticated INSERT with quote_id blocked |
+| R-S3-02 | Full line-item copy table omitted; totals + version pin only |
+| R-S3-04 | Office break-glass path does not call closeFollowUpTasks (public path does) |
+| R-S3-05 | Live concurrency / clean-apply production-unverified (A3) |

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE3_A2_CODING_EVIDENCE.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE3_A2_CODING_EVIDENCE.md
@@ -1,0 +1,37 @@
+# ML-P1 Slice 3 — A2 Coding Evidence
+
+> Coding authorized on branch `ml/p1-s3-quote-to-job` from main tip
+> `ef2470715ddf90c34a77416183eb5b2421bd6373`.
+>
+> **Does not authorize** migration apply, Hostinger deploy, Slice 4+, Stripe,
+> invoices, autonomous follow-up, TIS, or G2.3 reopen.
+
+## Delivered
+
+| Item | Path / note |
+| --- | --- |
+| Migration | `command-center/supabase/migrations/20260721200000_ml_p1_s3_canonical_job_writer.sql` |
+| Canonical writer | `public.ml_p1_s3_ensure_job_for_accepted_quote(...)` |
+| Lineage | `jobs.source_quote_version` |
+| Trigger neutralize | `ensure_job…` accepted/paid → deferred events only (no job INSERT) |
+| Belt retired | `DROP trg_ml_p1_s2_require_job_gate_off_on_accept` |
+| Approve wire | `ml_p1_s2_quote_lifecycle` + `ml_p1_s2_quote_approve_public` call writer in-txn |
+| Edge | `quote-update-status` DENY accept/approve; `public-quote-approve` drops gate, passes `job_id`/`job_created` |
+| UI | Lifecycle job status; ProposalList Accept → lifecycle route |
+| Client | `jobCreated` / `jobId` surfaced from RPC |
+| Tests | `tests/unit/ml-p1-s3-job-writer.test.mjs` (+ S2 suite updates) |
+
+## Explicit non-actions
+
+- Did **not** set `auto_create_job_on_quote_acceptance=true`
+- Did **not** apply migration to production
+- Did **not** deploy frontend
+- Stop before field execution / invoice / Stripe / follow-up
+
+## Residual (documented)
+
+| ID | Note |
+| --- | --- |
+| R-S3-01 | Orphan / non-canonical client job inserts not fully blocked by RLS in this slice |
+| R-S3-02 | Full line-item copy table omitted; invoice slice reads pinned quote version |
+| R-S3-03 | Admin repair RPC for approved-without-job drift not shipped (optional) |

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE3_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE3_EVIDENCE_MANIFEST.md
@@ -9,7 +9,7 @@
 | Coding auth base SHA | `ef2470715ddf90c34a77416183eb5b2421bd6373` (main) |
 | Branch / worktree | `ml/p1-s3-quote-to-job` / `F:\Dev\BHFOS-ml-p1-s3` |
 | PR | [#84](https://github.com/faydog127/BHFOS/pull/84) |
-| **Frozen review head** | `dce50d19cffec132bc2eec12eaadfdbe665ded1c` |
+| **Frozen review head** | Code: `dce50d19cffec132bc2eec12eaadfdbe665ded1c` · Tip: `ae18a05aa8f9d7562d6e5191615296b1e4fd13bf` |
 | Prior freeze (remediated) | `7fde2f4f2811b9074a1be2816b2b7ad3d4889656` |
 | Migration file | `command-center/supabase/migrations/20260721200000_ml_p1_s3_canonical_job_writer.sql` |
 | Migration SHA-256 | `B618AF707546150773784B71728BE75CE27C0A2B6D7814CF43EEFD41626579B1` |

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE3_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE3_EVIDENCE_MANIFEST.md
@@ -1,0 +1,26 @@
+# Evidence Manifest — ML-P1 Slice 3 A2 (canonical quote→job)
+
+> Pilot template. Builder cannot self-certify production apply or USABLE without
+> Founder/independent evidence.
+
+| Field | Value |
+| --- | --- |
+| Authorized slice / scope | **ML-P1-S3 A2 coding + review remediation** — canonical writer; approve+job same txn; idempotency; lineage pin; trigger neutralize; alternate-path DENY; minimum office UI |
+| Coding auth base SHA | `ef2470715ddf90c34a77416183eb5b2421bd6373` (main) |
+| Branch / worktree | `ml/p1-s3-quote-to-job` / `F:\Dev\BHFOS-ml-p1-s3` |
+| PR | [#84](https://github.com/faydog127/BHFOS/pull/84) |
+| **Frozen review head** | *(set at packet freeze — see Decision Packet)* |
+| Prior freeze (remediated) | `7fde2f4f2811b9074a1be2816b2b7ad3d4889656` |
+| Migration file | `command-center/supabase/migrations/20260721200000_ml_p1_s3_canonical_job_writer.sql` |
+| Data objects changed (proposed, not applied) | `jobs.source_quote_version`; `ml_p1_s3_ensure_job_for_accepted_quote`; rewired `ml_p1_s2_quote_lifecycle` / `ml_p1_s2_quote_approve_public`; neutralized `ensure_job…` + WO trigger; dropped gate belt; jobs INSERT RLS `quote_id IS NULL` |
+| Tests executed | `node --test tests/unit/ml-p1-s2-lifecycle.test.mjs tests/unit/ml-p1-s3-job-writer.test.mjs` — **36/36 pass** |
+| Tests skipped + reason | Live prod apply / edge deploy / DB concurrency against production — **not authorized** (A3) |
+| Runtime environments tested | Local Node unit + migration/edge source guards |
+| Claims proven by **execution** | Client surfaces `jobCreated`/`jobId`; transition helpers for sent/viewed/ensure_job; ADDRESS_REQUIRED mapping; source guards (no gate, no approve fallback, no kanban job insert, writer wiring, tenant mismatch raise, RLS quote_id null) |
+| Claims supported by **source inspection only** | Same-txn approve+job; `FOR UPDATE` + `jobs_quote_id_unique`; trigger deferred-only; flag flip ignored by neutralized ensure_job; financial re-pin on idempotent ensure |
+| Claims **production-unverified** | Clean-apply on `wwyxohjnyqnegzbxtuxs`; live concurrent approve race; live public-token approve→job; Hostinger edge deploy of functions |
+| Known residuals | R-S3-02 full line-item copy table omitted (totals + quote_id/version pin); R-S3-03 service_role can still insert jobs; invoice/Stripe/field still out of scope |
+| Rollback method | Before apply: revert/close PR. After A3 apply: forward-fix — restore prior function bodies/policies under new Founder auth; do not flip `auto_create_job_on_quote_acceptance=true` |
+| Required reviewers | Product · Data · Security · Financial Control · Architecture · UX/Field · Independent Adversarial Test |
+
+**Hard stop:** no merge without exact-head Founder auth; no deploy; no production S3 migration apply without A3; no Slice 4 / Stripe / follow-up / invoice / TIS / G2.3.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE3_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE3_EVIDENCE_MANIFEST.md
@@ -9,9 +9,10 @@
 | Coding auth base SHA | `ef2470715ddf90c34a77416183eb5b2421bd6373` (main) |
 | Branch / worktree | `ml/p1-s3-quote-to-job` / `F:\Dev\BHFOS-ml-p1-s3` |
 | PR | [#84](https://github.com/faydog127/BHFOS/pull/84) |
-| **Frozen review head** | *(set at packet freeze — see Decision Packet)* |
+| **Frozen review head** | `dce50d19cffec132bc2eec12eaadfdbe665ded1c` |
 | Prior freeze (remediated) | `7fde2f4f2811b9074a1be2816b2b7ad3d4889656` |
 | Migration file | `command-center/supabase/migrations/20260721200000_ml_p1_s3_canonical_job_writer.sql` |
+| Migration SHA-256 | `B618AF707546150773784B71728BE75CE27C0A2B6D7814CF43EEFD41626579B1` |
 | Data objects changed (proposed, not applied) | `jobs.source_quote_version`; `ml_p1_s3_ensure_job_for_accepted_quote`; rewired `ml_p1_s2_quote_lifecycle` / `ml_p1_s2_quote_approve_public`; neutralized `ensure_job…` + WO trigger; dropped gate belt; jobs INSERT RLS `quote_id IS NULL` |
 | Tests executed | `node --test tests/unit/ml-p1-s2-lifecycle.test.mjs tests/unit/ml-p1-s3-job-writer.test.mjs` — **36/36 pass** |
 | Tests skipped + reason | Live prod apply / edge deploy / DB concurrency against production — **not authorized** (A3) |

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE3_PILOT_M1_M5.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE3_PILOT_M1_M5.md
@@ -1,0 +1,17 @@
+# ML-P1 Slice 3 — Pilot M1–M5 (A2 review evidence)
+
+Frozen against Decision Packet head (see packet). **No production execution.**
+
+| Gate | Intent | Status @ A2 | Evidence class |
+| --- | --- | --- | --- |
+| **M1** | Canonical writer exists; alternate quote→job writers denied in source | **PASS (source)** | Migration defines `ml_p1_s3_ensure_job_for_accepted_quote`; `quote-update-status` DENY; `public-quote-approve` WRITER_REQUIRED if RPC missing; `kanban-move` no insert / no accept status write; jobs RLS `quote_id IS NULL` for authenticated INSERT |
+| **M2** | Approve + job same transaction; fail rolls back | **PASS (source)** | Writer called inside approve RPCs before COMMIT; ADDRESS/VERSION/TENANT raises abort PL/pgSQL function |
+| **M3** | Idempotency / uniqueness | **PASS (source + unit)** | `jobs_quote_id_unique` + `FOR UPDATE` on quote; unit replay surfaces same `jobId`; live concurrency **NOT PROVEN** |
+| **M4** | Lineage + address fail-closed | **PASS (source)** | Pins `source_quote_version`, `total_amount` from approved snapshot; `ML_P1_S3_ADDRESS_REQUIRED`; residual: no line-item copy table (R-S3-02) |
+| **M5** | Scope containment | **PASS (source)** | No invoice/Stripe/field scheduling product; UI status only; WO trigger remains deferred |
+
+## Explicit production-unverified
+
+- Migration not applied to production Supabase.
+- Edge functions not redeployed to Hostinger/Supabase functions runtime.
+- No live two-session concurrent approve test executed.

--- a/command-center/src/pages/crm/MlP1S2QuoteLifecyclePage.jsx
+++ b/command-center/src/pages/crm/MlP1S2QuoteLifecyclePage.jsx
@@ -90,7 +90,7 @@ export default function MlP1S2QuoteLifecyclePage() {
         actorRole: isAdmin ? 'admin' : actorRole,
       });
       setQuote(result.quote);
-      if (result.action === 'approve') {
+      if (result.action === 'approve' || result.action === 'ensure_job') {
         setJobStatus({
           jobId: result.jobId || null,
           jobCreated: Boolean(result.jobCreated),
@@ -126,7 +126,7 @@ export default function MlP1S2QuoteLifecyclePage() {
         isRoleAuthzDeniedError(error) || isTenantDenyError(error)
           ? error.message
           : error.message || `${label} failed`;
-      if (label.toLowerCase().includes('approve')) {
+      if (/approve|ensure job/i.test(label)) {
         setJobStatus({ error: error.code || msg });
       }
       toast({ variant: 'destructive', title: `${label} denied`, description: msg });

--- a/command-center/src/pages/crm/MlP1S2QuoteLifecyclePage.jsx
+++ b/command-center/src/pages/crm/MlP1S2QuoteLifecyclePage.jsx
@@ -107,12 +107,17 @@ export default function MlP1S2QuoteLifecyclePage() {
         title: `${label} complete`,
         description: result.superseded
           ? `New draft ${result.quote.id} (v${result.quote.quote_version})`
-          : result.action === 'approve' && result.jobId
-            ? result.jobCreated
-              ? `Job created: ${result.jobId}`
-              : `Job ensured (existing): ${result.jobId}`
+          : result.action === 'approve' || result.action === 'ensure_job'
+            ? result.jobId
+              ? result.jobCreated
+                ? `Job created: ${result.jobId}`
+                : `Job ensured (existing): ${result.jobId}`
+              : 'Approve recorded but no jobId returned — use Ensure job'
             : `Status: ${result.quote.status}`,
       });
+      if ((result.action === 'approve' || result.action === 'ensure_job') && !result.jobId) {
+        setJobStatus({ error: 'ML_P1_S3_JOB_ID_MISSING' });
+      }
       if (result.action === 'revise' && result.quote?.id) {
         navigate(tenantPath(`estimates/p1-lifecycle/${result.quote.id}`));
       }
@@ -222,7 +227,7 @@ export default function MlP1S2QuoteLifecyclePage() {
         </Card>
       )}
 
-      {status === 'issued' && (
+      {(['issued', 'sent', 'viewed'].includes(status)) && (
         <Card>
           <CardHeader>
             <CardTitle className="text-base">Issued actions</CardTitle>
@@ -337,8 +342,35 @@ export default function MlP1S2QuoteLifecyclePage() {
               </>
             ) : (
               <p className="text-slate-600">
-                Quote approved. No linked job yet — retry break-glass approve if create failed.
+                Quote approved. No linked job yet — use Ensure job (admin break-glass).
               </p>
+            )}
+            {isAdmin && !(linkedJob?.id || jobStatus?.jobId) && (
+              <div className="space-y-2 border-t pt-3">
+                <Label>Ensure job (reason required)</Label>
+                <Input
+                  value={breakGlassReason}
+                  onChange={(e) => setBreakGlassReason(e.target.value)}
+                  placeholder="reason_code"
+                />
+                <Button
+                  className="w-full"
+                  disabled={busy || !breakGlassReason.trim()}
+                  onClick={() =>
+                    runAction(
+                      (args) =>
+                        lifecycle.ensureJobForQuote({
+                          ...args,
+                          actorRole: 'admin',
+                          reasonCode: breakGlassReason.trim(),
+                        }),
+                      'Ensure job',
+                    )
+                  }
+                >
+                  Ensure job
+                </Button>
+              </div>
             )}
           </CardContent>
         </Card>

--- a/command-center/src/pages/crm/MlP1S2QuoteLifecyclePage.jsx
+++ b/command-center/src/pages/crm/MlP1S2QuoteLifecyclePage.jsx
@@ -1,7 +1,7 @@
 /**
- * ML-P1 Slice 2 — Office quote lifecycle actions (issue / revise / reject / expire).
+ * ML-P1 Slice 2/3 — Office quote lifecycle actions (issue / revise / reject / expire).
  * Approve uses customer path or admin break-glass with reason.
- * Does not create jobs or invoices.
+ * Slice 3: break-glass approve ensures exactly one job server-side (no invoice / field).
  */
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -33,6 +33,8 @@ export default function MlP1S2QuoteLifecyclePage() {
   const [rejectReason, setRejectReason] = useState('');
   const [breakGlassReason, setBreakGlassReason] = useState('');
   const [validUntil, setValidUntil] = useState('');
+  const [jobStatus, setJobStatus] = useState(null); // { jobId, jobCreated, idempotent } | { error }
+  const [linkedJob, setLinkedJob] = useState(null);
 
   const actorRole = role || 'viewer';
   const actorId = user?.id || null;
@@ -53,6 +55,13 @@ export default function MlP1S2QuoteLifecyclePage() {
       if (data.valid_until) {
         setValidUntil(String(data.valid_until).slice(0, 10));
       }
+      const { data: jobRow } = await supabase
+        .from('jobs')
+        .select('id, work_order_number, status, source_quote_version')
+        .eq('quote_id', id)
+        .eq('tenant_id', sessionTenantId)
+        .maybeSingle();
+      setLinkedJob(jobRow || null);
     } catch (error) {
       toast({
         variant: 'destructive',
@@ -81,11 +90,28 @@ export default function MlP1S2QuoteLifecyclePage() {
         actorRole: isAdmin ? 'admin' : actorRole,
       });
       setQuote(result.quote);
+      if (result.action === 'approve') {
+        setJobStatus({
+          jobId: result.jobId || null,
+          jobCreated: Boolean(result.jobCreated),
+          idempotent: Boolean(result.idempotent),
+        });
+        if (result.jobId) {
+          setLinkedJob((prev) => ({
+            ...(prev || {}),
+            id: result.jobId,
+          }));
+        }
+      }
       toast({
         title: `${label} complete`,
         description: result.superseded
           ? `New draft ${result.quote.id} (v${result.quote.quote_version})`
-          : `Status: ${result.quote.status}`,
+          : result.action === 'approve' && result.jobId
+            ? result.jobCreated
+              ? `Job created: ${result.jobId}`
+              : `Job ensured (existing): ${result.jobId}`
+            : `Status: ${result.quote.status}`,
       });
       if (result.action === 'revise' && result.quote?.id) {
         navigate(tenantPath(`estimates/p1-lifecycle/${result.quote.id}`));
@@ -95,6 +121,9 @@ export default function MlP1S2QuoteLifecyclePage() {
         isRoleAuthzDeniedError(error) || isTenantDenyError(error)
           ? error.message
           : error.message || `${label} failed`;
+      if (label.toLowerCase().includes('approve')) {
+        setJobStatus({ error: error.code || msg });
+      }
       toast({ variant: 'destructive', title: `${label} denied`, description: msg });
     } finally {
       setBusy(false);
@@ -130,7 +159,7 @@ export default function MlP1S2QuoteLifecyclePage() {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-lg">Quote lifecycle (Slice 2)</CardTitle>
+          <CardTitle className="text-lg">Quote lifecycle (Slice 2/3)</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3 text-sm">
           <div>
@@ -154,7 +183,7 @@ export default function MlP1S2QuoteLifecyclePage() {
             </div>
           </div>
           <p className="text-xs text-slate-500">
-            Job creation is deferred (S3). Approval does not create a job or invoice.
+            Approve ensures exactly one job server-side. No invoice or field scheduling here.
           </p>
         </CardContent>
       </Card>
@@ -283,9 +312,36 @@ export default function MlP1S2QuoteLifecyclePage() {
       )}
 
       {(status === 'accepted' || status === 'approved') && (
-        <p className="text-sm text-slate-600">
-          Quote approved. Accept→job is Slice 3 — not available here.
-        </p>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Job status</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            {jobStatus?.error ? (
+              <p className="text-red-700">Last approve error: {jobStatus.error}</p>
+            ) : linkedJob?.id || jobStatus?.jobId ? (
+              <>
+                <p>
+                  {jobStatus?.jobCreated
+                    ? 'Job created'
+                    : jobStatus?.idempotent
+                      ? 'Idempotent (existing)'
+                      : 'Job linked'}
+                </p>
+                <div className="font-mono text-xs break-all">
+                  {linkedJob?.id || jobStatus?.jobId}
+                </div>
+                {linkedJob?.work_order_number ? (
+                  <p className="text-slate-600">WO {linkedJob.work_order_number}</p>
+                ) : null}
+              </>
+            ) : (
+              <p className="text-slate-600">
+                Quote approved. No linked job yet — retry break-glass approve if create failed.
+              </p>
+            )}
+          </CardContent>
+        </Card>
       )}
     </div>
   );

--- a/command-center/src/pages/crm/proposals/ProposalList.jsx
+++ b/command-center/src/pages/crm/proposals/ProposalList.jsx
@@ -487,12 +487,15 @@ const ProposalList = () => {
                         </Button>
                       )}
 
-                      {(quote.status === 'sent' || quote.status === 'viewed') && (
+                      {(quote.status === 'sent' || quote.status === 'viewed' || quote.status === 'issued') && (
                         <Button
                           variant="outline"
                           size="sm"
                           className="flex-1 min-w-[8rem] border-green-200 text-green-700 hover:bg-green-50"
-                          onClick={() => handleUpdateStatus(quote.id, 'accepted')}
+                          onClick={() =>
+                            navigate(tenantPath(`estimates/p1-lifecycle/${quote.id}`, resolvedTenantId))
+                          }
+                          title="Open lifecycle to approve (creates job server-side)"
                         >
                           <Check className="mr-2 h-4 w-4" /> Accept
                         </Button>
@@ -625,14 +628,16 @@ const ProposalList = () => {
                               </Button>
                             )}
 
-                            {(quote.status === 'sent' || quote.status === 'viewed') && (
+                            {(quote.status === 'sent' || quote.status === 'viewed' || quote.status === 'issued') && (
                               <>
                                 <Button
                                   variant="outline"
                                   size="icon"
                                   className="h-8 w-8 text-green-600 border-green-200 hover:bg-green-50"
-                                  onClick={() => handleUpdateStatus(quote.id, 'accepted')}
-                                  title="Mark Accepted"
+                                  onClick={() =>
+                                    navigate(tenantPath(`estimates/p1-lifecycle/${quote.id}`, resolvedTenantId))
+                                  }
+                                  title="Open lifecycle to approve (creates job server-side)"
                                 >
                                   <Check className="w-4 h-4" />
                                 </Button>

--- a/command-center/src/services/mlP1S2QuoteLifecycleService.js
+++ b/command-center/src/services/mlP1S2QuoteLifecycleService.js
@@ -24,12 +24,16 @@ const IMMUTABLE_CONTENT = new Set([
 
 export const ML_P1_S2_TRANSITIONS = Object.freeze({
   issue: { from: new Set(['draft']), to: ML_P1_S2_STATUSES.ISSUED },
-  approve: { from: new Set(['issued']), to: ML_P1_S2_STATUSES.APPROVED },
-  reject: { from: new Set(['issued', 'draft']), to: ML_P1_S2_STATUSES.REJECTED },
-  expire: { from: new Set(['issued']), to: ML_P1_S2_STATUSES.EXPIRED },
+  approve: { from: new Set(['issued', 'sent', 'viewed']), to: ML_P1_S2_STATUSES.APPROVED },
+  reject: { from: new Set(['issued', 'draft', 'sent', 'viewed']), to: ML_P1_S2_STATUSES.REJECTED },
+  expire: { from: new Set(['issued', 'sent', 'viewed']), to: ML_P1_S2_STATUSES.EXPIRED },
   revise: {
-    from: new Set(['issued', 'rejected', 'expired']),
+    from: new Set(['issued', 'rejected', 'expired', 'sent', 'viewed']),
     to: ML_P1_S2_STATUSES.REVISED,
+  },
+  ensure_job: {
+    from: new Set(['approved', 'accepted']),
+    to: ML_P1_S2_STATUSES.ACCEPTED,
   },
 });
 
@@ -220,6 +224,12 @@ export function createMlP1S2QuoteLifecycleService(deps) {
     rejectQuote: (args) => callLifecycleRpc({ ...args, action: 'reject' }),
     expireQuote: (args) => callLifecycleRpc({ ...args, action: 'expire' }),
     reviseQuote: (args) => callLifecycleRpc({ ...args, action: 'revise' }),
+    ensureJobForQuote: (args) =>
+      callLifecycleRpc({
+        ...args,
+        action: 'ensure_job',
+        approvalMethod: args.approvalMethod || 'admin_break_glass',
+      }),
     approveByPublicToken,
     assertTransitionAllowed,
     assertQuoteMutableForEdit,

--- a/command-center/src/services/mlP1S2QuoteLifecycleService.js
+++ b/command-center/src/services/mlP1S2QuoteLifecycleService.js
@@ -103,7 +103,13 @@ function mapRpcError(error) {
     err.code = 'ML_P1_S2_TRANSITION_DENY';
   } else if (/ML_P1_S2_JOB_GATE_REQUIRED/i.test(msg)) {
     err.code = 'ML_P1_S2_JOB_GATE_REQUIRED';
-  } else if (/ML_P1_S2_QUOTE_NOT_FOUND/i.test(msg)) {
+  } else if (/ML_P1_S3_ADDRESS_REQUIRED/i.test(msg)) {
+    err.code = 'ML_P1_S3_ADDRESS_REQUIRED';
+  } else if (/ML_P1_S3_VERSION_MISMATCH/i.test(msg)) {
+    err.code = 'ML_P1_S3_VERSION_MISMATCH';
+  } else if (/ML_P1_S3_STATUS_DENY/i.test(msg)) {
+    err.code = 'ML_P1_S3_STATUS_DENY';
+  } else if (/ML_P1_S2_QUOTE_NOT_FOUND|ML_P1_S3_QUOTE_NOT_FOUND/i.test(msg)) {
     err.code = 'ML_P1_S2_QUOTE_NOT_FOUND';
   } else if (/ML_P1_S2_MISSING_TOKEN/i.test(msg)) {
     err.code = 'ML_P1_S2_MISSING_TOKEN';
@@ -120,6 +126,7 @@ function mapRpcError(error) {
 
 function normalizeRpcResult(data) {
   const payload = data && typeof data === 'object' ? data : {};
+  const jobId = payload.jobId ?? payload.job_id ?? null;
   return {
     quote: payload.quote || null,
     action: payload.action,
@@ -127,7 +134,9 @@ function normalizeRpcResult(data) {
     correlationId: payload.correlationId || null,
     audit: { ok: true, server: true },
     idempotent: Boolean(payload.idempotent),
-    jobCreated: false, // Slice 2 hard stop — never claim job create
+    // Slice 3: surface server job ensure result (approve path only creates jobs).
+    jobCreated: Boolean(payload.jobCreated ?? payload.job_created),
+    jobId: jobId ? String(jobId) : null,
   };
 }
 

--- a/command-center/supabase/functions/kanban-move/index.ts
+++ b/command-center/supabase/functions/kanban-move/index.ts
@@ -175,6 +175,8 @@ const getOrCreateQuoteForLead = async (lead: Record<string, unknown>) => {
 };
 
 const getOrCreateJobForQuote = async (quote: Record<string, unknown>) => {
+  // ML-P1 S3: quote-linked jobs are created only by ml_p1_s3_ensure_job_for_accepted_quote.
+  // Kanban may attach to an existing job; it must not insert independently.
   const { data: existing } = await supabaseAdmin
     .from('jobs')
     .select('id, status, quote_id, tenant_id')
@@ -184,51 +186,9 @@ const getOrCreateJobForQuote = async (quote: Record<string, unknown>) => {
 
   if (existing?.id) return existing;
 
-  const nowIso = new Date().toISOString();
-  const workOrderNumber = await allocateWorkOrderNumber(String(quote.tenant_id ?? ''), quote.quote_number, nowIso);
-  const serviceAddress = await resolveLeadServiceAddress(String(quote.tenant_id ?? ''), asString(quote.lead_id));
-  const richInsert: Record<string, unknown> = {
-    quote_id: quote.id,
-    lead_id: quote.lead_id ?? null,
-    tenant_id: quote.tenant_id,
-    status: 'scheduled',
-    total_amount: quote.total_amount ?? 0,
-    quote_number: asTracking(quote.quote_number) || null,
-    work_order_number: workOrderNumber,
-    job_number: workOrderNumber,
-    payment_status: 'unpaid',
-    service_address: serviceAddress,
-    created_at: nowIso,
-    updated_at: nowIso,
-  };
-
-  let { data, error } = await supabaseAdmin
-    .from('jobs')
-    .insert(richInsert)
-    .select('id, status, quote_id, tenant_id')
-    .single();
-
-  if (error && isMissingColumnError(error)) {
-    const fallbackInsert = await supabaseAdmin
-      .from('jobs')
-      .insert({
-        quote_id: quote.id,
-        lead_id: quote.lead_id ?? null,
-        tenant_id: quote.tenant_id,
-        status: 'scheduled',
-        total_amount: quote.total_amount ?? 0,
-        created_at: nowIso,
-        updated_at: nowIso,
-      })
-      .select('id, status, quote_id, tenant_id')
-      .single();
-
-    data = fallbackInsert.data;
-    error = fallbackInsert.error;
-  }
-
-  if (error || !data) throw error || new Error('Failed to create job');
-  return data;
+  throw new Error(
+    'ML_P1_S3_JOB_REQUIRED: quote has no job; approve via lifecycle/public-quote-approve first',
+  );
 };
 
 const getOrCreateInvoiceForJob = async (job: Record<string, unknown>) => {
@@ -534,20 +494,16 @@ Deno.serve(async (req) => {
         return respondJson({ error: viewedError.message }, 500, cors.headers);
       }
     } else if (['quote_sent', 'quote_viewed'].includes(fromColumnKey) && toColumnKey === 'quote_accepted') {
-      const { error: acceptedError } = await supabaseAdmin
-        .from('quotes')
-        .update({ status: 'accepted', accepted_at: new Date().toISOString(), updated_at: new Date().toISOString() })
-        .eq('id', quote.id)
-        .eq('tenant_id', jwtTenantId);
-      if (acceptedError) {
-        return respondJson({ error: acceptedError.message }, 500, cors.headers);
-      }
-
-      await closeFollowUpTasks({
-        tenantId: quote.tenant_id,
-        sourceType: 'quote',
-        sourceId: quote.id,
-      });
+      // ML-P1 S3: accept→job only via canonical approve RPCs — not kanban status write.
+      return respondJson(
+        {
+          error:
+            'ML_P1_S3_STATUS_PATH_DENY: accept quote via lifecycle or public-quote-approve (creates job)',
+          code: 'ML_P1_S3_STATUS_PATH_DENY',
+        },
+        403,
+        cors.headers,
+      );
     } else if (fromColumnKey === 'quote_accepted' && toColumnKey === 'job_scheduled') {
       const job = await getOrCreateJobForQuote(quote);
       const { error: quoteUpdateError } = await supabaseAdmin

--- a/command-center/supabase/functions/public-quote-approve/index.ts
+++ b/command-center/supabase/functions/public-quote-approve/index.ts
@@ -764,37 +764,50 @@ Deno.serve(async (req) => {
       );
     }
 
-    // If RPC missing (pre-A3), continue with direct update — still no job create.
+    // S3: approve requires canonical RPC (approve+job same txn). No fallback approve.
     const rpcMissing = /Could not find the function|function .* does not exist|PGRST202/i.test(
       String(rpcAttempt.error?.message || ''),
     );
-    if (!rpcMissing) {
-      await logPublicEvent({
-        kind: 'public_quote_approve',
-        tenantId,
-        quoteId: existingQuote.id,
-        token,
-        status: 'rpc_error',
-        ip,
-        userAgent,
-        metadata: { run_id: runId, error: rpcAttempt.error?.message },
-      });
-      return respondJson(
-        {
-          error: rpcAttempt.error?.message || 'Approve failed',
-          code: 'ML_P1_S2_APPROVE_FAILED',
-          job_created: false,
-        },
-        409,
-        cors.headers,
-      );
-    }
+    await logPublicEvent({
+      kind: 'public_quote_approve',
+      tenantId,
+      quoteId: existingQuote.id,
+      token,
+      status: rpcMissing ? 'writer_required' : 'rpc_error',
+      ip,
+      userAgent,
+      metadata: { run_id: runId, error: rpcAttempt.error?.message, slice: 'ml-p1-s3' },
+    });
+    return respondJson(
+      {
+        error: rpcMissing
+          ? 'Quote approve requires Slice 3 canonical job writer RPC (migration not applied).'
+          : rpcAttempt.error?.message || 'Approve failed',
+        code: rpcMissing ? 'ML_P1_S3_WRITER_REQUIRED' : 'ML_P1_S2_APPROVE_FAILED',
+        job_created: false,
+      },
+      rpcMissing ? 503 : 409,
+      cors.headers,
+    );
   }
 
+  // Decline-only path below (approve never falls through).
   if (!isDecline) {
+    return respondJson(
+      {
+        error: 'Approve must use ml_p1_s2_quote_approve_public',
+        code: 'ML_P1_S3_WRITER_REQUIRED',
+        job_created: false,
+      },
+      503,
+      cors.headers,
+    );
+  }
+
+  {
     const amount = asNumber(existingQuote.total_amount);
-    patch.approved_amount = amount;
-    patch.approved_by_actor_id = null;
+    // decline path does not set approved_amount
+    void amount;
   }
 
   let updateQuery = supabaseAdmin
@@ -803,11 +816,6 @@ Deno.serve(async (req) => {
     .eq('id', existingQuote.id)
     .eq('tenant_id', tenantId)
     .eq('public_token', token);
-
-  // Concurrent-safe approve: only transition from issued.
-  if (!isDecline) {
-    updateQuery = updateQuery.eq('status', 'issued');
-  }
 
   const { data, error } = await updateQuery
     .select(`
@@ -835,30 +843,6 @@ Deno.serve(async (req) => {
     .maybeSingle();
 
   if (error || !data) {
-    // Idempotent approve replay
-    if (!isDecline) {
-      const { data: again } = await supabaseAdmin
-        .from('quotes')
-        .select('*')
-        .eq('id', existingQuote.id)
-        .eq('tenant_id', tenantId)
-        .maybeSingle();
-      const againStatus = asString(again?.status).toLowerCase();
-      if (again && ['approved', 'accepted'].includes(againStatus)) {
-        return respondJson(
-          {
-            quote: again,
-            quote_result: 'approved',
-            invoice_id: null,
-            invoice_token: null,
-            job_created: false,
-            idempotent: true,
-          },
-          200,
-          cors.headers,
-        );
-      }
-    }
     await logPublicEvent({
       kind: 'public_quote_approve',
       tenantId,
@@ -877,7 +861,7 @@ Deno.serve(async (req) => {
     tenantId,
     quoteId: data.id,
     token,
-    status: isDecline ? 'rejected' : 'approved',
+    status: 'rejected',
     ip,
     userAgent,
     metadata: { run_id: runId },
@@ -885,43 +869,21 @@ Deno.serve(async (req) => {
 
   const actorType = 'public';
 
-  if (isDecline) {
-    if (
-      !(await hasEvent({
-        entityType: 'quote',
-        entityId: data.id,
-        eventType: 'QuoteDeclined',
-      }))
-    ) {
-      await logMoneyLoopEvent({
-        tenantId,
-        entityType: 'quote',
-        entityId: data.id,
-        eventType: 'QuoteDeclined',
-        actorType,
-        payload: { run_id: runId },
-      });
-    }
-  } else {
-    if (
-      !(await hasEvent({
-        entityType: 'quote',
-        entityId: data.id,
-        eventType: 'QuoteAccepted',
-      }))
-    ) {
-      await logMoneyLoopEvent({
-        tenantId,
-        entityType: 'quote',
-        entityId: data.id,
-        eventType: 'QuoteAccepted',
-        actorType,
-        payload: { run_id: runId, job_created: false, slice: 'ml-p1-s2' },
-      });
-    }
-
-    // ML-P1 S2 hard stop: NO job creation, NO schedule-job task, NO invoice.
-    // Accept→job remains Slice 3.
+  if (
+    !(await hasEvent({
+      entityType: 'quote',
+      entityId: data.id,
+      eventType: 'QuoteDeclined',
+    }))
+  ) {
+    await logMoneyLoopEvent({
+      tenantId,
+      entityType: 'quote',
+      entityId: data.id,
+      eventType: 'QuoteDeclined',
+      actorType,
+      payload: { run_id: runId },
+    });
   }
 
   resolvedInvoiceId = null;
@@ -930,7 +892,7 @@ Deno.serve(async (req) => {
   const acceptHeader = (req.headers.get('accept') || '').toLowerCase();
   if (req.method === 'GET' || acceptHeader.includes('text/html')) {
     const resultParams = {
-      approved: !isDecline,
+      approved: false,
       quoteId: data.id,
       token,
       tenantId,
@@ -944,7 +906,7 @@ Deno.serve(async (req) => {
   return respondJson(
     {
       quote: data,
-      quote_result: isDecline ? 'rejected' : 'approved',
+      quote_result: 'rejected',
       invoice_id: resolvedInvoiceId,
       invoice_token: resolvedInvoiceToken,
       job_created: false,

--- a/command-center/supabase/functions/public-quote-approve/index.ts
+++ b/command-center/supabase/functions/public-quote-approve/index.ts
@@ -10,6 +10,7 @@ import {
   hasEvent,
   logMoneyLoopEvent,
 } from '../_shared/moneyLoopUtils.ts';
+import { closeFollowUpTasks } from '../_shared/taskUtils.ts';
 
 const respondJson = (body: Record<string, unknown>, status: number, headers: Record<string, string>) =>
   new Response(JSON.stringify(body), {
@@ -736,6 +737,12 @@ Deno.serve(async (req) => {
           },
         });
       }
+
+      await closeFollowUpTasks({
+        tenantId,
+        sourceType: 'quote',
+        sourceId: String(rpcQuote.id || existingQuote.id),
+      });
 
       const acceptHeaderRpc = (req.headers.get('accept') || '').toLowerCase();
       if (req.method === 'GET' || acceptHeaderRpc.includes('text/html')) {

--- a/command-center/supabase/functions/public-quote-approve/index.ts
+++ b/command-center/supabase/functions/public-quote-approve/index.ts
@@ -682,42 +682,9 @@ Deno.serve(async (req) => {
     );
   }
 
-  // ML-P1 S2: prefer server RPC for approve (role/transition/gate/idempotency).
-  // Fail closed on approve if job-create gate is not explicitly off (eliminates pre-A3 auto-job).
+  // ML-P1 S3: prefer server RPC for approve (role/transition/idempotency + canonical job).
+  // Gate-off precheck retired — writer is mandatory inside approve RPC.
   if (!isDecline) {
-    const { data: gateRow, error: gateErr } = await supabaseAdmin
-      .from('global_config')
-      .select('value')
-      .eq('key', 'auto_create_job_on_quote_acceptance')
-      .maybeSingle();
-
-    const gateValue = String(gateRow?.value ?? 'true')
-      .trim()
-      .toLowerCase();
-    const gateOff = ['0', 'false', 'no', 'off'].includes(gateValue);
-    if (gateErr || !gateOff) {
-      await logPublicEvent({
-        kind: 'public_quote_approve',
-        tenantId,
-        quoteId: existingQuote.id,
-        token,
-        status: 'job_gate_required',
-        ip,
-        userAgent,
-        metadata: { run_id: runId, gate_value: gateRow?.value ?? null, error: gateErr?.message },
-      });
-      return respondJson(
-        {
-          error:
-            'Quote approval is deferred until job auto-create is disabled (ML-P1 S2 gate).',
-          code: 'ML_P1_S2_JOB_GATE_REQUIRED',
-          job_created: false,
-        },
-        503,
-        cors.headers,
-      );
-    }
-
     // Prefer SECURITY DEFINER RPC when migration applied (service_role / anon path).
     const rpcAttempt = await supabaseAdmin.rpc('ml_p1_s2_quote_approve_public', {
       p_public_token: token,
@@ -728,6 +695,8 @@ Deno.serve(async (req) => {
     if (!rpcAttempt.error && rpcAttempt.data) {
       const rpcPayload = rpcAttempt.data as Record<string, unknown>;
       const rpcQuote = (rpcPayload.quote || {}) as Record<string, unknown>;
+      const rpcJobId = (rpcPayload.jobId ?? rpcPayload.job_id ?? null) as string | null;
+      const rpcJobCreated = Boolean(rpcPayload.jobCreated ?? rpcPayload.job_created);
       await logPublicEvent({
         kind: 'public_quote_approve',
         tenantId,
@@ -740,6 +709,9 @@ Deno.serve(async (req) => {
           run_id: runId,
           via: 'ml_p1_s2_quote_approve_public',
           idempotent: Boolean(rpcPayload.idempotent),
+          job_id: rpcJobId,
+          job_created: rpcJobCreated,
+          slice: 'ml-p1-s3',
         },
       });
 
@@ -756,7 +728,12 @@ Deno.serve(async (req) => {
           entityId: String(rpcQuote.id || existingQuote.id),
           eventType: 'QuoteAccepted',
           actorType: 'public',
-          payload: { run_id: runId, job_created: false, slice: 'ml-p1-s2' },
+          payload: {
+            run_id: runId,
+            job_created: rpcJobCreated,
+            job_id: rpcJobId,
+            slice: 'ml-p1-s3',
+          },
         });
       }
 
@@ -778,7 +755,8 @@ Deno.serve(async (req) => {
           quote_result: 'approved',
           invoice_id: null,
           invoice_token: null,
-          job_created: false,
+          job_created: rpcJobCreated,
+          job_id: rpcJobId,
           idempotent: Boolean(rpcPayload.idempotent),
         },
         200,

--- a/command-center/supabase/functions/quote-update-status/index.ts
+++ b/command-center/supabase/functions/quote-update-status/index.ts
@@ -1,7 +1,6 @@
 import { supabaseAdmin } from '../_lib/supabaseAdmin.ts';
 import { getTenantIdFromClaims, getVerifiedClaims } from '../_shared/auth.ts';
 import { buildCorsHeaders, readJson } from '../_shared/publicUtils.ts';
-import { closeFollowUpTasks } from '../_shared/taskUtils.ts';
 
 const respondJson = (body: Record<string, unknown>, status: number, headers: Record<string, string>) =>
   new Response(JSON.stringify(body), {
@@ -48,11 +47,23 @@ Deno.serve(async (req) => {
   }
 
   const normalizedStatus = String(status).toLowerCase();
-  const updateData: Record<string, unknown> = { status };
 
+  // ML-P1 S3: quote-update-status must not accept money quotes / create jobs.
+  // Accept/approve goes through ml_p1_s2_quote_lifecycle or public-quote-approve RPC only.
   if (['accepted', 'approved'].includes(normalizedStatus)) {
-    updateData.accepted_at = new Date().toISOString();
+    return respondJson(
+      {
+        error:
+          'Accept/approve is not allowed via quote-update-status. Use lifecycle or public-quote-approve.',
+        code: 'ML_P1_S3_STATUS_PATH_DENY',
+        job_created: false,
+      },
+      403,
+      cors.headers,
+    );
   }
+
+  const updateData: Record<string, unknown> = { status };
 
   if (['rejected', 'declined'].includes(normalizedStatus)) {
     updateData.rejected_at = new Date().toISOString();
@@ -69,14 +80,6 @@ Deno.serve(async (req) => {
 
   if (error || !quote) {
     return respondJson({ error: error?.message || 'Quote not found' }, 404, cors.headers);
-  }
-
-  if (['accepted', 'approved'].includes(normalizedStatus)) {
-    await closeFollowUpTasks({
-      tenantId: quote.tenant_id || jwtTenantId,
-      sourceType: 'quote',
-      sourceId: quote.id,
-    });
   }
 
   return respondJson({ quote }, 200, cors.headers);

--- a/command-center/supabase/migrations/20260721200000_ml_p1_s3_canonical_job_writer.sql
+++ b/command-center/supabase/migrations/20260721200000_ml_p1_s3_canonical_job_writer.sql
@@ -1,0 +1,792 @@
+-- ML-P1 Slice 3 — Canonical server-side job writer (approved quote → exactly one job).
+-- Baseline: ef2470715ddf90c34a77416183eb5b2421bd6373
+-- Does NOT flip auto_create_job_on_quote_acceptance=true.
+-- Stop: before field execution / invoice / Stripe / follow-up.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- M1: Lineage column
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.jobs
+  ADD COLUMN IF NOT EXISTS source_quote_version integer;
+
+COMMENT ON COLUMN public.jobs.source_quote_version IS
+  'ML-P1 S3: quotes.quote_version pinned at canonical accept→job create.';
+
+-- ---------------------------------------------------------------------------
+-- M2: Canonical writer
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.ml_p1_s3_ensure_job_for_accepted_quote(
+  p_quote_id uuid,
+  p_correlation_id text DEFAULT NULL,
+  p_actor_role text DEFAULT NULL,
+  p_source text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_quote public.quotes%ROWTYPE;
+  v_job public.jobs%ROWTYPE;
+  v_job_id uuid;
+  v_created boolean := false;
+  v_idempotent boolean := false;
+  v_now timestamptz := now();
+  v_corr text := coalesce(nullif(btrim(p_correlation_id), ''), gen_random_uuid()::text);
+  v_source text := coalesce(nullif(btrim(p_source), ''), 'lifecycle_approve');
+  v_role text := coalesce(nullif(btrim(p_actor_role), ''), 'system');
+  v_service_address text;
+  v_amount numeric;
+  v_version int;
+BEGIN
+  IF p_quote_id IS NULL THEN
+    RAISE EXCEPTION 'ML_P1_S3_QUOTE_REQUIRED: quote_id required'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO v_quote
+  FROM public.quotes
+  WHERE id = p_quote_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ML_P1_S3_QUOTE_NOT_FOUND: quote not found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_quote.tenant_id IS NULL OR btrim(v_quote.tenant_id) = '' THEN
+    RAISE EXCEPTION 'ML_P1_S3_TENANT_DENY: quote missing tenant_id'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF public.normalize_quote_status(v_quote.status) IS DISTINCT FROM 'accepted' THEN
+    RAISE EXCEPTION 'ML_P1_S3_STATUS_DENY: job ensure requires accepted quote (got %)', v_quote.status
+      USING ERRCODE = '22023';
+  END IF;
+
+  v_version := coalesce(v_quote.quote_version, 1);
+  v_amount := coalesce(v_quote.approved_amount, v_quote.total_amount, 0);
+
+  -- Resolve service address (quote snapshot, else lead+property). Fail closed.
+  v_service_address := nullif(btrim(coalesce(v_quote.service_address, '')), '');
+  IF v_service_address IS NULL AND v_quote.lead_id IS NOT NULL THEN
+    SELECT nullif(
+      btrim(
+        concat_ws(
+          ', ',
+          nullif(btrim(concat_ws(' ', nullif(p.address1, ''), nullif(p.address2, ''))), ''),
+          nullif(btrim(p.city), ''),
+          nullif(btrim(p.state), ''),
+          nullif(btrim(p.zip), '')
+        )
+      ),
+      ''
+    )
+    INTO v_service_address
+    FROM public.leads l
+    LEFT JOIN public.properties p ON p.id = l.property_id
+    WHERE l.id = v_quote.lead_id
+    LIMIT 1;
+  END IF;
+
+  IF v_service_address IS NULL THEN
+    RAISE EXCEPTION 'ML_P1_S3_ADDRESS_REQUIRED: service address required before job create'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Idempotent path: existing quote-linked job.
+  SELECT * INTO v_job
+  FROM public.jobs
+  WHERE quote_id = v_quote.id
+  LIMIT 1;
+
+  IF FOUND THEN
+    IF v_job.source_quote_version IS NOT NULL
+       AND v_job.source_quote_version IS DISTINCT FROM v_version THEN
+      RAISE EXCEPTION 'ML_P1_S3_VERSION_MISMATCH: existing job pinned to version %; quote is %',
+        v_job.source_quote_version, v_version
+        USING ERRCODE = '22023';
+    END IF;
+
+    -- Backfill empty address / missing version pin only (no pricing drift).
+    UPDATE public.jobs
+    SET
+      updated_at = v_now,
+      source_quote_version = coalesce(source_quote_version, v_version),
+      service_address = CASE
+        WHEN service_address IS NULL OR btrim(service_address) = '' THEN v_service_address
+        ELSE service_address
+      END
+    WHERE id = v_job.id
+    RETURNING * INTO v_job;
+
+    INSERT INTO public.events (tenant_id, entity_type, entity_id, event_type, actor_type, actor_id, payload)
+    VALUES (
+      v_quote.tenant_id,
+      'quote',
+      v_quote.id,
+      'QuoteAccepted_JobEnsured',
+      v_role,
+      NULL,
+      jsonb_build_object(
+        'job_id', v_job.id,
+        'quote_id', v_quote.id,
+        'quote_version', v_version,
+        'correlation_id', v_corr,
+        'source', v_source,
+        'idempotent', true,
+        'created', false,
+        'slice', 'ml-p1-s3'
+      )
+    );
+
+    RETURN jsonb_build_object(
+      'job_id', v_job.id,
+      'created', false,
+      'idempotent', true
+    );
+  END IF;
+
+  BEGIN
+    INSERT INTO public.jobs (
+      tenant_id,
+      lead_id,
+      quote_id,
+      quote_number,
+      status,
+      payment_status,
+      total_amount,
+      service_address,
+      work_order_number,
+      source_quote_version
+    ) VALUES (
+      v_quote.tenant_id,
+      v_quote.lead_id,
+      v_quote.id,
+      v_quote.quote_number,
+      'unscheduled',
+      'unpaid',
+      v_amount,
+      v_service_address,
+      public.next_work_order_number(v_quote.tenant_id, coalesce(v_quote.created_at, v_now)),
+      v_version
+    )
+    ON CONFLICT (quote_id) WHERE quote_id IS NOT NULL
+    DO NOTHING
+    RETURNING id INTO v_job_id;
+  EXCEPTION
+    WHEN unique_violation THEN
+      v_job_id := NULL;
+  END;
+
+  IF v_job_id IS NULL THEN
+    SELECT id INTO v_job_id
+    FROM public.jobs
+    WHERE quote_id = v_quote.id
+    LIMIT 1;
+
+    IF v_job_id IS NULL THEN
+      RAISE EXCEPTION 'ML_P1_S3_JOB_ENSURE_FAILED: could not create or load job for quote'
+        USING ERRCODE = 'P0001';
+    END IF;
+
+    v_created := false;
+    v_idempotent := true;
+  ELSE
+    v_created := true;
+    v_idempotent := false;
+  END IF;
+
+  INSERT INTO public.events (tenant_id, entity_type, entity_id, event_type, actor_type, actor_id, payload)
+  VALUES (
+    v_quote.tenant_id,
+    'quote',
+    v_quote.id,
+    'QuoteAccepted_JobEnsured',
+    v_role,
+    NULL,
+    jsonb_build_object(
+      'job_id', v_job_id,
+      'quote_id', v_quote.id,
+      'quote_version', v_version,
+      'correlation_id', v_corr,
+      'source', v_source,
+      'idempotent', v_idempotent,
+      'created', v_created,
+      'slice', 'ml-p1-s3'
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'job_id', v_job_id,
+    'created', v_created,
+    'idempotent', v_idempotent
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ml_p1_s3_ensure_job_for_accepted_quote(uuid, text, text, text) FROM PUBLIC;
+-- Callable only by SECURITY DEFINER approve RPCs (same owner); no client GRANT.
+
+-- ---------------------------------------------------------------------------
+-- M4: Neutralize trigger inserts — accepted/paid never create jobs.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.ensure_job_and_optional_draft_invoice_for_accepted_quote()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_new_status text;
+  v_old_status text;
+BEGIN
+  v_new_status := public.normalize_quote_status(new.status);
+
+  IF tg_op = 'INSERT' THEN
+    v_old_status := '';
+  ELSE
+    v_old_status := public.normalize_quote_status(old.status);
+  END IF;
+
+  IF new.tenant_id IS NULL OR btrim(new.tenant_id) = '' THEN
+    RETURN new;
+  END IF;
+
+  -- S3: accept → deferred only. Canonical create is RPC-only.
+  IF v_new_status = 'accepted' AND v_old_status <> 'accepted' THEN
+    INSERT INTO public.events (tenant_id, entity_type, entity_id, event_type, actor_type, payload)
+    VALUES (
+      new.tenant_id,
+      'quote',
+      new.id,
+      'QuoteAccepted_JobCreateDeferred',
+      'system',
+      jsonb_build_object(
+        'reason', 'ml-p1-s3-rpc-only-job-writer',
+        'slice', 'ml-p1-s3',
+        'auto_create_job_on_quote_acceptance', 'ignored'
+      )
+    );
+    RETURN new;
+  END IF;
+
+  -- S3: paid → deferred only (no job/invoice inserts).
+  IF lower(btrim(coalesce(new.status, ''))) = 'paid'
+     AND lower(btrim(coalesce(old.status, ''))) <> 'paid' THEN
+    INSERT INTO public.events (tenant_id, entity_type, entity_id, event_type, actor_type, payload)
+    VALUES (
+      new.tenant_id,
+      'quote',
+      new.id,
+      'QuotePaid_JobCreateDeferred',
+      'system',
+      jsonb_build_object(
+        'reason', 'ml-p1-s3-paid-deferred-no-job-insert',
+        'slice', 'ml-p1-s3'
+      )
+    );
+    RETURN new;
+  END IF;
+
+  RETURN new;
+END;
+$$;
+
+-- Keep WO-on-accept neutralized (still deferred).
+CREATE OR REPLACE FUNCTION public.trg_emit_wo_on_quote_accept()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_new text;
+  v_old text;
+BEGIN
+  v_new := public.normalize_quote_status(new.status);
+  IF tg_op = 'INSERT' THEN
+    v_old := '';
+  ELSE
+    v_old := public.normalize_quote_status(old.status);
+  END IF;
+
+  IF v_new = 'accepted' AND v_old IS DISTINCT FROM 'accepted' THEN
+    INSERT INTO public.events (tenant_id, entity_type, entity_id, event_type, actor_type, payload)
+    VALUES (
+      new.tenant_id,
+      'quote',
+      new.id,
+      'QuoteAccepted_WorkOrderDeferred',
+      'system',
+      jsonb_build_object(
+        'reason', 'ml-p1-s3-wo-neutralized',
+        'slice', 'ml-p1-s3'
+      )
+    );
+  END IF;
+
+  RETURN new;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- M3: Drop S2 gate-off accept belt (writer is mandatory in approve RPCs).
+-- ---------------------------------------------------------------------------
+DROP TRIGGER IF EXISTS trg_ml_p1_s2_require_job_gate_off_on_accept ON public.quotes;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s2_trg_require_job_gate_off_on_accept()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- S3: belt retired. Accept is allowed; job ensure is RPC-owned.
+  RETURN new;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Wire approve RPCs: remove gate checks; call canonical writer in-txn.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.ml_p1_s2_quote_lifecycle(
+  p_action text,
+  p_quote_id uuid,
+  p_reason_code text DEFAULT NULL,
+  p_rejection_reason text DEFAULT NULL,
+  p_approval_method text DEFAULT NULL,
+  p_valid_until date DEFAULT NULL,
+  p_correlation_id text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_action text := lower(btrim(coalesce(p_action, '')));
+  v_role text := public.ml_p1_s2_current_actor_role();
+  v_uid uuid := auth.uid();
+  v_tenant text;
+  v_jwt_tenant text;
+  v_quote public.quotes%ROWTYPE;
+  v_prev text;
+  v_now timestamptz := now();
+  v_corr text := coalesce(nullif(btrim(p_correlation_id), ''), gen_random_uuid()::text);
+  v_capability text;
+  v_draft public.quotes%ROWTYPE;
+  v_next_version int;
+  v_amount numeric;
+  v_updated int;
+  v_job jsonb;
+  v_job_id uuid;
+  v_job_created boolean := false;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'ML_P1_S2_ROLE_DENY: unauthenticated actor cannot mutate quote money state'
+      USING ERRCODE = '42501';
+  END IF;
+
+  v_jwt_tenant := nullif(btrim(coalesce(
+    auth.jwt() -> 'app_metadata' ->> 'tenant_id',
+    ''
+  )), '');
+  IF v_jwt_tenant IS NULL THEN
+    RAISE EXCEPTION 'ML_P1_S2_TENANT_DENY: missing TVG tenant context'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO v_quote
+  FROM public.quotes
+  WHERE id = p_quote_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ML_P1_S2_QUOTE_NOT_FOUND: quote not found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_quote.tenant_id IS DISTINCT FROM v_jwt_tenant THEN
+    RAISE EXCEPTION 'ML_P1_S2_TENANT_DENY: quote tenant mismatch'
+      USING ERRCODE = '42501';
+  END IF;
+
+  v_tenant := v_quote.tenant_id;
+  v_prev := v_quote.status;
+
+  IF v_action = 'approve' THEN
+    v_capability := 'quote.approve_break_glass';
+  ELSIF v_action = 'issue' THEN
+    v_capability := 'quote.issue';
+  ELSIF v_action = 'revise' THEN
+    v_capability := 'quote.revise';
+  ELSIF v_action = 'reject' THEN
+    v_capability := 'quote.reject_office';
+  ELSIF v_action = 'expire' THEN
+    v_capability := 'quote.expire';
+  ELSE
+    RAISE EXCEPTION 'ML_P1_S2_UNKNOWN_ACTION: %', p_action USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM public.ml_p1_s2_assert_capability(v_capability, v_role, p_reason_code);
+  PERFORM public.ml_p1_s2_assert_transition(v_action, v_quote.status);
+
+  IF v_action = 'revise' THEN
+    v_next_version := coalesce(v_quote.quote_version, 1) + 1;
+    v_amount := coalesce(v_quote.total_amount, 0);
+
+    UPDATE public.quotes
+    SET status = 'revised', updated_at = v_now
+    WHERE id = v_quote.id
+      AND tenant_id = v_tenant
+      AND lower(status) = lower(v_prev);
+
+    GET DIAGNOSTICS v_updated = ROW_COUNT;
+    IF v_updated <> 1 THEN
+      RAISE EXCEPTION 'ML_P1_S2_TRANSITION_DENY: concurrent revise conflict'
+        USING ERRCODE = '40001';
+    END IF;
+
+    INSERT INTO public.quotes (
+      lead_id, tenant_id, status, service_address, customer_name, customer_email, customer_phone,
+      subtotal, total_amount, tax_amount, tax_rate, header_text, footer_text, fulfillment_mode,
+      estimate_id, user_id, inspection_id, inspection_revision, line_items,
+      quote_version, supersedes_quote_id, created_at, updated_at
+    ) VALUES (
+      v_quote.lead_id, v_tenant, 'draft', v_quote.service_address, v_quote.customer_name,
+      v_quote.customer_email, v_quote.customer_phone, v_quote.subtotal, v_amount,
+      coalesce(v_quote.tax_amount, 0), coalesce(v_quote.tax_rate, 0),
+      v_quote.header_text, v_quote.footer_text, v_quote.fulfillment_mode,
+      v_quote.estimate_id, v_quote.user_id, v_quote.inspection_id, v_quote.inspection_revision,
+      coalesce(v_quote.line_items, '[]'::jsonb),
+      v_next_version, v_quote.id, v_now, v_now
+    )
+    RETURNING * INTO v_draft;
+
+    INSERT INTO public.quote_items (quote_id, description, quantity, unit_price, total_price)
+    SELECT v_draft.id, qi.description, qi.quantity, qi.unit_price, qi.total_price
+    FROM public.quote_items qi
+    WHERE qi.quote_id = v_quote.id;
+
+    INSERT INTO public.events (tenant_id, entity_type, entity_id, event_type, actor_type, actor_id, payload)
+    VALUES (
+      v_tenant, 'quote', v_draft.id, 'quote.revised', v_role, v_uid::text,
+      jsonb_build_object(
+        'event_id', gen_random_uuid()::text,
+        'record_id', v_draft.id,
+        'record_type', 'quote',
+        'tenant_id', v_tenant,
+        'actor_id', v_uid::text,
+        'actor_role', v_role,
+        'previous_state', v_prev,
+        'new_state', 'draft',
+        'reason', coalesce(p_reason_code, 'revise'),
+        'source_action', 'ml_p1_s2.revise_quote',
+        'correlation_id', v_corr,
+        'success', true,
+        'timestamp', v_now,
+        'quote_id', v_draft.id,
+        'lead_id', v_draft.lead_id,
+        'quote_version', v_draft.quote_version,
+        'supersedes_quote_id', v_quote.id,
+        'job_id', NULL,
+        'invoice_id', NULL
+      )
+    );
+
+    RETURN jsonb_build_object(
+      'action', 'revise',
+      'jobCreated', false,
+      'idempotent', false,
+      'jobId', NULL,
+      'correlationId', v_corr,
+      'superseded', v_quote.id,
+      'quote', to_jsonb(v_draft)
+    );
+  END IF;
+
+  IF v_action = 'issue' THEN
+    UPDATE public.quotes
+    SET status = 'issued',
+        issued_at = v_now,
+        valid_until = coalesce(p_valid_until, valid_until),
+        updated_at = v_now
+    WHERE id = v_quote.id
+      AND tenant_id = v_tenant
+      AND lower(status) = 'draft'
+    RETURNING * INTO v_quote;
+  ELSIF v_action = 'approve' THEN
+    UPDATE public.quotes
+    SET status = 'approved',
+        accepted_at = v_now,
+        approval_method = coalesce(nullif(btrim(p_approval_method), ''), 'admin_break_glass'),
+        approved_by_actor_id = v_uid::text,
+        approved_amount = coalesce(total_amount, 0),
+        updated_at = v_now
+    WHERE id = v_quote.id
+      AND tenant_id = v_tenant
+      AND lower(status) = 'issued'
+    RETURNING * INTO v_quote;
+  ELSIF v_action = 'reject' THEN
+    UPDATE public.quotes
+    SET status = 'rejected',
+        rejected_at = v_now,
+        rejection_reason = coalesce(p_rejection_reason, p_reason_code, 'rejected'),
+        updated_at = v_now
+    WHERE id = v_quote.id
+      AND tenant_id = v_tenant
+      AND lower(status) IN ('issued', 'draft')
+    RETURNING * INTO v_quote;
+  ELSIF v_action = 'expire' THEN
+    UPDATE public.quotes
+    SET status = 'expired',
+        expired_at = v_now,
+        updated_at = v_now
+    WHERE id = v_quote.id
+      AND tenant_id = v_tenant
+      AND lower(status) = 'issued'
+    RETURNING * INTO v_quote;
+  END IF;
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  IF v_updated <> 1 THEN
+    SELECT * INTO v_quote FROM public.quotes WHERE id = p_quote_id AND tenant_id = v_tenant;
+    IF v_action = 'approve' AND public.normalize_quote_status(v_quote.status) = 'accepted' THEN
+      v_job := public.ml_p1_s3_ensure_job_for_accepted_quote(
+        v_quote.id, v_corr, v_role, 'office_break_glass'
+      );
+      RETURN jsonb_build_object(
+        'action', 'approve',
+        'jobCreated', coalesce((v_job->>'created')::boolean, false),
+        'idempotent', true,
+        'jobId', v_job->>'job_id',
+        'correlationId', v_corr,
+        'quote', to_jsonb(v_quote)
+      );
+    END IF;
+    RAISE EXCEPTION 'ML_P1_S2_TRANSITION_DENY: concurrent transition conflict for %', v_action
+      USING ERRCODE = '40001';
+  END IF;
+
+  IF v_action = 'approve' THEN
+    v_job := public.ml_p1_s3_ensure_job_for_accepted_quote(
+      v_quote.id, v_corr, v_role, 'office_break_glass'
+    );
+    v_job_id := nullif(v_job->>'job_id', '')::uuid;
+    v_job_created := coalesce((v_job->>'created')::boolean, false);
+  END IF;
+
+  INSERT INTO public.events (tenant_id, entity_type, entity_id, event_type, actor_type, actor_id, payload)
+  VALUES (
+    v_tenant,
+    'quote',
+    v_quote.id,
+    CASE v_action
+      WHEN 'issue' THEN 'quote.issued'
+      WHEN 'approve' THEN 'quote.approved'
+      WHEN 'reject' THEN 'quote.rejected'
+      WHEN 'expire' THEN 'quote.expired'
+    END,
+    v_role,
+    v_uid::text,
+    jsonb_build_object(
+      'event_id', gen_random_uuid()::text,
+      'record_id', v_quote.id,
+      'record_type', 'quote',
+      'tenant_id', v_tenant,
+      'actor_id', v_uid::text,
+      'actor_role', v_role,
+      'previous_state', v_prev,
+      'new_state', v_quote.status,
+      'reason', coalesce(p_reason_code, p_rejection_reason),
+      'source_action', 'ml_p1_s2.' || v_action || '_quote',
+      'correlation_id', v_corr,
+      'success', true,
+      'timestamp', v_now,
+      'quote_id', v_quote.id,
+      'lead_id', v_quote.lead_id,
+      'quote_version', v_quote.quote_version,
+      'approved_amount', v_quote.approved_amount,
+      'approval_method', v_quote.approval_method,
+      'job_id', v_job_id,
+      'invoice_id', NULL
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'action', v_action,
+    'jobCreated', v_job_created,
+    'idempotent', false,
+    'jobId', v_job_id,
+    'correlationId', v_corr,
+    'quote', to_jsonb(v_quote)
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s2_quote_approve_public(
+  p_public_token text,
+  p_correlation_id text DEFAULT NULL,
+  p_approval_method text DEFAULT 'public_token'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_token text := btrim(coalesce(p_public_token, ''));
+  v_quote public.quotes%ROWTYPE;
+  v_prev text;
+  v_now timestamptz := now();
+  v_corr text := coalesce(nullif(btrim(p_correlation_id), ''), gen_random_uuid()::text);
+  v_updated int;
+  v_expiry timestamptz;
+  v_job jsonb;
+  v_job_id uuid;
+  v_job_created boolean := false;
+BEGIN
+  IF auth.uid() IS NOT NULL THEN
+    RAISE EXCEPTION 'ML_P1_S2_ROLE_DENY: authenticated sessions cannot use public-token approve'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_token = '' THEN
+    RAISE EXCEPTION 'ML_P1_S2_MISSING_TOKEN: public_token required'
+      USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM public.ml_p1_s2_assert_capability('quote.approve_customer', 'customer', NULL);
+
+  SELECT * INTO v_quote
+  FROM public.quotes
+  WHERE public_token::text = v_token
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ML_P1_S2_QUOTE_NOT_FOUND: quote not found for token'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_quote.tenant_id IS NULL OR btrim(v_quote.tenant_id) = '' THEN
+    RAISE EXCEPTION 'ML_P1_S2_TENANT_DENY: quote missing tenant_id'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF public.normalize_quote_status(v_quote.status) = 'accepted' THEN
+    v_job := public.ml_p1_s3_ensure_job_for_accepted_quote(
+      v_quote.id, v_corr, 'customer', 'customer_public'
+    );
+    RETURN jsonb_build_object(
+      'action', 'approve',
+      'jobCreated', coalesce((v_job->>'created')::boolean, false),
+      'idempotent', true,
+      'jobId', v_job->>'job_id',
+      'correlationId', v_corr,
+      'quote', to_jsonb(v_quote)
+    );
+  END IF;
+
+  IF v_quote.valid_until IS NOT NULL THEN
+    v_expiry := ((v_quote.valid_until::date + 1)::timestamp AT TIME ZONE 'UTC') - interval '1 second';
+  ELSIF v_quote.sent_at IS NOT NULL THEN
+    v_expiry := v_quote.sent_at + interval '7 days';
+  ELSE
+    v_expiry := NULL;
+  END IF;
+
+  IF v_expiry IS NOT NULL
+     AND v_now > v_expiry
+     AND lower(coalesce(v_quote.status, '')) NOT IN ('approved', 'accepted', 'paid', 'declined', 'rejected', 'expired') THEN
+    RAISE EXCEPTION 'ML_P1_S2_QUOTE_EXPIRED: quote has expired and cannot be approved'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  PERFORM public.ml_p1_s2_assert_transition('approve', v_quote.status);
+  v_prev := v_quote.status;
+
+  UPDATE public.quotes
+  SET status = 'approved',
+      accepted_at = v_now,
+      approval_method = coalesce(nullif(btrim(p_approval_method), ''), 'public_token'),
+      approved_by_actor_id = NULL,
+      approved_amount = coalesce(total_amount, 0),
+      updated_at = v_now
+  WHERE id = v_quote.id
+    AND tenant_id = v_quote.tenant_id
+    AND public_token::text = v_token
+    AND lower(status) = 'issued'
+  RETURNING * INTO v_quote;
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  IF v_updated <> 1 THEN
+    SELECT * INTO v_quote FROM public.quotes WHERE public_token::text = v_token;
+    IF public.normalize_quote_status(v_quote.status) = 'accepted' THEN
+      v_job := public.ml_p1_s3_ensure_job_for_accepted_quote(
+        v_quote.id, v_corr, 'customer', 'customer_public'
+      );
+      RETURN jsonb_build_object(
+        'action', 'approve',
+        'jobCreated', coalesce((v_job->>'created')::boolean, false),
+        'idempotent', true,
+        'jobId', v_job->>'job_id',
+        'correlationId', v_corr,
+        'quote', to_jsonb(v_quote)
+      );
+    END IF;
+    RAISE EXCEPTION 'ML_P1_S2_TRANSITION_DENY: concurrent approve conflict'
+      USING ERRCODE = '40001';
+  END IF;
+
+  v_job := public.ml_p1_s3_ensure_job_for_accepted_quote(
+    v_quote.id, v_corr, 'customer', 'customer_public'
+  );
+  v_job_id := nullif(v_job->>'job_id', '')::uuid;
+  v_job_created := coalesce((v_job->>'created')::boolean, false);
+
+  INSERT INTO public.events (tenant_id, entity_type, entity_id, event_type, actor_type, actor_id, payload)
+  VALUES (
+    v_quote.tenant_id,
+    'quote',
+    v_quote.id,
+    'quote.approved',
+    'customer',
+    NULL,
+    jsonb_build_object(
+      'event_id', gen_random_uuid()::text,
+      'record_id', v_quote.id,
+      'record_type', 'quote',
+      'tenant_id', v_quote.tenant_id,
+      'actor_id', NULL,
+      'actor_role', 'customer',
+      'previous_state', v_prev,
+      'new_state', v_quote.status,
+      'reason', NULL,
+      'source_action', 'ml_p1_s2.approve_quote_public_token',
+      'correlation_id', v_corr,
+      'success', true,
+      'timestamp', v_now,
+      'quote_id', v_quote.id,
+      'lead_id', v_quote.lead_id,
+      'quote_version', v_quote.quote_version,
+      'approved_amount', v_quote.approved_amount,
+      'approval_method', v_quote.approval_method,
+      'job_id', v_job_id,
+      'invoice_id', NULL
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'action', 'approve',
+    'jobCreated', v_job_created,
+    'idempotent', false,
+    'jobId', v_job_id,
+    'correlationId', v_corr,
+    'quote', to_jsonb(v_quote)
+  );
+END;
+$$;
+
+COMMIT;

--- a/command-center/supabase/migrations/20260721200000_ml_p1_s3_canonical_job_writer.sql
+++ b/command-center/supabase/migrations/20260721200000_ml_p1_s3_canonical_job_writer.sql
@@ -97,10 +97,23 @@ BEGIN
       USING ERRCODE = 'P0001';
   END IF;
 
-  -- Idempotent path: existing quote-linked job.
+  -- Fail closed on cross-tenant squat (quote_id unique is global).
   SELECT * INTO v_job
   FROM public.jobs
   WHERE quote_id = v_quote.id
+    AND tenant_id IS DISTINCT FROM v_quote.tenant_id
+  LIMIT 1;
+
+  IF FOUND THEN
+    RAISE EXCEPTION 'ML_P1_S3_TENANT_DENY: existing job tenant mismatch for quote'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Idempotent path: existing quote-linked job (same tenant).
+  SELECT * INTO v_job
+  FROM public.jobs
+  WHERE quote_id = v_quote.id
+    AND tenant_id IS NOT DISTINCT FROM v_quote.tenant_id
   LIMIT 1;
 
   IF FOUND THEN
@@ -111,11 +124,14 @@ BEGIN
         USING ERRCODE = '22023';
     END IF;
 
-    -- Backfill empty address / missing version pin only (no pricing drift).
+    -- Re-pin lineage + money snapshot from approved quote (no silent financial drift).
     UPDATE public.jobs
     SET
       updated_at = v_now,
       source_quote_version = coalesce(source_quote_version, v_version),
+      total_amount = v_amount,
+      quote_number = coalesce(v_quote.quote_number, quote_number),
+      lead_id = coalesce(v_quote.lead_id, lead_id),
       service_address = CASE
         WHEN service_address IS NULL OR btrim(service_address) = '' THEN v_service_address
         ELSE service_address
@@ -348,6 +364,33 @@ BEGIN
 END;
 $$;
 
+-- Allow legacy sent/viewed statuses as approve-eligible; add ensure_job repair action.
+CREATE OR REPLACE FUNCTION public.ml_p1_s2_assert_transition(p_action text, p_status text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_action text := lower(btrim(coalesce(p_action, '')));
+  v_status text := lower(btrim(coalesce(p_status, '')));
+  v_ok boolean := false;
+BEGIN
+  v_ok := CASE v_action
+    WHEN 'issue' THEN v_status = 'draft'
+    WHEN 'approve' THEN v_status IN ('issued', 'sent', 'viewed')
+    WHEN 'reject' THEN v_status IN ('issued', 'draft', 'sent', 'viewed')
+    WHEN 'expire' THEN v_status IN ('issued', 'sent', 'viewed')
+    WHEN 'revise' THEN v_status IN ('issued', 'rejected', 'expired', 'sent', 'viewed')
+    WHEN 'ensure_job' THEN v_status IN ('approved', 'accepted')
+    ELSE false
+  END;
+
+  IF NOT v_ok THEN
+    RAISE EXCEPTION 'ML_P1_S2_TRANSITION_DENY: cannot % quote in status "%"', v_action, p_status
+      USING ERRCODE = '22023';
+  END IF;
+END;
+$$;
+
 -- ---------------------------------------------------------------------------
 -- Wire approve RPCs: remove gate checks; call canonical writer in-txn.
 -- ---------------------------------------------------------------------------
@@ -418,6 +461,8 @@ BEGIN
 
   IF v_action = 'approve' THEN
     v_capability := 'quote.approve_break_glass';
+  ELSIF v_action = 'ensure_job' THEN
+    v_capability := 'quote.approve_break_glass';
   ELSIF v_action = 'issue' THEN
     v_capability := 'quote.issue';
   ELSIF v_action = 'revise' THEN
@@ -432,6 +477,25 @@ BEGIN
 
   PERFORM public.ml_p1_s2_assert_capability(v_capability, v_role, p_reason_code);
   PERFORM public.ml_p1_s2_assert_transition(v_action, v_quote.status);
+
+  -- Repair path: accepted/approved without job (or idempotent re-ensure).
+  IF v_action = 'ensure_job' THEN
+    IF public.normalize_quote_status(v_quote.status) IS DISTINCT FROM 'accepted' THEN
+      RAISE EXCEPTION 'ML_P1_S3_STATUS_DENY: ensure_job requires accepted quote'
+        USING ERRCODE = '22023';
+    END IF;
+    v_job := public.ml_p1_s3_ensure_job_for_accepted_quote(
+      v_quote.id, v_corr, v_role, 'office_break_glass_ensure'
+    );
+    RETURN jsonb_build_object(
+      'action', 'ensure_job',
+      'jobCreated', coalesce((v_job->>'created')::boolean, false),
+      'idempotent', coalesce((v_job->>'idempotent')::boolean, true),
+      'jobId', v_job->>'job_id',
+      'correlationId', v_corr,
+      'quote', to_jsonb(v_quote)
+    );
+  END IF;
 
   IF v_action = 'revise' THEN
     v_next_version := coalesce(v_quote.quote_version, 1) + 1;
@@ -527,7 +591,7 @@ BEGIN
         updated_at = v_now
     WHERE id = v_quote.id
       AND tenant_id = v_tenant
-      AND lower(status) = 'issued'
+      AND lower(status) IN ('issued', 'sent', 'viewed')
     RETURNING * INTO v_quote;
   ELSIF v_action = 'reject' THEN
     UPDATE public.quotes
@@ -537,7 +601,7 @@ BEGIN
         updated_at = v_now
     WHERE id = v_quote.id
       AND tenant_id = v_tenant
-      AND lower(status) IN ('issued', 'draft')
+      AND lower(status) IN ('issued', 'draft', 'sent', 'viewed')
     RETURNING * INTO v_quote;
   ELSIF v_action = 'expire' THEN
     UPDATE public.quotes
@@ -546,7 +610,7 @@ BEGIN
         updated_at = v_now
     WHERE id = v_quote.id
       AND tenant_id = v_tenant
-      AND lower(status) = 'issued'
+      AND lower(status) IN ('issued', 'sent', 'viewed')
     RETURNING * INTO v_quote;
   END IF;
 
@@ -717,7 +781,7 @@ BEGIN
   WHERE id = v_quote.id
     AND tenant_id = v_quote.tenant_id
     AND public_token::text = v_token
-    AND lower(status) = 'issued'
+    AND lower(status) IN ('issued', 'sent', 'viewed')
   RETURNING * INTO v_quote;
 
   GET DIAGNOSTICS v_updated = ROW_COUNT;
@@ -788,5 +852,19 @@ BEGIN
   );
 END;
 $$;
+
+-- Deny authenticated client INSERT of quote-linked jobs (canonical writer is SECURITY DEFINER).
+DROP POLICY IF EXISTS "Jobs are insertable by tenant" ON public.jobs;
+CREATE POLICY "Jobs are insertable by tenant"
+  ON public.jobs
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    tenant_id = coalesce(
+      auth.jwt() -> 'app_metadata' ->> 'tenant_id',
+      auth.jwt() -> 'user_metadata' ->> 'tenant_id'
+    )
+    AND quote_id IS NULL
+  );
 
 COMMIT;

--- a/command-center/supabase/migrations/20260721200000_ml_p1_s3_canonical_job_writer.sql
+++ b/command-center/supabase/migrations/20260721200000_ml_p1_s3_canonical_job_writer.sql
@@ -41,6 +41,7 @@ DECLARE
   v_service_address text;
   v_amount numeric;
   v_version int;
+  v_wo text;
 BEGIN
   IF p_quote_id IS NULL THEN
     RAISE EXCEPTION 'ML_P1_S3_QUOTE_REQUIRED: quote_id required'
@@ -69,6 +70,7 @@ BEGIN
 
   v_version := coalesce(v_quote.quote_version, 1);
   v_amount := coalesce(v_quote.approved_amount, v_quote.total_amount, 0);
+  v_wo := public.next_work_order_number(v_quote.tenant_id, coalesce(v_quote.created_at, v_now));
 
   -- Resolve service address (quote snapshot, else lead+property). Fail closed.
   v_service_address := nullif(btrim(coalesce(v_quote.service_address, '')), '');
@@ -177,6 +179,7 @@ BEGIN
       total_amount,
       service_address,
       work_order_number,
+      job_number,
       source_quote_version
     ) VALUES (
       v_quote.tenant_id,
@@ -187,7 +190,8 @@ BEGIN
       'unpaid',
       v_amount,
       v_service_address,
-      public.next_work_order_number(v_quote.tenant_id, coalesce(v_quote.created_at, v_now)),
+      v_wo,
+      v_wo,
       v_version
     )
     ON CONFLICT (quote_id) WHERE quote_id IS NOT NULL
@@ -199,15 +203,41 @@ BEGIN
   END;
 
   IF v_job_id IS NULL THEN
-    SELECT id INTO v_job_id
+    SELECT * INTO v_job
     FROM public.jobs
     WHERE quote_id = v_quote.id
     LIMIT 1;
 
-    IF v_job_id IS NULL THEN
+    IF NOT FOUND THEN
       RAISE EXCEPTION 'ML_P1_S3_JOB_ENSURE_FAILED: could not create or load job for quote'
         USING ERRCODE = 'P0001';
     END IF;
+
+    IF v_job.tenant_id IS DISTINCT FROM v_quote.tenant_id THEN
+      RAISE EXCEPTION 'ML_P1_S3_TENANT_DENY: existing job tenant mismatch for quote'
+        USING ERRCODE = '42501';
+    END IF;
+
+    IF v_job.source_quote_version IS NOT NULL
+       AND v_job.source_quote_version IS DISTINCT FROM v_version THEN
+      RAISE EXCEPTION 'ML_P1_S3_VERSION_MISMATCH: existing job pinned to version %; quote is %',
+        v_job.source_quote_version, v_version
+        USING ERRCODE = '22023';
+    END IF;
+
+    UPDATE public.jobs
+    SET
+      updated_at = v_now,
+      source_quote_version = coalesce(source_quote_version, v_version),
+      total_amount = v_amount,
+      quote_number = coalesce(v_quote.quote_number, quote_number),
+      lead_id = coalesce(v_quote.lead_id, lead_id),
+      service_address = CASE
+        WHEN service_address IS NULL OR btrim(service_address) = '' THEN v_service_address
+        ELSE service_address
+      END
+    WHERE id = v_job.id
+    RETURNING id INTO v_job_id;
 
     v_created := false;
     v_idempotent := true;

--- a/command-center/tests/unit/ml-p1-s2-lifecycle.test.mjs
+++ b/command-center/tests/unit/ml-p1-s2-lifecycle.test.mjs
@@ -61,7 +61,11 @@ describe('ML-P1 S2 transitions + immutability helpers', () => {
   it('allows Money-State happy path transitions only', () => {
     assertTransitionAllowed('issue', 'draft');
     assertTransitionAllowed('approve', 'issued');
+    assertTransitionAllowed('approve', 'sent');
+    assertTransitionAllowed('approve', 'viewed');
+    assertTransitionAllowed('ensure_job', 'accepted');
     assert.throws(() => assertTransitionAllowed('approve', 'draft'), (e) => e.code === 'ML_P1_S2_TRANSITION_DENY');
+    assert.throws(() => assertTransitionAllowed('ensure_job', 'issued'), (e) => e.code === 'ML_P1_S2_TRANSITION_DENY');
   });
 
   it('blocks in-place edit of issued/approved content', () => {
@@ -316,7 +320,7 @@ describe('ML-P1 S2 lifecycle service via server RPC', () => {
 });
 
 describe('ML-P1 S2 remediation source guards', () => {
-  it('public-quote-approve does not insert jobs; passes through RPC job fields', () => {
+  it('public-quote-approve does not insert jobs; fails closed without writer RPC', () => {
     const edgePath = path.join(
       __dirname,
       '../../supabase/functions/public-quote-approve/index.ts',
@@ -325,8 +329,10 @@ describe('ML-P1 S2 remediation source guards', () => {
     assert.equal(/from\('jobs'\)/.test(src), false);
     assert.equal(/ML_P1_S2_JOB_GATE_REQUIRED/.test(src), false);
     assert.match(src, /ml_p1_s2_quote_approve_public/);
+    assert.match(src, /ML_P1_S3_WRITER_REQUIRED/);
     assert.match(src, /job_created:\s*rpcJobCreated/);
     assert.match(src, /job_id:\s*rpcJobId/);
+    assert.equal(/continue with direct update/i.test(src), false);
   });
 
   it('server authz migration defines RPC + gate-off accept trigger + draft-only RLS', () => {

--- a/command-center/tests/unit/ml-p1-s2-lifecycle.test.mjs
+++ b/command-center/tests/unit/ml-p1-s2-lifecycle.test.mjs
@@ -93,7 +93,7 @@ describe('ML-P1 S2 audit G-02 fields', () => {
 });
 
 describe('ML-P1 S2 lifecycle service via server RPC', () => {
-  it('issues via RPC and always returns jobCreated false', async () => {
+  it('issues via RPC and surfaces server jobCreated/jobId (issue = false)', async () => {
     const calls = [];
     const supabase = {
       rpc: async (name, args) => {
@@ -102,7 +102,8 @@ describe('ML-P1 S2 lifecycle service via server RPC', () => {
         return {
           data: {
             action: 'issue',
-            jobCreated: true, // hostile server — client must still report false
+            jobCreated: false,
+            jobId: null,
             correlationId: 'c-issue',
             quote: { id: 'q1', status: 'issued', tenant_id: 'tvg' },
           },
@@ -118,8 +119,34 @@ describe('ML-P1 S2 lifecycle service via server RPC', () => {
       actorRole: 'technician', // forged — server ignores; client still calls RPC
     });
     assert.equal(result.jobCreated, false);
+    assert.equal(result.jobId, null);
     assert.equal(result.quote.status, 'issued');
     assert.equal(calls[0].args.p_action, 'issue');
+  });
+
+  it('approve surfaces jobCreated and jobId from server', async () => {
+    const supabase = {
+      rpc: async () => ({
+        data: {
+          action: 'approve',
+          jobCreated: true,
+          jobId: 'job-1',
+          idempotent: false,
+          quote: { id: 'q1', status: 'approved', tenant_id: 'tvg' },
+        },
+        error: null,
+      }),
+    };
+    const svc = createMlP1S2QuoteLifecycleService({ supabase });
+    const result = await svc.approveQuote({
+      quoteId: 'q1',
+      sessionTenantId: 'tvg',
+      urlTenantId: 'tvg',
+      actorRole: 'admin',
+      reasonCode: 'bg-1',
+    });
+    assert.equal(result.jobCreated, true);
+    assert.equal(result.jobId, 'job-1');
   });
 
   it('maps server ROLE_DENY for technician', async () => {
@@ -179,7 +206,7 @@ describe('ML-P1 S2 lifecycle service via server RPC', () => {
     );
   });
 
-  it('public-token approve via RPC; concurrent idempotent safe', async () => {
+  it('public-token approve via RPC; concurrent idempotent safe; surfaces jobId', async () => {
     let n = 0;
     const supabase = {
       rpc: async (name) => {
@@ -188,7 +215,8 @@ describe('ML-P1 S2 lifecycle service via server RPC', () => {
         return {
           data: {
             action: 'approve',
-            jobCreated: false,
+            jobCreated: n === 1,
+            jobId: 'job-tok',
             idempotent: n > 1,
             quote: { id: 'q-tok', status: 'accepted', approved_amount: 40 },
           },
@@ -199,9 +227,11 @@ describe('ML-P1 S2 lifecycle service via server RPC', () => {
     const svc = createMlP1S2QuoteLifecycleService({ supabase });
     const a = await svc.approveByPublicToken({ publicToken: 'tok-abc' });
     const b = await svc.approveByPublicToken({ publicToken: 'tok-abc' });
-    assert.equal(a.jobCreated, false);
+    assert.equal(a.jobCreated, true);
+    assert.equal(a.jobId, 'job-tok');
     assert.equal(b.jobCreated, false);
     assert.equal(b.idempotent, true);
+    assert.equal(b.jobId, 'job-tok');
   });
 
   it('revise via RPC returns new draft and jobCreated false', async () => {
@@ -231,7 +261,30 @@ describe('ML-P1 S2 lifecycle service via server RPC', () => {
     assert.equal(revised.jobCreated, false);
   });
 
-  it('JOB_GATE_REQUIRED mapped from server (pre-A3 fail-closed)', async () => {
+  it('maps ADDRESS_REQUIRED from S3 writer', async () => {
+    const supabase = {
+      rpc: async () => ({
+        data: null,
+        error: {
+          message: 'ML_P1_S3_ADDRESS_REQUIRED: service address required before job create',
+        },
+      }),
+    };
+    const svc = createMlP1S2QuoteLifecycleService({ supabase });
+    await assert.rejects(
+      () =>
+        svc.approveQuote({
+          quoteId: 'q1',
+          sessionTenantId: 'tvg',
+          urlTenantId: 'tvg',
+          actorRole: 'admin',
+          reasonCode: 'bg-1',
+        }),
+      (err) => err.code === 'ML_P1_S3_ADDRESS_REQUIRED',
+    );
+  });
+
+  it('JOB_GATE_REQUIRED still mapped if legacy server returns it', async () => {
     const supabase = {
       rpc: async () => ({
         data: null,
@@ -263,16 +316,17 @@ describe('ML-P1 S2 lifecycle service via server RPC', () => {
 });
 
 describe('ML-P1 S2 remediation source guards', () => {
-  it('public-quote-approve no longer inserts jobs', () => {
+  it('public-quote-approve does not insert jobs; passes through RPC job fields', () => {
     const edgePath = path.join(
       __dirname,
       '../../supabase/functions/public-quote-approve/index.ts',
     );
     const src = fs.readFileSync(edgePath, 'utf8');
     assert.equal(/from\('jobs'\)/.test(src), false);
-    assert.match(src, /ML_P1_S2_JOB_GATE_REQUIRED/);
-    assert.match(src, /job_created:\s*false/);
+    assert.equal(/ML_P1_S2_JOB_GATE_REQUIRED/.test(src), false);
     assert.match(src, /ml_p1_s2_quote_approve_public/);
+    assert.match(src, /job_created:\s*rpcJobCreated/);
+    assert.match(src, /job_id:\s*rpcJobId/);
   });
 
   it('server authz migration defines RPC + gate-off accept trigger + draft-only RLS', () => {

--- a/command-center/tests/unit/ml-p1-s3-job-writer.test.mjs
+++ b/command-center/tests/unit/ml-p1-s3-job-writer.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * ML-P1 Slice 3 — canonical job writer source guards + client surface.
+ * Run: node --test tests/unit/ml-p1-s3-job-writer.test.mjs
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createMlP1S2QuoteLifecycleService } from '../../src/services/mlP1S2QuoteLifecycleService.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(__dirname, '../..');
+
+describe('ML-P1 S3 migration source guards', () => {
+  const migPath = path.join(
+    root,
+    'supabase/migrations/20260721200000_ml_p1_s3_canonical_job_writer.sql',
+  );
+  const mig = fs.readFileSync(migPath, 'utf8');
+
+  it('defines canonical writer + lineage column', () => {
+    assert.match(mig, /source_quote_version/);
+    assert.match(mig, /ml_p1_s3_ensure_job_for_accepted_quote/);
+    assert.match(mig, /ML_P1_S3_ADDRESS_REQUIRED/);
+    assert.match(mig, /QuoteAccepted_JobEnsured/);
+    assert.match(mig, /ON CONFLICT \(quote_id\) WHERE quote_id IS NOT NULL/);
+  });
+
+  it('does not enable auto_create_job_on_quote_acceptance', () => {
+    assert.equal(
+      /UPDATE\s+public\.global_config[\s\S]{0,200}auto_create_job_on_quote_acceptance/i.test(mig),
+      false,
+    );
+    assert.equal(
+      /INSERT\s+INTO\s+public\.global_config[\s\S]{0,200}auto_create_job_on_quote_acceptance[\s\S]{0,80}'true'/i.test(
+        mig,
+      ),
+      false,
+    );
+  });
+
+  it('neutralizes ensure_job accepted/paid inserts (deferred only)', () => {
+    assert.match(mig, /QuoteAccepted_JobCreateDeferred/);
+    assert.match(mig, /QuotePaid_JobCreateDeferred/);
+    assert.match(mig, /ml-p1-s3-rpc-only-job-writer/);
+    // ensure_job body in this migration must not INSERT into jobs.
+    const ensureStart = mig.indexOf(
+      'CREATE OR REPLACE FUNCTION public.ensure_job_and_optional_draft_invoice_for_accepted_quote()',
+    );
+    const ensureEnd = mig.indexOf(
+      'CREATE OR REPLACE FUNCTION public.trg_emit_wo_on_quote_accept()',
+      ensureStart,
+    );
+    assert.ok(ensureStart > 0 && ensureEnd > ensureStart);
+    const ensureBody = mig.slice(ensureStart, ensureEnd);
+    assert.equal(/INSERT INTO public\.jobs/i.test(ensureBody), false);
+  });
+
+  it('drops S2 gate-off accept belt and removes approve gate asserts', () => {
+    assert.match(mig, /DROP TRIGGER IF EXISTS trg_ml_p1_s2_require_job_gate_off_on_accept/);
+    assert.equal(/ML_P1_S2_JOB_GATE_REQUIRED/.test(mig), false);
+    assert.equal(/ml_p1_s2_job_gate_is_off\(\)/.test(mig), false);
+  });
+
+  it('wires both approve RPCs to canonical writer', () => {
+    assert.match(mig, /ml_p1_s2_quote_lifecycle/);
+    assert.match(mig, /ml_p1_s2_quote_approve_public/);
+    const writerCalls = [...mig.matchAll(/ml_p1_s3_ensure_job_for_accepted_quote/g)];
+    assert.ok(writerCalls.length >= 5, `expected multiple writer call sites, got ${writerCalls.length}`);
+  });
+});
+
+describe('ML-P1 S3 edge / UI source guards', () => {
+  it('quote-update-status denies accept/approve money path', () => {
+    const src = fs.readFileSync(
+      path.join(root, 'supabase/functions/quote-update-status/index.ts'),
+      'utf8',
+    );
+    assert.match(src, /ML_P1_S3_STATUS_PATH_DENY/);
+    assert.match(src, /accepted.*approved|approved.*accepted/s);
+    assert.equal(/closeFollowUpTasks/.test(src), false);
+  });
+
+  it('ProposalList Accept navigates to lifecycle (no quote-update-status accept)', () => {
+    const src = fs.readFileSync(
+      path.join(root, 'src/pages/crm/proposals/ProposalList.jsx'),
+      'utf8',
+    );
+    assert.equal(/handleUpdateStatus\(quote\.id,\s*'accepted'\)/.test(src), false);
+    assert.match(src, /estimates\/p1-lifecycle\//);
+  });
+
+  it('lifecycle page shows job status surface', () => {
+    const src = fs.readFileSync(
+      path.join(root, 'src/pages/crm/MlP1S2QuoteLifecyclePage.jsx'),
+      'utf8',
+    );
+    assert.match(src, /Job status/);
+    assert.match(src, /jobCreated/);
+    assert.match(src, /Idempotent \(existing\)/);
+  });
+});
+
+describe('ML-P1 S3 client normalizeRpcResult', () => {
+  it('maps job_id snake_case from RPC payload', async () => {
+    const supabase = {
+      rpc: async () => ({
+        data: {
+          action: 'approve',
+          job_created: true,
+          job_id: 'j-snake',
+          quote: { id: 'q1', status: 'accepted' },
+        },
+        error: null,
+      }),
+    };
+    const svc = createMlP1S2QuoteLifecycleService({ supabase });
+    const result = await svc.approveByPublicToken({ publicToken: 't' });
+    assert.equal(result.jobCreated, true);
+    assert.equal(result.jobId, 'j-snake');
+  });
+});

--- a/command-center/tests/unit/ml-p1-s3-job-writer.test.mjs
+++ b/command-center/tests/unit/ml-p1-s3-job-writer.test.mjs
@@ -69,6 +69,18 @@ describe('ML-P1 S3 migration source guards', () => {
     const writerCalls = [...mig.matchAll(/ml_p1_s3_ensure_job_for_accepted_quote/g)];
     assert.ok(writerCalls.length >= 5, `expected multiple writer call sites, got ${writerCalls.length}`);
   });
+
+  it('rejects cross-tenant job squat and pins total_amount on idempotent hit', () => {
+    assert.match(mig, /ML_P1_S3_TENANT_DENY: existing job tenant mismatch/);
+    assert.match(mig, /total_amount = v_amount/);
+    assert.match(mig, /quote_id IS NULL/);
+  });
+
+  it('allows sent/viewed approve and ensure_job repair', () => {
+    assert.match(mig, /WHEN 'approve' THEN v_status IN \('issued', 'sent', 'viewed'\)/);
+    assert.match(mig, /WHEN 'ensure_job'/);
+    assert.match(mig, /office_break_glass_ensure/);
+  });
 });
 
 describe('ML-P1 S3 edge / UI source guards', () => {
@@ -82,6 +94,17 @@ describe('ML-P1 S3 edge / UI source guards', () => {
     assert.equal(/closeFollowUpTasks/.test(src), false);
   });
 
+  it('kanban-move cannot insert quote-linked jobs or accept via status write', () => {
+    const src = fs.readFileSync(
+      path.join(root, 'supabase/functions/kanban-move/index.ts'),
+      'utf8',
+    );
+    assert.match(src, /ML_P1_S3_JOB_REQUIRED/);
+    assert.match(src, /ML_P1_S3_STATUS_PATH_DENY/);
+    assert.equal(/\.insert\(richInsert\)/.test(src), false);
+    assert.equal(/status:\s*'accepted'/.test(src), false);
+  });
+
   it('ProposalList Accept navigates to lifecycle (no quote-update-status accept)', () => {
     const src = fs.readFileSync(
       path.join(root, 'src/pages/crm/proposals/ProposalList.jsx'),
@@ -91,7 +114,7 @@ describe('ML-P1 S3 edge / UI source guards', () => {
     assert.match(src, /estimates\/p1-lifecycle\//);
   });
 
-  it('lifecycle page shows job status surface', () => {
+  it('lifecycle page shows job status surface and ensure-job repair', () => {
     const src = fs.readFileSync(
       path.join(root, 'src/pages/crm/MlP1S2QuoteLifecyclePage.jsx'),
       'utf8',
@@ -99,6 +122,8 @@ describe('ML-P1 S3 edge / UI source guards', () => {
     assert.match(src, /Job status/);
     assert.match(src, /jobCreated/);
     assert.match(src, /Idempotent \(existing\)/);
+    assert.match(src, /ensureJobForQuote/);
+    assert.match(src, /sent.*viewed|viewed.*sent/s);
   });
 });
 

--- a/command-center/tests/unit/ml-p1-s3-job-writer.test.mjs
+++ b/command-center/tests/unit/ml-p1-s3-job-writer.test.mjs
@@ -74,6 +74,10 @@ describe('ML-P1 S3 migration source guards', () => {
     assert.match(mig, /ML_P1_S3_TENANT_DENY: existing job tenant mismatch/);
     assert.match(mig, /total_amount = v_amount/);
     assert.match(mig, /quote_id IS NULL/);
+    // ON CONFLICT recovery must re-check tenant
+    assert.ok(
+      (mig.match(/ML_P1_S3_TENANT_DENY: existing job tenant mismatch for quote/g) || []).length >= 2,
+    );
   });
 
   it('allows sent/viewed approve and ensure_job repair', () => {


### PR DESCRIPTION
## Summary
- Adds server-side `ml_p1_s3_ensure_job_for_accepted_quote` with `jobs.source_quote_version`, idempotent unique `quote_id`, address fail-closed, and audit `QuoteAccepted_JobEnsured`.
- Wires S2 approve RPCs (lifecycle break-glass + public token) to call the writer in the same transaction; retires gate-off belt; neutralizes accept/paid trigger job inserts (RPC-only create; does **not** flip `auto_create_job_on_quote_acceptance=true`).
- Edge/UI: `quote-update-status` denies accept/approve; `public-quote-approve` drops gate precheck and returns `job_id`/`job_created`; lifecycle shows job status; ProposalList Accept routes to lifecycle.

## Test plan
- [x] `node --test tests/unit/ml-p1-s2-lifecycle.test.mjs tests/unit/ml-p1-s3-job-writer.test.mjs` (33 pass)
- [ ] A3 (separate Founder auth): apply migration only — **not authorized by this PR**
- [ ] Deploy — **not authorized**
- [ ] Manual: public approve + break-glass approve → one job; replay → same `job_id`; missing address → `ML_P1_S3_ADDRESS_REQUIRED`

## Hard locks
No migration apply · no Hostinger deploy · no Slice 4+ · no Stripe/invoices/follow-up/TIS/G2.3

Made with [Cursor](https://cursor.com)