### PR TITLE
docs(ml-p1): Slice 5 planning with PD-S5-01..07 ratified

### DIFF
--- a/command-center/docs/governance/decisions/ML-P1_SLICE5_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/ML-P1_SLICE5_DECISION_PACKET.md
@@ -1,0 +1,74 @@
+# Decision Packet — ML-P1 Slice 5 (Invoice Generation)
+
+| Field | Value |
+| --- | --- |
+| Disposition | **SLICE5_PLANNING_REQUIRES_CODING_AUTH** (product decisions **RATIFIED**) |
+| Planning base (exact `origin/main`) | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Branch | `plan/ml-p1-s5-invoice-generation` |
+| Prior slices | S1–S4 closed; price-book **A2-MERGED**; invoice-on-complete **disabled** |
+| Coding | **Not authorized** until this planning PR merges and Founder grants coding auth |
+| Supersedes | Draft packet on prior tip `84452db` (base `3bb175e`) |
+
+## Purpose
+
+Completed canonical job → **exactly one** canonical **`final`** invoice (`draft` → office review → issue as persisted `sent` / display “Issued”), with lineage from approved quote + approved change orders. Stop before Stripe (S5b) and autonomous follow-up (S6).
+
+## Live baseline (revalidated 2026-07-23 against linked prod)
+
+| Fact | Evidence |
+| --- | --- |
+| Invoices | **25** rows; `draft` 2 · `sent` 14 · `paid` 9 |
+| Uniqueness | `idx_invoices_unique_job`, `idx_invoices_one_active_per_job`, `invoices_one_draft_per_job_type_uq` present |
+| S4 gate (source on main) | `ML_P1_S4_INVOICE_ON_COMPLETE_ENABLED = false` in `work-order-update` |
+| Kanban | `ML_P1_S4_INVOICE_PATH_DENY` still denies invoice create |
+| Config (repo) | `auto_create_draft_invoice_on_acceptance` seeded `false` |
+| Schema | `invoice_type` CHECK still allows deposit/progress/final; **S5 product creates `final` only** (PD-S5-03 A) |
+
+## Ratified product decisions (Founder 2026-07-23)
+
+### PD-S5-01 — Invoice creation trigger → **C (Hybrid)** RATIFIED
+- Auto-create **draft** when eligible job reaches `completed` (S4 readiness pass, no pending COs, no existing blocking invoice).
+- Office may create draft if auto-create did not occur.
+- Remains **draft** until office review and **explicit issue**.
+- **Never** auto-issue or auto-send.
+
+### PD-S5-02 — Issued status vocabulary → **C** RATIFIED
+- Persist issued state as **`sent`**.
+- Display office/customer label **“Issued”** where appropriate.
+- **No** database status rename migration.
+
+### PD-S5-03 — `invoice_type` → **A** RATIFIED
+- S5 creates **`final`** invoices only.
+- Do not expose deposit/progress creation in S5 UI/RPC.
+- Keep schema CHECK for compatibility; do not drop columns for migration risk avoidance.
+
+### PD-S5-04 — Tax at invoice creation → **B+C** RATIFIED
+- Default tax from **approved quote financial snapshot**.
+- Authorized office may correct tax while status is **draft**.
+- **Freeze** tax and all invoice financial values when issued (`sent`).
+- **Never** silently recalculate an issued invoice from current pricebook or tax settings.
+
+### PD-S5-05 — Void and write-off authority → **A** RATIFIED
+- Void: **office | manager | admin** (reason + immutable audit required).
+- Write-off: **admin only** (reason + immutable audit required).
+- Technicians **never** void, write off, or modify invoice financial values.
+
+### PD-S5-06 — Correction after issue (unpaid) → **A** RATIFIED
+- Issued unpaid invoices **may not** be edited in place.
+- Corrections = **void + reissue**.
+- Preserve original issued invoice and audit history.
+
+### PD-S5-07 — Pre-existing invoices (25) → **A** RATIFIED
+- **Grandfather** the 25 live invoices.
+- Do **not** rewrite or reprice historical financial data.
+- Canonical S5 writer applies to **new** creates.
+- Safe best-effort lineage backfill only (no changes to historical amounts, statuses, or customer-visible records).
+
+## Explicit non-scope
+
+Slice 5b Stripe · refunds · payment reconciliation · Slice 6 autonomous follow-up · TIS · G2.3 · multi-tenancy · pricebook optimization · historical invoice reprice.
+
+## Coding gate (after this planning PR merges)
+
+Requires separate Founder line: **authorize Slice 5 coding** on exact branch/base SHA.  
+Until then: **no migrations, no app implementation, no deploy.**

--- a/command-center/docs/stabilization/releases/ML-P1_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/stabilization/releases/ML-P1_EVIDENCE_MANIFEST.md
@@ -38,4 +38,5 @@ Paths relative to `command-center/`; SHA-256 over path + newline + file bytes, c
 | --- | --- |
 | Slice 4 evidence | `ML-P1_SLICE4_EVIDENCE_MANIFEST.md` |
 | Slice 4 state | `ML-P1_SLICE4_STATE_LEDGER.md` |
+| Slice 5 planning evidence | `ML-P1_SLICE5_EVIDENCE_MANIFEST.md` |
 | Program state | `ML-P1_STATE_LEDGER.md` |

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_ARCHITECTURE_FINDINGS.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_ARCHITECTURE_FINDINGS.md
@@ -1,0 +1,61 @@
+# ML-P1 Slice 5 — Architecture Findings (Invoice) — revalidated
+
+| Field | Value |
+| --- | --- |
+| Planning base | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Revalidated | 2026-07-23 |
+| Live invoices | 25 · `draft`/`sent`/`paid` · unique-job indexes present |
+| S4 gate | Invoice-on-complete **disabled** in source |
+| PD status | PD-S5-01…07 **RATIFIED** |
+
+## System picture
+
+```mermaid
+flowchart LR
+  subgraph s4 [Slice 4 done]
+    Job[jobs completed]
+    CO[approved change_orders]
+    Q[quotes approved]
+  end
+  subgraph today [Current invoice reality]
+    IS[invoice-save Edge]
+    WO[work-order-update create gated off]
+    KM[kanban invoice deny]
+    SI[send-invoice]
+  end
+  subgraph s5 [Slice 5 target]
+    CW[ml_p1_s5_invoice_create]
+    Draft[invoice draft final]
+    Issue[issue to sent / Issued]
+  end
+  Job --> CW
+  Q --> CW
+  CO --> CW
+  CW --> Draft
+  Draft --> Issue
+  IS -.->|convert| CW
+  WO -.->|deny| X[blocked]
+  KM -.->|deny| X
+  Issue --> SI
+```
+
+## Findings (still true on current main + live)
+
+1. **No S5 canonical create RPC** on main — closest writer remains Edge `invoice-save`.
+2. **One-invoice-per-job indexes** present live (`idx_invoices_unique_job`, active/draft-type uniques).
+3. **Parallel creators remain dangerous if re-enabled:** work-order ensure, kanban getOrCreate, quote-accept auto-draft flag, MyMoney/direct inserts.
+4. **S4 correctly disables** complete→invoice create; kanban denies invoice path.
+5. **Settlement writers** are S5b — S5 must not own Stripe/offline payment authority; may read settlement.
+6. **Lineage incomplete** on live invoices — job/quote ids present; frozen quote version + CO id set + calc snapshot still to be designed in coding (grandfather PD-S5-07).
+7. **Status vocabulary live-simple:** `draft`/`sent`/`paid` — PD-S5-02 keeps `sent`, display “Issued”.
+8. **tenant_id** remains storage; authz follows single-company role model (not multi-tenant).
+9. **Price-book on main** now includes HCP catalog — **forbidden** as silent recalculation source at invoice create/issue (PD-S5-04).
+
+## Boundary
+
+| In S5 | Out |
+| --- | --- |
+| Canonical create from completed job + quote + approved COs | Stripe initiate/webhook/refunds |
+| Draft review, issue/send, void | Autonomous unpaid follow-up |
+| Tax from quote snapshot + draft correct | Pricebook reprice of issued |
+| Customer invoice view (read) | TIS / G2.3 / multi-tenant redesign |

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_BRIEF.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_BRIEF.md
@@ -1,0 +1,37 @@
+# ML-P1 Slice 5 — Brief
+
+| Field | Value |
+| --- | --- |
+| Slice | **ML-P1-S5** Invoice generation (canonical draft → issue) |
+| Planning base | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Product decisions | **PD-S5-01…07 RATIFIED** 2026-07-23 |
+| Coding | Not started · not authorized |
+| Out of scope | Stripe/S5b · refunds · autonomous follow-up · TIS · G2.3 · multi-tenant |
+
+## One-sentence goal
+
+After a job is properly completed, create exactly one final draft invoice from approved quote + approved change orders, let office review and issue it (stored as `sent`, shown as “Issued”), and never silently change money after issue.
+
+## In / out
+
+| In | Out |
+| --- | --- |
+| Hybrid draft create (auto + office fallback) | Auto-send / auto-issue |
+| Office issue → `sent` (“Issued”) | Deposit/progress invoice product |
+| Quote-snapshot tax + draft tax correct | Silent reprice from pricebook |
+| Void+reissue corrections | In-place edit of issued amounts |
+| Grandfather 25 live invoices | Historical rewrite |
+| Deny alternate create writers | Stripe / refunds / dunning |
+
+## Success criteria (when coding is later authorized)
+
+1. Eligible completed job yields one `final` draft (auto or office).  
+2. Issue freezes financials; display “Issued”; persist `sent`.  
+3. Tech cannot create/void/write-off/edit money.  
+4. Parallel create paths remain denied.  
+5. Synthetic-only prod validation; cleanup after.
+
+## Related artifacts
+
+- Decision packet: `docs/governance/decisions/ML-P1_SLICE5_DECISION_PACKET.md`  
+- Architecture / planning design / writer inventory / state ledger / evidence / residuals under `docs/stabilization/releases/ML-P1_SLICE5_*`

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_EVIDENCE_MANIFEST.md
@@ -1,0 +1,33 @@
+# Evidence Manifest — ML-P1 Slice 5 Planning (ratified)
+
+| Field | Value |
+| --- | --- |
+| Scope | Planning / governance only — completed job → canonical invoice |
+| Exact main SHA | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Branch | `plan/ml-p1-s5-invoice-generation` |
+| Disposition | PD-S5-01…07 **RATIFIED**; coding **not** authorized |
+| Supersedes | Prior planning tip `84452db` / base `3bb175e` |
+
+## Artifacts
+
+| Path | Role |
+| --- | --- |
+| `docs/governance/decisions/ML-P1_SLICE5_DECISION_PACKET.md` | Ratified PD-S5-01…07 |
+| `docs/stabilization/releases/ML-P1_SLICE5_BRIEF.md` | Slice brief |
+| `docs/stabilization/releases/ML-P1_SLICE5_ARCHITECTURE_FINDINGS.md` | Architecture (revalidated) |
+| `docs/stabilization/releases/ML-P1_SLICE5_PLANNING_DESIGN.md` | Design |
+| `docs/stabilization/releases/ML-P1_SLICE5_INVOICE_WRITER_INVENTORY.md` | Writer inventory |
+| `docs/stabilization/releases/ML-P1_SLICE5_STATE_LEDGER.md` | S5 state |
+| `docs/stabilization/releases/ML-P1_SLICE5_RESIDUAL_REGISTER.md` | Residuals |
+| `docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_*_REVIEW.md` | Three critique rounds |
+
+## EXECUTED revalidation (2026-07-23)
+
+- `origin/main` = `e9cc3317fcb9c84f44643700927699f40c7f1a93`
+- Live invoices: 25 (`draft` 2, `sent` 14, `paid` 9)
+- Indexes: `idx_invoices_unique_job`, `idx_invoices_one_active_per_job`, draft-per-type unique present
+- Source: `ML_P1_S4_INVOICE_ON_COMPLETE_ENABLED=false`; kanban `ML_P1_S4_INVOICE_PATH_DENY`
+
+## Explicit non-claims
+
+No Slice 5 coding · no migrations applied · no Stripe · no refunds · no historical invoice rewrite · no Hostinger deploy.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_INVOICE_WRITER_INVENTORY.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_INVOICE_WRITER_INVENTORY.md
@@ -1,0 +1,36 @@
+# ML-P1 Slice 5 — Invoice Writer Inventory (revalidated)
+
+| Field | Value |
+| --- | --- |
+| Planning base | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Revalidated | 2026-07-23 against current main source |
+| Rule | Inventory alone is not closure — each row has exactly one disposition |
+
+| # | Writer | Surface | Disposition | Closure evidence required |
+| --- | --- | --- | --- | --- |
+| 1 | **`ml_p1_s5_invoice_create`** (new) | RPC | **Canonical** | Migration + tests + I2 (coding auth later) |
+| 2 | **`ml_p1_s5_invoice_draft_update` / `issue` / `void`** (new) | RPC | **Canonical** | Migration + tests |
+| 3 | Job-complete auto-draft hook (new, PD-S5-01 C) | SQL/Edge | **Canonical companion** | Creates **draft only**; never send |
+| 4 | Edge `invoice-save` | Edge/UI | **Convert to call canonical** | Bridge or deny free-form create; draft edit only via S5 rules |
+| 5 | `InvoiceBuilder.jsx` | Frontend | **Convert** | Calls S5 RPC / bridged edge; `final` only |
+| 6 | `work-order-update` create/ensure invoice | Edge | **Denied + source-guarded** | Keep `ML_P1_S4_INVOICE_ON_COMPLETE_ENABLED=false`; extend deny to payment-ensure create |
+| 7 | `work-order-update` `syncInvoiceForPayment` create branch | Edge | **Denied + source-guarded** | Settlement stays S5b |
+| 8 | `kanban-move` `getOrCreateInvoiceForJob` | Edge | **Denied + source-guarded** | `ML_P1_S4_INVOICE_PATH_DENY` confirmed on main |
+| 9 | Quote-accept draft invoice trigger branch | SQL | **Denied + source-guarded** | Keep `auto_create_draft_invoice_on_acceptance=false` |
+| 10 | `MyMoney.jsx` / legacy direct inserts | Frontend | **Denied + source-guarded** | Client deny + RPC-only path |
+| 11 | `send-invoice` | Edge | **Convert** | Delivery after issue; no amount mutation |
+| 12 | Offline/Stripe settlement writers | SQL/Edge | **Approved exception (S5b)** | Out of S5 coding |
+| 13 | `public-pay` / public-invoice | Edge | **Approved exception** | Read / provider pointers only |
+| 14 | `process_public_payment` mock | SQL/service | **Denied + source-guarded** | Legacy mock |
+| 15 | Job/quote payment→invoice sync triggers | SQL | **Denied + source-guarded** | Invoice settlement ≠ quote/job payment patch |
+| 16 | `money-loop-delete` invoice cleanup | Edge | **Approved exception** | Admin/ops only |
+| 17 | Discount helpers | SQL | **Convert or deny** | Draft-only via canonical rules |
+| 18 | Test/smoke admin inserts | Tests | **Approved exception** | Synthetic/test-only |
+| 19 | Stale UI “prepares draft invoice” copy | UI | **Remove / rewrite** | Align to hybrid draft + office issue |
+
+## Residual create risks (close in coding — not this PR)
+
+1. Payment-field patch on `work-order-update` still able to ensure/create invoice.  
+2. Direct authenticated inserts into `invoices` if RLS allows.  
+3. Re-enabling `auto_create_draft_invoice_on_acceptance`.  
+4. Accidental auto-`sent` if issue wired into complete path.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_PLANNING_DESIGN.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_PLANNING_DESIGN.md
@@ -1,0 +1,246 @@
+# ML-P1 Slice 5 — Planning Design (Completed Job → Invoice)
+
+| Field | Value |
+| --- | --- |
+| Base SHA | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Branch | `plan/ml-p1-s5-invoice-generation` |
+| Disposition | **SLICE5_PLANNING_REQUIRES_CODING_AUTH** — PD-S5-01…07 **RATIFIED** |
+| Depends on | S4 completion readiness + approved COs; invoice-on-complete remains off |
+| Revalidated | 2026-07-23 live invoice baseline unchanged (25; draft/sent/paid) |
+
+---
+
+## 1. Canonical writer design
+
+### `ml_p1_s5_invoice_create(p_job_id, p_client_mutation_id, p_actor_role_hint unused)`
+
+**SECURITY DEFINER** RPC; role from `ml_p1_s2_current_actor_role()` (Auth UUID → `app_user_roles`).
+
+**Inputs (server-resolved, not client amounts):**
+- `p_job_id`
+- `p_client_mutation_id` (idempotency)
+- Tax defaults from **approved quote snapshot** (PD-S5-04 B); office draft tax correct via `ml_p1_s5_invoice_draft_update` (PD-S5-04 C)
+
+**Algorithm:**
+1. Lock job `FOR UPDATE`.
+2. Assert capability `invoice.create` (office/manager/admin).
+3. Eligibility gate (§2) — else raise typed deny codes.
+4. Load approved quote pinned on job (`quote_id` + `source_quote_version` if present).
+5. Load change orders with `status='approved'` only.
+6. Build line snapshot:
+   - original quote lines (stored historical unit prices)
+   - plus approved CO lines (stored deltas)
+   - exclude rejected/cancelled/pending COs
+7. Compute financials per §6; write `invoices` + `invoice_items` in one transaction.
+8. Emit audit event; record mutation idempotency row.
+9. Return invoice id + status=`draft` + `invoice_created=true` + lineage payload.
+10. **Never** set status to `sent`/`paid`; **never** call Stripe; **never** send customer email inside create.
+
+### Companion RPCs (planned)
+| RPC | Purpose |
+| --- | --- |
+| `ml_p1_s5_invoice_draft_update` | Pre-issue corrections (lines/tax/notes) while `draft` |
+| `ml_p1_s5_invoice_issue` | `draft`→`sent`; sets `sent_at`, release flags; may create `public_token` |
+| `ml_p1_s5_invoice_void` | Void with reason; authority per PD-S5-05 |
+| `ml_p1_s5_invoice_get` / readiness | Blocked reasons for UI |
+
+Idempotency: same `(job_id, client_mutation_id)` returns prior result. Unique job invoice index enforces single non-null job invoice.
+
+---
+
+## 2. Eligibility contract
+
+| Code | Condition |
+| --- | --- |
+| `ML_P1_S5_JOB_NOT_FOUND` | Missing job |
+| `ML_P1_S5_JOB_NOT_COMPLETED` | `jobs.status <> completed` |
+| `ML_P1_S5_COMPLETION_NOT_READY` | `ml_p1_s4_completion_readiness.ready <> true` (recompute) |
+| `ML_P1_S5_PENDING_CHANGE_ORDER` | Any CO in `proposed`/`pending_approval` |
+| `ML_P1_S5_QUOTE_REQUIRED` | Missing approved source quote |
+| `ML_P1_S5_INVOICE_EXISTS` | Invoice already linked to job (unique hit / found row) |
+| `ML_P1_S5_ROLE_DENY` | Role cannot `invoice.create` |
+| `ML_P1_S5_STALE_JOB` | Optional row_version mismatch |
+| `ML_P1_S5_CANCELLED_JOB` | Job cancelled |
+| `ML_P1_S5_MUTATION_ID_REQUIRED` | Missing idempotency key |
+
+---
+
+## 3. Lineage (persist on invoice + items + events)
+
+| Field | Source |
+| --- | --- |
+| `job_id` | Job |
+| `quote_id` | Job.source quote |
+| `source_quote_version` | **Add column** if missing — pin version at create |
+| `approved_change_order_ids` | **Add jsonb/uuid[]** of approved CO ids + versions |
+| Customer / address | From lead/property/job snapshot fields |
+| Line `source_kind` | `quote` \| `change_order` |
+| Line `source_id` | quote_item id or CO item id |
+| `unit_price` / qty | **Stored historical** — never live price_book re-fetch |
+| Actor / timestamps | `auth.uid()`, `created_at` |
+| Audit | `events` row `InvoiceCreated` with payload hash of totals |
+
+---
+
+## 4. Lifecycle state machine (proposed vs live)
+
+**Live observed:** `draft` → `sent` → `paid` (and stay).
+
+**Ratified S5 product states (PD-S5-02 C):**
+
+```
+draft → sent (display “Issued”) → paid
+                ↘ void
+sent → void (if unpaid; PD-S5-06 A)
+paid → (refunded via S5b only — out of scope)
+```
+
+| State | S5 meaning | Who |
+| --- | --- | --- |
+| `draft` | Editable office review | office/manager/admin |
+| `sent` | Issued to customer (UI label **“Issued”**); amounts immutable (PD-S5-06 A) | office issue |
+| `partial` / `partially_paid` | Settlement projection (S5b writers) | read in S5 |
+| `paid` | Settled | read in S5 |
+| `void` | Cancelled invoice | void authority (PD-S5-05 A) |
+| `written_off` | Financial close — admin write-off (PD-S5-05); may land in S5b if deferred | admin |
+
+S5 **writes:** `draft`, `sent`, `void` only. Payment statuses are **read** from settlement fields.
+
+---
+
+## 5. Authorization matrix (S5)
+
+| Capability | tech | office/CSR | manager | admin | viewer | partner | customer |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Create draft invoice | N | Y | Y | Y | N | N | N |
+| Edit draft | N | Y | Y | Y | N | N | N |
+| Issue/send | N | Y | Y | Y | N | N | N |
+| Void | N | Y* | Y | Y | N | N | N |
+| Write-off | N | N | N | Y* | N | N | N |
+| Edit issued totals | N | N | N | N | N | N | N |
+| View office invoice | N | Y | Y | Y | Y | limited | N |
+| View public invoice | — | — | — | — | — | — | token |
+| Record payment | — | — | — | — | — | — | **S5b** |
+
+\* Per PD-S5-05 A. Technicians **never** edit invoice totals, void, or write off.
+
+---
+
+## 6. Financial calculation contract (no invented pricing)
+
+| Rule | Spec |
+| --- | --- |
+| Price source | Stored quote lines + approved CO lines only |
+| Pricebook | **Forbidden** as recalculation source at invoice create |
+| Subtotal | Σ (qty × unit_price) for included lines |
+| Discounts | Include quote/CO discount lines as stored; header `discount_amount` if present on draft per office edit |
+| Negative lines | Allowed when `line_type=discount` or stored negative (e.g. bundle discount) |
+| Zero-dollar lines | Allowed; still appear if on approved scope |
+| Tax | PD-S5-04 B+C: default from quote snapshot; office may correct on draft; freeze on issue; `tax_amount = round(taxable_subtotal × tax_rate, 2)` half-up to cents |
+| Credits | No new credit-memo product in S5; void+reissue for corrections |
+| Total | `subtotal - discount_amount + tax_amount` → `total_amount` |
+| Immutability | On `sent`, financial columns + items **DENY** update except void transition |
+| Write-off | Out of S5 default (PD) |
+| Rounding | Per-line round to 2 decimals; then tax on taxable sum |
+
+---
+
+## 7. Creation behavior (PD-S5-01 C RATIFIED)
+
+**Hybrid (C)**  
+- Auto-`draft` when job → `completed` **and** S4 readiness pass **and** no pending CO **and** no existing blocking invoice.  
+- Office always issues (explicit).  
+- Office can manually create if auto missed.  
+- **`invoice_type='final'` only** (PD-S5-03 A).  
+- **Never** auto-`sent` / auto-email on complete.
+
+---
+
+## 8. Issue / customer communication boundary
+
+| Allowed in S5 | Not in S5 |
+| --- | --- |
+| Issue → `sent` | Autonomous unpaid dunning |
+| `send-invoice` email/SMS re-delivery | Failed-payment automation |
+| Public invoice view by token | Review-request automation |
+| Payment status **read-only** display | Stripe checkout (S5b) |
+
+---
+
+## 9. Correction / void model (PD-S5-06 A RATIFIED)
+
+| Case | Policy |
+| --- | --- |
+| Draft typo / wrong line / tax | Edit via draft update RPC |
+| Missed approved CO before issue | Rebuild draft from lineage (replace items) while draft |
+| After issue, unpaid | **Void** + reissue (new id; old void retained) — **no in-place edit** |
+| After partial/full payment | **No S5 amount edit** — S5b/finance exception path |
+| Duplicate create | Idempotent return / `INVOICE_EXISTS` |
+| Wrong customer/address on draft | Edit snapshot fields on draft only |
+| Pre-existing 25 invoices | Grandfather (PD-S5-07 A); no historical rewrite |
+
+---
+
+## 10. Office UI plan
+
+- Completed job → Invoice panel: Create / Open draft  
+- Show: linked job, quote version, approved COs, blocked reasons  
+- Financial summary (subtotal/tax/discount/total)  
+- Issue/Send, Void (with reason), Audit history  
+- No duplicate-create button when invoice exists  
+- Remove stale “completion prepares invoice” copy
+
+## 11. Customer invoice UI plan
+
+- Invoice number, issue date, due date (if used), status  
+- Work summary, service address  
+- Line items (quote + approved CO), subtotal, tax, credits/discounts, total  
+- Payment status read-only  
+- **No** internal notes, actor emails, break-glass proofs, office audit
+
+---
+
+## 12. Migration plan (ordered)
+
+1. Additive lineage columns on `invoices` / `invoice_items` (`source_quote_version`, `approved_change_order_ids`, `source_kind`, `source_id`, calculation snapshot jsonb).  
+2. Canonical RPCs + grants.  
+3. Alternate-writer denials (work-order ensure, MyMoney, trigger flags asserted false).  
+4. Idempotency / mutation table if needed.  
+5. UI + edge bridges.  
+6. Forward-fix plan: disable RPC / feature flag; do not delete historical invoices.  
+7. Pre-apply: confirm unique indexes; count existing invoices; no multi-invoice jobs (currently 0).
+
+**Do not** use deprecated `estimates` writers.  
+**Do not** treat `tenant_id` as auth — preserve column defaults only.
+
+---
+
+## 13. Failure / recovery
+
+| Failure | Behavior |
+| --- | --- |
+| Duplicate / concurrent create | Unique violation → return existing or `INVOICE_EXISTS`; transaction abort |
+| Eligibility fail | No partial invoice row |
+| Audit insert fail | Abort whole transaction |
+| Issue/send email fail | Invoice may be `sent` with delivery_error event **or** keep draft until delivery ack — **prefer: mark sent only after token ready; delivery failure = retryable event, not false success** |
+| Void fail | No status change |
+| Customer token missing | Generate on issue; fail closed if cannot |
+| Stale client | Version check deny |
+
+---
+
+## 14. Test sentinels (adversarial)
+
+Unauthorized create · tech total edit · duplicate create · concurrent create · unapproved CO included · approved CO omitted · pricebook drift attempt · direct frontend insert · legacy alternate writer · invoice-on-complete bleed · missing job/quote lineage · partial persistence · issue without review (if required) · edit after issue · void without authority · customer sees internal fields · send false success · create from incomplete/cancelled job.
+
+---
+
+## 15. Review lanes
+
+Product · Data · Security · Financial Control · Architecture · UX/Field · Independent Adversarial Test — freeze exact coding tip before reviews.
+
+---
+
+## 16. Coding-readiness
+
+PD-S5-01…07 **ratified**. Next: merge this planning PR → Founder **coding authorization** on exact branch/base. No implementation until that auth.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_RESIDUAL_REGISTER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_RESIDUAL_REGISTER.md
@@ -1,0 +1,13 @@
+# ML-P1 Slice 5 — Residual Register
+
+| ID | Severity | Status | Note |
+| --- | --- | --- | --- |
+| R-S5-01 | Medium | Open (coding) | `work-order-update` payment-ensure may still create invoice — must deny in coding |
+| R-S5-02 | Medium | Open (coding) | Direct `invoices` insert if RLS permits — force RPC-only |
+| R-S5-03 | Low | Open (coding) | Stale UI copy implying auto invoice on complete |
+| R-S5-04 | Low | Open (coding) | Lineage columns (quote version / CO ids / calc snapshot) absent on grandfathered rows — best-effort only (PD-S5-07) |
+| R-S5-05 | Info | Closed (product) | PD-S5-01…07 ratified 2026-07-23 |
+| R-S5-06 | Info | Closed (planning) | Stale base `3bb175e` replaced by `e9cc331` |
+| R-S4-07 | Soft | Carry | tenant_id stamps — non-blocking |
+
+No residual authorizes Stripe, historical reprice, or multi-tenant work.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_STATE_LEDGER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_STATE_LEDGER.md
@@ -1,0 +1,13 @@
+# ML-P1 Slice 5 — Active State Ledger
+
+| Field | Value |
+| --- | --- |
+| Active slice | **ML-P1-S5** (planning) |
+| Stage | Product decisions **RATIFIED** → planning PR → coding auth (later) |
+| Exact main SHA | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Branch | `plan/ml-p1-s5-invoice-generation` |
+| Migration status | None for S5 |
+| Deploy status | N/A |
+| Open decisions | None (PD-S5-01…07 closed) |
+| Next Founder auth | After planning PR merge: **authorize Slice 5 coding** on exact SHA |
+| Explicitly not started | Implementation · migrations · S5b · Stripe · S6 · TIS · G2.3 |

--- a/command-center/docs/stabilization/releases/ML-P1_STATE_LEDGER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_STATE_LEDGER.md
@@ -4,37 +4,21 @@
 | --- | --- |
 | Updated | 2026-07-23 |
 | Repo | https://github.com/faydog127/BHFOS |
-| Worktree | `F:\Dev\BHFOS-ml-p1-s3` (main) |
-| Current main | `9b5402c5eaa2e06cf5aebe923f36900f64f8b2d2` |
-| Evidence bundle | `260C5CB28EE1A7F5E4E76A488C38749926CDC8435608F83A1B421808E90A4158` → `ML-P1_EVIDENCE_MANIFEST.md` |
-| Active work queue | **None** — all authorized items complete |
+| Current main (planning base) | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Evidence bundle (price-book) | `260C5CB28EE1A7F5E4E76A488C38749926CDC8435608F83A1B421808E90A4158` |
 
 ## Slice / gate posture
 
 | Slice | Gate | Status |
 | --- | --- | --- |
-| S1–S3 | Closed | Production coherent |
-| **S4** Field execution | **CLOSED ✔** | A3 PASS; R-S4-06 remediated; soft R-S4-07 |
-| HCP price-book | **A2-MERGED ✔** | PR #100 @ `a1c822b` → merge `ced9bfb`; ledger record `9b5402c` |
-| **S5** Billing / invoices | **BLOCKED** | Waiting **PD-S5-01…07** — no coding |
+| S4 | CLOSED ✔ | A3 PASS |
+| Price-book | A2-MERGED ✔ | PR #100 |
+| **S5** | Planning PR (docs) | PD-S5-01…07 **RATIFIED**; coding **blocked** until planning PR merges + coding auth |
 
-## Waiting on Founder
+## Waiting on Founder (after planning PR merges)
 
-- **PD-S5-01 … PD-S5-07** (Slice 5 billing / invoices)
+- Authorize **Slice 5 coding** on exact branch/base SHA (not yet requested)
 
-## Standing rules
+## Halt / non-scope
 
-- A0 → three-round peer review → exact-SHA merge → prod A3
-- Auto-continue inside already-authorized scope; halt on gate fail / scope drift / missing PD
-- Synthetic tech/office only for prod validation; never mutate real customer data
-- Never enable Stripe, autonomous follow-up, TIS, G2.3, or multi-tenant writers unless explicitly re-authorized
-
-## Next steps (when PD-S5 arrives)
-
-1. Create `ml/p1-s5-billing` worktree from main  
-2. Draft Slice 5 packet (scope, migrations, tests); open A2 PR  
-3. Standard review → merge → apply → validation  
-
-## Halt
-
-Idle until Founder PD-S5 answers. No migrations, deploys, or Slice 5 coding.
+No migrations · no app implementation · no Hostinger deploy · no Stripe · no historical invoice rewrite until coding is explicitly authorized.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_ARCHITECTURE_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_ARCHITECTURE_REVIEW.md
@@ -1,0 +1,17 @@
+# ML-P1 S5 Planning — Round 1 Review (Architecture / Scope / Source-of-Truth)
+
+| Field | Value |
+| --- | --- |
+| Target | Slice 5 planning docs on `plan/ml-p1-s5-invoice-generation` vs main `e9cc331` |
+| Verdict | **APPROVED** with residuals deferred to coding |
+
+## Findings
+
+- **No P0/P1.** Ratified PD-S5-01…07 are consistently reflected in decision packet, brief, design, and architecture.
+- Source-of-truth: planning base SHA updated from stale `3bb175e` → `e9cc331`; live invoice counts revalidated.
+- Scope boundary clear: no Stripe/S5b, no historical rewrite, `final` only, `sent` persist / “Issued” display.
+- Writer inventory still correctly denies parallel creators; auto-draft companion added for PD-S5-01 C without auto-issue.
+
+## Residual
+
+Coding must close R-S5-01/02 (ensure-create / direct insert). Not blockers for planning merge.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_OPS_UX_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_OPS_UX_REVIEW.md
@@ -1,0 +1,15 @@
+# ML-P1 S5 Planning — Round 3 Review (Usability / Ops / Founder Interruptions)
+
+| Field | Value |
+| --- | --- |
+| Target | Same planning package |
+| Verdict | **APPROVED** |
+
+## Findings
+
+- Hybrid create (PD-S5-01 C) reduces missed billing without customer spam (no auto-send).
+- “Issued” label with stored `sent` avoids disruptive rename migration (PD-S5-02 C) — good ops choice.
+- Office void + admin write-off matches day-to-day vs finance escalation.
+- Next Founder ask is **one** coding-authorization line after this PR merges — avoids re-asking PD-S5.
+
+## No CHANGES_REQUIRED for planning merge.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_SECURITY_FINANCIAL_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_SECURITY_FINANCIAL_REVIEW.md
@@ -1,0 +1,15 @@
+# ML-P1 S5 Planning — Round 2 Review (Security / Financial Integrity / Adversarial)
+
+| Field | Value |
+| --- | --- |
+| Target | Same planning package |
+| Verdict | **APPROVED** |
+
+## Findings
+
+- Financial integrity: quote-snapshot tax + draft-only correct + freeze on issue (PD-S5-04) prevents silent pricebook recalculation — especially important after HCP price-book merge.
+- Adversarial: void+reissue (PD-S5-06) blocks in-place mutation of issued unpaid invoices; grandfather (PD-S5-07) blocks historical reprice.
+- Authority: tech never voids/writes-off/edits money (PD-S5-05); write-off admin-only.
+- Security: planning docs do not introduce new public endpoints or secret handling; coding must keep SECURITY DEFINER role checks.
+
+## No CHANGES_REQUIRED for planning merge.


### PR DESCRIPTION
## Summary
- Rebases Slice 5 planning onto current main `e9cc331`.
- Promotes Founder-ratified PD-S5-01..07 into the authoritative decision packet.
- Revalidates live invoice baseline (25) and source invoice gates.
- Adds brief, residuals, and three planning critique rounds.

## Scope
Docs/planning only. No migrations, app code, deploy, Stripe, or historical invoice changes.

## Test plan
- [x] Docs-only diff
- [ ] CI green
- [x] Three critique rounds recorded under reviews/
