### PR TITLE
ML-P1 S5 A2: invoice collection (SOURCE only)

### DIFF
--- a/command-center/docs/governance/decisions/ML-P1_SLICE5_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/ML-P1_SLICE5_DECISION_PACKET.md
@@ -2,11 +2,12 @@
 
 | Field | Value |
 | --- | --- |
-| Disposition | **SLICE5_PLANNING_REQUIRES_CODING_AUTH** (product decisions **RATIFIED**) |
-| Planning base (exact `origin/main`) | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
-| Branch | `plan/ml-p1-s5-invoice-generation` |
+| Disposition | **SLICE5_A2_CODING** (product decisions **RATIFIED**; coding on `ml/p1-s5-invoice-collection`) |
+| Planning base (exact `origin/main` ancestor) | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Coding base SHA | `8505a89a0e920ff68e35d0f10b49e98693125674` |
+| Branch | `ml/p1-s5-invoice-collection` |
 | Prior slices | S1–S4 closed; price-book **A2-MERGED**; invoice-on-complete **disabled** |
-| Coding | **Not authorized** until this planning PR merges and Founder grants coding auth |
+| Coding | **Authorized** — A2 SOURCE PR; **no prod migration apply / deploy / Stripe** until separate Founder A3 |
 | Supersedes | Draft packet on prior tip `84452db` (base `3bb175e`) |
 
 ## Purpose
@@ -68,7 +69,8 @@ Completed canonical job → **exactly one** canonical **`final`** invoice (`draf
 
 Slice 5b Stripe · refunds · payment reconciliation · Slice 6 autonomous follow-up · TIS · G2.3 · multi-tenancy · pricebook optimization · historical invoice reprice.
 
-## Coding gate (after this planning PR merges)
+## Coding gate
 
-Requires separate Founder line: **authorize Slice 5 coding** on exact branch/base SHA.  
-Until then: **no migrations, no app implementation, no deploy.**
+Founder authorized Slice 5 coding on branch `ml/p1-s5-invoice-collection` at base `8505a89`.  
+A2 SOURCE complete. **Merge** requires exact-head Founder approval.  
+**A3** (prod migrations / Hostinger / Stripe) requires separate Founder line — not granted.

--- a/command-center/docs/governance/decisions/ML-P1_SLICE5_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/ML-P1_SLICE5_DECISION_PACKET.md
@@ -1,0 +1,74 @@
+# Decision Packet — ML-P1 Slice 5 (Invoice Generation)
+
+| Field | Value |
+| --- | --- |
+| Disposition | **SLICE5_PLANNING_REQUIRES_CODING_AUTH** (product decisions **RATIFIED**) |
+| Planning base (exact `origin/main`) | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Branch | `plan/ml-p1-s5-invoice-generation` |
+| Prior slices | S1–S4 closed; price-book **A2-MERGED**; invoice-on-complete **disabled** |
+| Coding | **Not authorized** until this planning PR merges and Founder grants coding auth |
+| Supersedes | Draft packet on prior tip `84452db` (base `3bb175e`) |
+
+## Purpose
+
+Completed canonical job → **exactly one** canonical **`final`** invoice (`draft` → office review → issue as persisted `sent` / display “Issued”), with lineage from approved quote + approved change orders. Stop before Stripe (S5b) and autonomous follow-up (S6).
+
+## Live baseline (revalidated 2026-07-23 against linked prod)
+
+| Fact | Evidence |
+| --- | --- |
+| Invoices | **25** rows; `draft` 2 · `sent` 14 · `paid` 9 |
+| Uniqueness | `idx_invoices_unique_job`, `idx_invoices_one_active_per_job`, `invoices_one_draft_per_job_type_uq` present |
+| S4 gate (source on main) | `ML_P1_S4_INVOICE_ON_COMPLETE_ENABLED = false` in `work-order-update` |
+| Kanban | `ML_P1_S4_INVOICE_PATH_DENY` still denies invoice create |
+| Config (repo) | `auto_create_draft_invoice_on_acceptance` seeded `false` |
+| Schema | `invoice_type` CHECK still allows deposit/progress/final; **S5 product creates `final` only** (PD-S5-03 A) |
+
+## Ratified product decisions (Founder 2026-07-23)
+
+### PD-S5-01 — Invoice creation trigger → **C (Hybrid)** RATIFIED
+- Auto-create **draft** when eligible job reaches `completed` (S4 readiness pass, no pending COs, no existing blocking invoice).
+- Office may create draft if auto-create did not occur.
+- Remains **draft** until office review and **explicit issue**.
+- **Never** auto-issue or auto-send.
+
+### PD-S5-02 — Issued status vocabulary → **C** RATIFIED
+- Persist issued state as **`sent`**.
+- Display office/customer label **“Issued”** where appropriate.
+- **No** database status rename migration.
+
+### PD-S5-03 — `invoice_type` → **A** RATIFIED
+- S5 creates **`final`** invoices only.
+- Do not expose deposit/progress creation in S5 UI/RPC.
+- Keep schema CHECK for compatibility; do not drop columns for migration risk avoidance.
+
+### PD-S5-04 — Tax at invoice creation → **B+C** RATIFIED
+- Default tax from **approved quote financial snapshot**.
+- Authorized office may correct tax while status is **draft**.
+- **Freeze** tax and all invoice financial values when issued (`sent`).
+- **Never** silently recalculate an issued invoice from current pricebook or tax settings.
+
+### PD-S5-05 — Void and write-off authority → **A** RATIFIED
+- Void: **office | manager | admin** (reason + immutable audit required).
+- Write-off: **admin only** (reason + immutable audit required).
+- Technicians **never** void, write off, or modify invoice financial values.
+
+### PD-S5-06 — Correction after issue (unpaid) → **A** RATIFIED
+- Issued unpaid invoices **may not** be edited in place.
+- Corrections = **void + reissue**.
+- Preserve original issued invoice and audit history.
+
+### PD-S5-07 — Pre-existing invoices (25) → **A** RATIFIED
+- **Grandfather** the 25 live invoices.
+- Do **not** rewrite or reprice historical financial data.
+- Canonical S5 writer applies to **new** creates.
+- Safe best-effort lineage backfill only (no changes to historical amounts, statuses, or customer-visible records).
+
+## Explicit non-scope
+
+Slice 5b Stripe · refunds · payment reconciliation · Slice 6 autonomous follow-up · TIS · G2.3 · multi-tenancy · pricebook optimization · historical invoice reprice.
+
+## Coding gate (after this planning PR merges)
+
+Requires separate Founder line: **authorize Slice 5 coding** on exact branch/base SHA.  
+Until then: **no migrations, no app implementation, no deploy.**

--- a/command-center/docs/stabilization/releases/ML-P1_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/stabilization/releases/ML-P1_EVIDENCE_MANIFEST.md
@@ -38,4 +38,5 @@ Paths relative to `command-center/`; SHA-256 over path + newline + file bytes, c
 | --- | --- |
 | Slice 4 evidence | `ML-P1_SLICE4_EVIDENCE_MANIFEST.md` |
 | Slice 4 state | `ML-P1_SLICE4_STATE_LEDGER.md` |
+| Slice 5 planning evidence | `ML-P1_SLICE5_EVIDENCE_MANIFEST.md` |
 | Program state | `ML-P1_STATE_LEDGER.md` |

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_A2_CODING_EVIDENCE.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_A2_CODING_EVIDENCE.md
@@ -1,0 +1,49 @@
+# ML-P1 Slice 5 — A2 Coding Evidence
+
+> Coding authorized on branch `ml/p1-s5-invoice-collection` at base SHA
+> `8505a89a0e920ff68e35d0f10b49e98693125674` (PD-S5-01…07 ratified planning tip).
+>
+> **Does not authorize** production migration apply, Hostinger deploy, Stripe/Braintree,
+> S5b payments, Slice 6, TIS, or G2.3.
+
+## Delivered (SOURCE)
+
+| Item | Path / note |
+| --- | --- |
+| Schema | `supabase/migrations/20260723120000_ml_p1_s5_invoice_schema.sql` |
+| RPCs | `supabase/migrations/20260723121000_ml_p1_s5_invoice_rpcs.sql` |
+| Auto-draft | `supabase/migrations/20260723122000_ml_p1_s5_auto_draft_trigger.sql` |
+| Edge deny | `work-order-update` → `ML_P1_S5_ALT_WRITER_DENY` |
+| MyMoney deny | direct `invoices.insert` removed / denied |
+| Authz | `src/lib/mlP1S5InvoiceAuthz.js` |
+| Service | `src/services/mlP1S5InvoiceService.js` (RPC-only) |
+| UI | `OfficeInvoicePanel` wired in Jobs record modal; Invoices badge **Issued** for `sent` |
+| Tests | `tests/unit/ml-p1-s5-invoice.test.mjs` |
+
+## PD mapping
+
+| PD | Implementation |
+| --- | --- |
+| PD-S5-01 C | Trigger auto-draft on `jobs.status→completed` + office create RPC; never auto-issue |
+| PD-S5-02 C | Persist `sent`; UI/RPC `display_status` / badge **Issued** |
+| PD-S5-03 A | Create `invoice_type = 'final'` only |
+| PD-S5-04 B+C | Tax from quote snapshot; draft tax update; issued immutability trigger; `pricebook_used=false` |
+| PD-S5-05 A | Void office\|manager\|admin\|csr; write-off capability admin-only (RPC deferred → residual); tech deny |
+| PD-S5-06 A | Issued financial UPDATE blocked; void+reissue path |
+| PD-S5-07 A | `s5_created` flag; no historical rewrite |
+
+## Explicit non-actions
+
+- Did **not** apply any S5 migration to linked production
+- Did **not** deploy Hostinger / Edge
+- Did **not** enable Stripe / Braintree / payment capture
+- Did **not** rewrite the 25 grandfathered live invoices
+- Did **not** re-enable S4 invoice-on-complete (`false` retained)
+
+## Residuals (coding)
+
+| ID | Note |
+| --- | --- |
+| R-S5-08 | Admin write-off RPC/UI deferred (capability helper present; S5b-compatible) |
+| R-S5-07 | Soft-fail auto-draft depends on `events` insert; office manual create remains |
+| R-S5-04 | Grandfathered rows lack full lineage until best-effort backfill (no amount rewrite) |

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_ARCHITECTURE_FINDINGS.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_ARCHITECTURE_FINDINGS.md
@@ -1,0 +1,61 @@
+# ML-P1 Slice 5 — Architecture Findings (Invoice) — revalidated
+
+| Field | Value |
+| --- | --- |
+| Planning base | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Revalidated | 2026-07-23 |
+| Live invoices | 25 · `draft`/`sent`/`paid` · unique-job indexes present |
+| S4 gate | Invoice-on-complete **disabled** in source |
+| PD status | PD-S5-01…07 **RATIFIED** |
+
+## System picture
+
+```mermaid
+flowchart LR
+  subgraph s4 [Slice 4 done]
+    Job[jobs completed]
+    CO[approved change_orders]
+    Q[quotes approved]
+  end
+  subgraph today [Current invoice reality]
+    IS[invoice-save Edge]
+    WO[work-order-update create gated off]
+    KM[kanban invoice deny]
+    SI[send-invoice]
+  end
+  subgraph s5 [Slice 5 target]
+    CW[ml_p1_s5_invoice_create]
+    Draft[invoice draft final]
+    Issue[issue to sent / Issued]
+  end
+  Job --> CW
+  Q --> CW
+  CO --> CW
+  CW --> Draft
+  Draft --> Issue
+  IS -.->|convert| CW
+  WO -.->|deny| X[blocked]
+  KM -.->|deny| X
+  Issue --> SI
+```
+
+## Findings (still true on current main + live)
+
+1. **No S5 canonical create RPC** on main — closest writer remains Edge `invoice-save`.
+2. **One-invoice-per-job indexes** present live (`idx_invoices_unique_job`, active/draft-type uniques).
+3. **Parallel creators remain dangerous if re-enabled:** work-order ensure, kanban getOrCreate, quote-accept auto-draft flag, MyMoney/direct inserts.
+4. **S4 correctly disables** complete→invoice create; kanban denies invoice path.
+5. **Settlement writers** are S5b — S5 must not own Stripe/offline payment authority; may read settlement.
+6. **Lineage incomplete** on live invoices — job/quote ids present; frozen quote version + CO id set + calc snapshot still to be designed in coding (grandfather PD-S5-07).
+7. **Status vocabulary live-simple:** `draft`/`sent`/`paid` — PD-S5-02 keeps `sent`, display “Issued”.
+8. **tenant_id** remains storage; authz follows single-company role model (not multi-tenant).
+9. **Price-book on main** now includes HCP catalog — **forbidden** as silent recalculation source at invoice create/issue (PD-S5-04).
+
+## Boundary
+
+| In S5 | Out |
+| --- | --- |
+| Canonical create from completed job + quote + approved COs | Stripe initiate/webhook/refunds |
+| Draft review, issue/send, void | Autonomous unpaid follow-up |
+| Tax from quote snapshot + draft correct | Pricebook reprice of issued |
+| Customer invoice view (read) | TIS / G2.3 / multi-tenant redesign |

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_BRIEF.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_BRIEF.md
@@ -1,0 +1,37 @@
+# ML-P1 Slice 5 — Brief
+
+| Field | Value |
+| --- | --- |
+| Slice | **ML-P1-S5** Invoice generation (canonical draft → issue) |
+| Planning base | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Product decisions | **PD-S5-01…07 RATIFIED** 2026-07-23 |
+| Coding | Not started · not authorized |
+| Out of scope | Stripe/S5b · refunds · autonomous follow-up · TIS · G2.3 · multi-tenant |
+
+## One-sentence goal
+
+After a job is properly completed, create exactly one final draft invoice from approved quote + approved change orders, let office review and issue it (stored as `sent`, shown as “Issued”), and never silently change money after issue.
+
+## In / out
+
+| In | Out |
+| --- | --- |
+| Hybrid draft create (auto + office fallback) | Auto-send / auto-issue |
+| Office issue → `sent` (“Issued”) | Deposit/progress invoice product |
+| Quote-snapshot tax + draft tax correct | Silent reprice from pricebook |
+| Void+reissue corrections | In-place edit of issued amounts |
+| Grandfather 25 live invoices | Historical rewrite |
+| Deny alternate create writers | Stripe / refunds / dunning |
+
+## Success criteria (when coding is later authorized)
+
+1. Eligible completed job yields one `final` draft (auto or office).  
+2. Issue freezes financials; display “Issued”; persist `sent`.  
+3. Tech cannot create/void/write-off/edit money.  
+4. Parallel create paths remain denied.  
+5. Synthetic-only prod validation; cleanup after.
+
+## Related artifacts
+
+- Decision packet: `docs/governance/decisions/ML-P1_SLICE5_DECISION_PACKET.md`  
+- Architecture / planning design / writer inventory / state ledger / evidence / residuals under `docs/stabilization/releases/ML-P1_SLICE5_*`

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_EVIDENCE_MANIFEST.md
@@ -1,33 +1,24 @@
-# Evidence Manifest — ML-P1 Slice 5 Planning (ratified)
+# Evidence Manifest — ML-P1 Slice 5 A2 Coding
 
 | Field | Value |
 | --- | --- |
-| Scope | Planning / governance only — completed job → canonical invoice |
-| Exact main SHA | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
-| Branch | `plan/ml-p1-s5-invoice-generation` |
-| Disposition | PD-S5-01…07 **RATIFIED**; coding **not** authorized |
-| Supersedes | Prior planning tip `84452db` / base `3bb175e` |
+| Scope | Completed job → canonical final invoice (draft → issue `sent` / Issued) |
+| Exact coding base SHA | `8505a89a0e920ff68e35d0f10b49e98693125674` |
+| Branch | `ml/p1-s5-invoice-collection` |
+| Disposition | **A2 coding complete (SOURCE)**; merge requires Founder exact-head approval; **no prod apply** |
 
 ## Artifacts
 
 | Path | Role |
 | --- | --- |
 | `docs/governance/decisions/ML-P1_SLICE5_DECISION_PACKET.md` | Ratified PD-S5-01…07 |
-| `docs/stabilization/releases/ML-P1_SLICE5_BRIEF.md` | Slice brief |
-| `docs/stabilization/releases/ML-P1_SLICE5_ARCHITECTURE_FINDINGS.md` | Architecture (revalidated) |
-| `docs/stabilization/releases/ML-P1_SLICE5_PLANNING_DESIGN.md` | Design |
-| `docs/stabilization/releases/ML-P1_SLICE5_INVOICE_WRITER_INVENTORY.md` | Writer inventory |
+| `docs/stabilization/releases/ML-P1_SLICE5_A2_CODING_EVIDENCE.md` | Coding evidence |
 | `docs/stabilization/releases/ML-P1_SLICE5_STATE_LEDGER.md` | S5 state |
 | `docs/stabilization/releases/ML-P1_SLICE5_RESIDUAL_REGISTER.md` | Residuals |
-| `docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_*_REVIEW.md` | Three critique rounds |
-
-## EXECUTED revalidation (2026-07-23)
-
-- `origin/main` = `e9cc3317fcb9c84f44643700927699f40c7f1a93`
-- Live invoices: 25 (`draft` 2, `sent` 14, `paid` 9)
-- Indexes: `idx_invoices_unique_job`, `idx_invoices_one_active_per_job`, draft-per-type unique present
-- Source: `ML_P1_S4_INVOICE_ON_COMPLETE_ENABLED=false`; kanban `ML_P1_S4_INVOICE_PATH_DENY`
+| `docs/stabilization/releases/reviews/ML-P1_S5_CODING_*_REVIEW.md` | Three coding critique rounds |
+| `supabase/migrations/2026072312*_ml_p1_s5_*.sql` | Schema / RPCs / auto-draft (SOURCE) |
+| `tests/unit/ml-p1-s5-invoice.test.mjs` | Unit / source guards |
 
 ## Explicit non-claims
 
-No Slice 5 coding · no migrations applied · no Stripe · no refunds · no historical invoice rewrite · no Hostinger deploy.
+No production migrations applied · no Hostinger deploy · no Stripe/Braintree · no historical invoice rewrite · merge not authorized without Founder exact-head approval.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_EVIDENCE_MANIFEST.md
@@ -1,0 +1,33 @@
+# Evidence Manifest — ML-P1 Slice 5 Planning (ratified)
+
+| Field | Value |
+| --- | --- |
+| Scope | Planning / governance only — completed job → canonical invoice |
+| Exact main SHA | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Branch | `plan/ml-p1-s5-invoice-generation` |
+| Disposition | PD-S5-01…07 **RATIFIED**; coding **not** authorized |
+| Supersedes | Prior planning tip `84452db` / base `3bb175e` |
+
+## Artifacts
+
+| Path | Role |
+| --- | --- |
+| `docs/governance/decisions/ML-P1_SLICE5_DECISION_PACKET.md` | Ratified PD-S5-01…07 |
+| `docs/stabilization/releases/ML-P1_SLICE5_BRIEF.md` | Slice brief |
+| `docs/stabilization/releases/ML-P1_SLICE5_ARCHITECTURE_FINDINGS.md` | Architecture (revalidated) |
+| `docs/stabilization/releases/ML-P1_SLICE5_PLANNING_DESIGN.md` | Design |
+| `docs/stabilization/releases/ML-P1_SLICE5_INVOICE_WRITER_INVENTORY.md` | Writer inventory |
+| `docs/stabilization/releases/ML-P1_SLICE5_STATE_LEDGER.md` | S5 state |
+| `docs/stabilization/releases/ML-P1_SLICE5_RESIDUAL_REGISTER.md` | Residuals |
+| `docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_*_REVIEW.md` | Three critique rounds |
+
+## EXECUTED revalidation (2026-07-23)
+
+- `origin/main` = `e9cc3317fcb9c84f44643700927699f40c7f1a93`
+- Live invoices: 25 (`draft` 2, `sent` 14, `paid` 9)
+- Indexes: `idx_invoices_unique_job`, `idx_invoices_one_active_per_job`, draft-per-type unique present
+- Source: `ML_P1_S4_INVOICE_ON_COMPLETE_ENABLED=false`; kanban `ML_P1_S4_INVOICE_PATH_DENY`
+
+## Explicit non-claims
+
+No Slice 5 coding · no migrations applied · no Stripe · no refunds · no historical invoice rewrite · no Hostinger deploy.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_INVOICE_WRITER_INVENTORY.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_INVOICE_WRITER_INVENTORY.md
@@ -1,0 +1,36 @@
+# ML-P1 Slice 5 — Invoice Writer Inventory (revalidated)
+
+| Field | Value |
+| --- | --- |
+| Planning base | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Revalidated | 2026-07-23 against current main source |
+| Rule | Inventory alone is not closure — each row has exactly one disposition |
+
+| # | Writer | Surface | Disposition | Closure evidence required |
+| --- | --- | --- | --- | --- |
+| 1 | **`ml_p1_s5_invoice_create`** (new) | RPC | **Canonical** | Migration + tests + I2 (coding auth later) |
+| 2 | **`ml_p1_s5_invoice_draft_update` / `issue` / `void`** (new) | RPC | **Canonical** | Migration + tests |
+| 3 | Job-complete auto-draft hook (new, PD-S5-01 C) | SQL/Edge | **Canonical companion** | Creates **draft only**; never send |
+| 4 | Edge `invoice-save` | Edge/UI | **Convert to call canonical** | Bridge or deny free-form create; draft edit only via S5 rules |
+| 5 | `InvoiceBuilder.jsx` | Frontend | **Convert** | Calls S5 RPC / bridged edge; `final` only |
+| 6 | `work-order-update` create/ensure invoice | Edge | **Denied + source-guarded** | Keep `ML_P1_S4_INVOICE_ON_COMPLETE_ENABLED=false`; extend deny to payment-ensure create |
+| 7 | `work-order-update` `syncInvoiceForPayment` create branch | Edge | **Denied + source-guarded** | Settlement stays S5b |
+| 8 | `kanban-move` `getOrCreateInvoiceForJob` | Edge | **Denied + source-guarded** | `ML_P1_S4_INVOICE_PATH_DENY` confirmed on main |
+| 9 | Quote-accept draft invoice trigger branch | SQL | **Denied + source-guarded** | Keep `auto_create_draft_invoice_on_acceptance=false` |
+| 10 | `MyMoney.jsx` / legacy direct inserts | Frontend | **Denied + source-guarded** | Client deny + RPC-only path |
+| 11 | `send-invoice` | Edge | **Convert** | Delivery after issue; no amount mutation |
+| 12 | Offline/Stripe settlement writers | SQL/Edge | **Approved exception (S5b)** | Out of S5 coding |
+| 13 | `public-pay` / public-invoice | Edge | **Approved exception** | Read / provider pointers only |
+| 14 | `process_public_payment` mock | SQL/service | **Denied + source-guarded** | Legacy mock |
+| 15 | Job/quote payment→invoice sync triggers | SQL | **Denied + source-guarded** | Invoice settlement ≠ quote/job payment patch |
+| 16 | `money-loop-delete` invoice cleanup | Edge | **Approved exception** | Admin/ops only |
+| 17 | Discount helpers | SQL | **Convert or deny** | Draft-only via canonical rules |
+| 18 | Test/smoke admin inserts | Tests | **Approved exception** | Synthetic/test-only |
+| 19 | Stale UI “prepares draft invoice” copy | UI | **Remove / rewrite** | Align to hybrid draft + office issue |
+
+## Residual create risks (close in coding — not this PR)
+
+1. Payment-field patch on `work-order-update` still able to ensure/create invoice.  
+2. Direct authenticated inserts into `invoices` if RLS allows.  
+3. Re-enabling `auto_create_draft_invoice_on_acceptance`.  
+4. Accidental auto-`sent` if issue wired into complete path.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_PLANNING_DESIGN.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_PLANNING_DESIGN.md
@@ -243,4 +243,5 @@ Product · Data · Security · Financial Control · Architecture · UX/Field · 
 
 ## 16. Coding-readiness
 
-PD-S5-01…07 **ratified**. Next: merge this planning PR → Founder **coding authorization** on exact branch/base. No implementation until that auth.
+PD-S5-01…07 **ratified**. Coding authorized on `ml/p1-s5-invoice-collection` @ `8505a89`.  
+A2 SOURCE delivered (see `ML-P1_SLICE5_A2_CODING_EVIDENCE.md`). Stop before prod apply / deploy / Stripe.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_PLANNING_DESIGN.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_PLANNING_DESIGN.md
@@ -1,0 +1,246 @@
+# ML-P1 Slice 5 — Planning Design (Completed Job → Invoice)
+
+| Field | Value |
+| --- | --- |
+| Base SHA | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Branch | `plan/ml-p1-s5-invoice-generation` |
+| Disposition | **SLICE5_PLANNING_REQUIRES_CODING_AUTH** — PD-S5-01…07 **RATIFIED** |
+| Depends on | S4 completion readiness + approved COs; invoice-on-complete remains off |
+| Revalidated | 2026-07-23 live invoice baseline unchanged (25; draft/sent/paid) |
+
+---
+
+## 1. Canonical writer design
+
+### `ml_p1_s5_invoice_create(p_job_id, p_client_mutation_id, p_actor_role_hint unused)`
+
+**SECURITY DEFINER** RPC; role from `ml_p1_s2_current_actor_role()` (Auth UUID → `app_user_roles`).
+
+**Inputs (server-resolved, not client amounts):**
+- `p_job_id`
+- `p_client_mutation_id` (idempotency)
+- Tax defaults from **approved quote snapshot** (PD-S5-04 B); office draft tax correct via `ml_p1_s5_invoice_draft_update` (PD-S5-04 C)
+
+**Algorithm:**
+1. Lock job `FOR UPDATE`.
+2. Assert capability `invoice.create` (office/manager/admin).
+3. Eligibility gate (§2) — else raise typed deny codes.
+4. Load approved quote pinned on job (`quote_id` + `source_quote_version` if present).
+5. Load change orders with `status='approved'` only.
+6. Build line snapshot:
+   - original quote lines (stored historical unit prices)
+   - plus approved CO lines (stored deltas)
+   - exclude rejected/cancelled/pending COs
+7. Compute financials per §6; write `invoices` + `invoice_items` in one transaction.
+8. Emit audit event; record mutation idempotency row.
+9. Return invoice id + status=`draft` + `invoice_created=true` + lineage payload.
+10. **Never** set status to `sent`/`paid`; **never** call Stripe; **never** send customer email inside create.
+
+### Companion RPCs (planned)
+| RPC | Purpose |
+| --- | --- |
+| `ml_p1_s5_invoice_draft_update` | Pre-issue corrections (lines/tax/notes) while `draft` |
+| `ml_p1_s5_invoice_issue` | `draft`→`sent`; sets `sent_at`, release flags; may create `public_token` |
+| `ml_p1_s5_invoice_void` | Void with reason; authority per PD-S5-05 |
+| `ml_p1_s5_invoice_get` / readiness | Blocked reasons for UI |
+
+Idempotency: same `(job_id, client_mutation_id)` returns prior result. Unique job invoice index enforces single non-null job invoice.
+
+---
+
+## 2. Eligibility contract
+
+| Code | Condition |
+| --- | --- |
+| `ML_P1_S5_JOB_NOT_FOUND` | Missing job |
+| `ML_P1_S5_JOB_NOT_COMPLETED` | `jobs.status <> completed` |
+| `ML_P1_S5_COMPLETION_NOT_READY` | `ml_p1_s4_completion_readiness.ready <> true` (recompute) |
+| `ML_P1_S5_PENDING_CHANGE_ORDER` | Any CO in `proposed`/`pending_approval` |
+| `ML_P1_S5_QUOTE_REQUIRED` | Missing approved source quote |
+| `ML_P1_S5_INVOICE_EXISTS` | Invoice already linked to job (unique hit / found row) |
+| `ML_P1_S5_ROLE_DENY` | Role cannot `invoice.create` |
+| `ML_P1_S5_STALE_JOB` | Optional row_version mismatch |
+| `ML_P1_S5_CANCELLED_JOB` | Job cancelled |
+| `ML_P1_S5_MUTATION_ID_REQUIRED` | Missing idempotency key |
+
+---
+
+## 3. Lineage (persist on invoice + items + events)
+
+| Field | Source |
+| --- | --- |
+| `job_id` | Job |
+| `quote_id` | Job.source quote |
+| `source_quote_version` | **Add column** if missing — pin version at create |
+| `approved_change_order_ids` | **Add jsonb/uuid[]** of approved CO ids + versions |
+| Customer / address | From lead/property/job snapshot fields |
+| Line `source_kind` | `quote` \| `change_order` |
+| Line `source_id` | quote_item id or CO item id |
+| `unit_price` / qty | **Stored historical** — never live price_book re-fetch |
+| Actor / timestamps | `auth.uid()`, `created_at` |
+| Audit | `events` row `InvoiceCreated` with payload hash of totals |
+
+---
+
+## 4. Lifecycle state machine (proposed vs live)
+
+**Live observed:** `draft` → `sent` → `paid` (and stay).
+
+**Ratified S5 product states (PD-S5-02 C):**
+
+```
+draft → sent (display “Issued”) → paid
+                ↘ void
+sent → void (if unpaid; PD-S5-06 A)
+paid → (refunded via S5b only — out of scope)
+```
+
+| State | S5 meaning | Who |
+| --- | --- | --- |
+| `draft` | Editable office review | office/manager/admin |
+| `sent` | Issued to customer (UI label **“Issued”**); amounts immutable (PD-S5-06 A) | office issue |
+| `partial` / `partially_paid` | Settlement projection (S5b writers) | read in S5 |
+| `paid` | Settled | read in S5 |
+| `void` | Cancelled invoice | void authority (PD-S5-05 A) |
+| `written_off` | Financial close — admin write-off (PD-S5-05); may land in S5b if deferred | admin |
+
+S5 **writes:** `draft`, `sent`, `void` only. Payment statuses are **read** from settlement fields.
+
+---
+
+## 5. Authorization matrix (S5)
+
+| Capability | tech | office/CSR | manager | admin | viewer | partner | customer |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Create draft invoice | N | Y | Y | Y | N | N | N |
+| Edit draft | N | Y | Y | Y | N | N | N |
+| Issue/send | N | Y | Y | Y | N | N | N |
+| Void | N | Y* | Y | Y | N | N | N |
+| Write-off | N | N | N | Y* | N | N | N |
+| Edit issued totals | N | N | N | N | N | N | N |
+| View office invoice | N | Y | Y | Y | Y | limited | N |
+| View public invoice | — | — | — | — | — | — | token |
+| Record payment | — | — | — | — | — | — | **S5b** |
+
+\* Per PD-S5-05 A. Technicians **never** edit invoice totals, void, or write off.
+
+---
+
+## 6. Financial calculation contract (no invented pricing)
+
+| Rule | Spec |
+| --- | --- |
+| Price source | Stored quote lines + approved CO lines only |
+| Pricebook | **Forbidden** as recalculation source at invoice create |
+| Subtotal | Σ (qty × unit_price) for included lines |
+| Discounts | Include quote/CO discount lines as stored; header `discount_amount` if present on draft per office edit |
+| Negative lines | Allowed when `line_type=discount` or stored negative (e.g. bundle discount) |
+| Zero-dollar lines | Allowed; still appear if on approved scope |
+| Tax | PD-S5-04 B+C: default from quote snapshot; office may correct on draft; freeze on issue; `tax_amount = round(taxable_subtotal × tax_rate, 2)` half-up to cents |
+| Credits | No new credit-memo product in S5; void+reissue for corrections |
+| Total | `subtotal - discount_amount + tax_amount` → `total_amount` |
+| Immutability | On `sent`, financial columns + items **DENY** update except void transition |
+| Write-off | Out of S5 default (PD) |
+| Rounding | Per-line round to 2 decimals; then tax on taxable sum |
+
+---
+
+## 7. Creation behavior (PD-S5-01 C RATIFIED)
+
+**Hybrid (C)**  
+- Auto-`draft` when job → `completed` **and** S4 readiness pass **and** no pending CO **and** no existing blocking invoice.  
+- Office always issues (explicit).  
+- Office can manually create if auto missed.  
+- **`invoice_type='final'` only** (PD-S5-03 A).  
+- **Never** auto-`sent` / auto-email on complete.
+
+---
+
+## 8. Issue / customer communication boundary
+
+| Allowed in S5 | Not in S5 |
+| --- | --- |
+| Issue → `sent` | Autonomous unpaid dunning |
+| `send-invoice` email/SMS re-delivery | Failed-payment automation |
+| Public invoice view by token | Review-request automation |
+| Payment status **read-only** display | Stripe checkout (S5b) |
+
+---
+
+## 9. Correction / void model (PD-S5-06 A RATIFIED)
+
+| Case | Policy |
+| --- | --- |
+| Draft typo / wrong line / tax | Edit via draft update RPC |
+| Missed approved CO before issue | Rebuild draft from lineage (replace items) while draft |
+| After issue, unpaid | **Void** + reissue (new id; old void retained) — **no in-place edit** |
+| After partial/full payment | **No S5 amount edit** — S5b/finance exception path |
+| Duplicate create | Idempotent return / `INVOICE_EXISTS` |
+| Wrong customer/address on draft | Edit snapshot fields on draft only |
+| Pre-existing 25 invoices | Grandfather (PD-S5-07 A); no historical rewrite |
+
+---
+
+## 10. Office UI plan
+
+- Completed job → Invoice panel: Create / Open draft  
+- Show: linked job, quote version, approved COs, blocked reasons  
+- Financial summary (subtotal/tax/discount/total)  
+- Issue/Send, Void (with reason), Audit history  
+- No duplicate-create button when invoice exists  
+- Remove stale “completion prepares invoice” copy
+
+## 11. Customer invoice UI plan
+
+- Invoice number, issue date, due date (if used), status  
+- Work summary, service address  
+- Line items (quote + approved CO), subtotal, tax, credits/discounts, total  
+- Payment status read-only  
+- **No** internal notes, actor emails, break-glass proofs, office audit
+
+---
+
+## 12. Migration plan (ordered)
+
+1. Additive lineage columns on `invoices` / `invoice_items` (`source_quote_version`, `approved_change_order_ids`, `source_kind`, `source_id`, calculation snapshot jsonb).  
+2. Canonical RPCs + grants.  
+3. Alternate-writer denials (work-order ensure, MyMoney, trigger flags asserted false).  
+4. Idempotency / mutation table if needed.  
+5. UI + edge bridges.  
+6. Forward-fix plan: disable RPC / feature flag; do not delete historical invoices.  
+7. Pre-apply: confirm unique indexes; count existing invoices; no multi-invoice jobs (currently 0).
+
+**Do not** use deprecated `estimates` writers.  
+**Do not** treat `tenant_id` as auth — preserve column defaults only.
+
+---
+
+## 13. Failure / recovery
+
+| Failure | Behavior |
+| --- | --- |
+| Duplicate / concurrent create | Unique violation → return existing or `INVOICE_EXISTS`; transaction abort |
+| Eligibility fail | No partial invoice row |
+| Audit insert fail | Abort whole transaction |
+| Issue/send email fail | Invoice may be `sent` with delivery_error event **or** keep draft until delivery ack — **prefer: mark sent only after token ready; delivery failure = retryable event, not false success** |
+| Void fail | No status change |
+| Customer token missing | Generate on issue; fail closed if cannot |
+| Stale client | Version check deny |
+
+---
+
+## 14. Test sentinels (adversarial)
+
+Unauthorized create · tech total edit · duplicate create · concurrent create · unapproved CO included · approved CO omitted · pricebook drift attempt · direct frontend insert · legacy alternate writer · invoice-on-complete bleed · missing job/quote lineage · partial persistence · issue without review (if required) · edit after issue · void without authority · customer sees internal fields · send false success · create from incomplete/cancelled job.
+
+---
+
+## 15. Review lanes
+
+Product · Data · Security · Financial Control · Architecture · UX/Field · Independent Adversarial Test — freeze exact coding tip before reviews.
+
+---
+
+## 16. Coding-readiness
+
+PD-S5-01…07 **ratified**. Next: merge this planning PR → Founder **coding authorization** on exact branch/base. No implementation until that auth.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_RESIDUAL_REGISTER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_RESIDUAL_REGISTER.md
@@ -1,0 +1,13 @@
+# ML-P1 Slice 5 — Residual Register
+
+| ID | Severity | Status | Note |
+| --- | --- | --- | --- |
+| R-S5-01 | Medium | Open (coding) | `work-order-update` payment-ensure may still create invoice — must deny in coding |
+| R-S5-02 | Medium | Open (coding) | Direct `invoices` insert if RLS permits — force RPC-only |
+| R-S5-03 | Low | Open (coding) | Stale UI copy implying auto invoice on complete |
+| R-S5-04 | Low | Open (coding) | Lineage columns (quote version / CO ids / calc snapshot) absent on grandfathered rows — best-effort only (PD-S5-07) |
+| R-S5-05 | Info | Closed (product) | PD-S5-01…07 ratified 2026-07-23 |
+| R-S5-06 | Info | Closed (planning) | Stale base `3bb175e` replaced by `e9cc331` |
+| R-S4-07 | Soft | Carry | tenant_id stamps — non-blocking |
+
+No residual authorizes Stripe, historical reprice, or multi-tenant work.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_RESIDUAL_REGISTER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_RESIDUAL_REGISTER.md
@@ -2,12 +2,14 @@
 
 | ID | Severity | Status | Note |
 | --- | --- | --- | --- |
-| R-S5-01 | Medium | Open (coding) | `work-order-update` payment-ensure may still create invoice — must deny in coding |
-| R-S5-02 | Medium | Open (coding) | Direct `invoices` insert if RLS permits — force RPC-only |
-| R-S5-03 | Low | Open (coding) | Stale UI copy implying auto invoice on complete |
-| R-S5-04 | Low | Open (coding) | Lineage columns (quote version / CO ids / calc snapshot) absent on grandfathered rows — best-effort only (PD-S5-07) |
+| R-S5-01 | Medium | Closed (coding SOURCE) | Edge ensure/create throws `ML_P1_S5_ALT_WRITER_DENY` |
+| R-S5-02 | Medium | Closed (coding SOURCE) | MyMoney create denied; office UI uses RPC facade only |
+| R-S5-03 | Low | Closed (coding SOURCE) | Office execution badge → “Invoice via Slice 5 (no auto-send)” |
+| R-S5-04 | Low | Open (A3) | Grandfathered rows lack full lineage — best-effort only (PD-S5-07) |
 | R-S5-05 | Info | Closed (product) | PD-S5-01…07 ratified 2026-07-23 |
-| R-S5-06 | Info | Closed (planning) | Stale base `3bb175e` replaced by `e9cc331` |
+| R-S5-06 | Info | Closed (planning) | Stale base `3bb175e` replaced by `e9cc331` / coding base `8505a89` |
+| R-S5-07 | Low | Open (A3) | Auto-draft soft-fail path depends on `events` insert when create fails |
+| R-S5-08 | Low | Deferred | Admin write-off RPC/UI not shipped (capability helper present; S5b-compatible) |
 | R-S4-07 | Soft | Carry | tenant_id stamps — non-blocking |
 
-No residual authorizes Stripe, historical reprice, or multi-tenant work.
+No residual authorizes Stripe, historical reprice, prod apply, or multi-tenant work.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_STATE_LEDGER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_STATE_LEDGER.md
@@ -2,12 +2,12 @@
 
 | Field | Value |
 | --- | --- |
-| Active slice | **ML-P1-S5** (planning) |
-| Stage | Product decisions **RATIFIED** → planning PR → coding auth (later) |
-| Exact main SHA | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
-| Branch | `plan/ml-p1-s5-invoice-generation` |
-| Migration status | None for S5 |
-| Deploy status | N/A |
+| Active slice | **ML-P1-S5** (coding A2) |
+| Stage | Coding on branch; **A2 docs/code PR** — stop before prod apply / deploy / Stripe |
+| Exact coding base SHA | `8505a89a0e920ff68e35d0f10b49e98693125674` |
+| Branch | `ml/p1-s5-invoice-collection` |
+| Migration status | SOURCE committed; **not applied** to production |
+| Deploy status | Not deployed |
 | Open decisions | None (PD-S5-01…07 closed) |
-| Next Founder auth | After planning PR merge: **authorize Slice 5 coding** on exact SHA |
-| Explicitly not started | Implementation · migrations · S5b · Stripe · S6 · TIS · G2.3 |
+| Next Founder auth | Exact-head merge approval for A2 PR; separate A3 for prod migration apply |
+| Explicitly not started | Prod migrations · Hostinger · Stripe/Braintree · S5b · S6 · TIS · G2.3 |

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE5_STATE_LEDGER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE5_STATE_LEDGER.md
@@ -1,0 +1,13 @@
+# ML-P1 Slice 5 — Active State Ledger
+
+| Field | Value |
+| --- | --- |
+| Active slice | **ML-P1-S5** (planning) |
+| Stage | Product decisions **RATIFIED** → planning PR → coding auth (later) |
+| Exact main SHA | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Branch | `plan/ml-p1-s5-invoice-generation` |
+| Migration status | None for S5 |
+| Deploy status | N/A |
+| Open decisions | None (PD-S5-01…07 closed) |
+| Next Founder auth | After planning PR merge: **authorize Slice 5 coding** on exact SHA |
+| Explicitly not started | Implementation · migrations · S5b · Stripe · S6 · TIS · G2.3 |

--- a/command-center/docs/stabilization/releases/ML-P1_STATE_LEDGER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_STATE_LEDGER.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | Updated | 2026-07-23 |
 | Repo | https://github.com/faydog127/BHFOS |
-| Current main (planning base) | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Current coding branch | `ml/p1-s5-invoice-collection` @ base `8505a89` |
 | Evidence bundle (price-book) | `260C5CB28EE1A7F5E4E76A488C38749926CDC8435608F83A1B421808E90A4158` |
 
 ## Slice / gate posture
@@ -13,12 +13,13 @@
 | --- | --- | --- |
 | S4 | CLOSED ✔ | A3 PASS |
 | Price-book | A2-MERGED ✔ | PR #100 |
-| **S5** | Planning PR (docs) | PD-S5-01…07 **RATIFIED**; coding **blocked** until planning PR merges + coding auth |
+| **S5** | **A2 coding** | PD-S5-01…07 ratified; coding on `ml/p1-s5-invoice-collection`; **no prod apply** |
 
-## Waiting on Founder (after planning PR merges)
+## Waiting on Founder
 
-- Authorize **Slice 5 coding** on exact branch/base SHA (not yet requested)
+- Exact-head **merge approval** for Slice 5 A2 coding PR
+- Separate **A3** auth before production migrations / Hostinger / Stripe
 
 ## Halt / non-scope
 
-No migrations · no app implementation · no Hostinger deploy · no Stripe · no historical invoice rewrite until coding is explicitly authorized.
+No production migrations · no Hostinger deploy · no Stripe/Braintree · no historical invoice rewrite · merge requires exact-head Founder approval.

--- a/command-center/docs/stabilization/releases/ML-P1_STATE_LEDGER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_STATE_LEDGER.md
@@ -4,37 +4,21 @@
 | --- | --- |
 | Updated | 2026-07-23 |
 | Repo | https://github.com/faydog127/BHFOS |
-| Worktree | `F:\Dev\BHFOS-ml-p1-s3` (main) |
-| Current main | `9b5402c5eaa2e06cf5aebe923f36900f64f8b2d2` |
-| Evidence bundle | `260C5CB28EE1A7F5E4E76A488C38749926CDC8435608F83A1B421808E90A4158` → `ML-P1_EVIDENCE_MANIFEST.md` |
-| Active work queue | **None** — all authorized items complete |
+| Current main (planning base) | `e9cc3317fcb9c84f44643700927699f40c7f1a93` |
+| Evidence bundle (price-book) | `260C5CB28EE1A7F5E4E76A488C38749926CDC8435608F83A1B421808E90A4158` |
 
 ## Slice / gate posture
 
 | Slice | Gate | Status |
 | --- | --- | --- |
-| S1–S3 | Closed | Production coherent |
-| **S4** Field execution | **CLOSED ✔** | A3 PASS; R-S4-06 remediated; soft R-S4-07 |
-| HCP price-book | **A2-MERGED ✔** | PR #100 @ `a1c822b` → merge `ced9bfb`; ledger record `9b5402c` |
-| **S5** Billing / invoices | **BLOCKED** | Waiting **PD-S5-01…07** — no coding |
+| S4 | CLOSED ✔ | A3 PASS |
+| Price-book | A2-MERGED ✔ | PR #100 |
+| **S5** | Planning PR (docs) | PD-S5-01…07 **RATIFIED**; coding **blocked** until planning PR merges + coding auth |
 
-## Waiting on Founder
+## Waiting on Founder (after planning PR merges)
 
-- **PD-S5-01 … PD-S5-07** (Slice 5 billing / invoices)
+- Authorize **Slice 5 coding** on exact branch/base SHA (not yet requested)
 
-## Standing rules
+## Halt / non-scope
 
-- A0 → three-round peer review → exact-SHA merge → prod A3
-- Auto-continue inside already-authorized scope; halt on gate fail / scope drift / missing PD
-- Synthetic tech/office only for prod validation; never mutate real customer data
-- Never enable Stripe, autonomous follow-up, TIS, G2.3, or multi-tenant writers unless explicitly re-authorized
-
-## Next steps (when PD-S5 arrives)
-
-1. Create `ml/p1-s5-billing` worktree from main  
-2. Draft Slice 5 packet (scope, migrations, tests); open A2 PR  
-3. Standard review → merge → apply → validation  
-
-## Halt
-
-Idle until Founder PD-S5 answers. No migrations, deploys, or Slice 5 coding.
+No migrations · no app implementation · no Hostinger deploy · no Stripe · no historical invoice rewrite until coding is explicitly authorized.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S5_CODING_ARCHITECTURE_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S5_CODING_ARCHITECTURE_REVIEW.md
@@ -1,0 +1,18 @@
+# ML-P1 S5 Coding — Round 1 Review (Architecture / Scope / Source-of-Truth)
+
+| Field | Value |
+| --- | --- |
+| Target | `ml/p1-s5-invoice-collection` coding vs base `8505a89` |
+| Verdict | **APPROVE** (SOURCE-ONLY; migrations not applied) |
+
+## Findings
+
+- Canonical create/issue/void/readiness RPCs + auto-draft companion match PD-S5-01…07.
+- Single writer intent preserved: Edge/MyMoney alternate creates denied; UI uses RPC facade.
+- `final` only; persist `sent` / display Issued; quote snapshot tax; issued immutability trigger.
+- No Stripe / payment / historical rewrite in scope.
+
+## Residuals
+
+- Write-off RPC deferred (R-S5-06) — capability + role helper present.
+- Production apply / deploy remain Founder A3.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S5_CODING_OPS_UX_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S5_CODING_OPS_UX_REVIEW.md
@@ -1,0 +1,19 @@
+# ML-P1 S5 Coding — Round 3 Review (Ops / UX)
+
+| Field | Value |
+| --- | --- |
+| Target | Office invoice panel + Invoices status label + auto-draft soft-fail |
+| Verdict | **APPROVE** (SOURCE-ONLY) |
+
+## Findings
+
+- Office panel on completed-job record modal: readiness, create draft, tax adjust, issue, void+reason.
+- Invoices list badge shows **Issued** for persisted `sent` (PD-S5-02).
+- Auto-draft soft-fails without rolling back job completion; office can create manually.
+- No auto-send / payment CTA introduced.
+
+## Residuals
+
+- Write-off UI not present (deferred).
+- Full field/tech mobile invoice UX out of scope (tech never edits totals).
+- Live A3 validation of auto-draft + issue path still required before merge-to-prod.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S5_CODING_SECURITY_FINANCIAL_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S5_CODING_SECURITY_FINANCIAL_REVIEW.md
@@ -1,0 +1,19 @@
+# ML-P1 S5 Coding — Round 2 Review (Security / Financial Control)
+
+| Field | Value |
+| --- | --- |
+| Target | S5 invoice RPCs + client authz + alt-writer denials |
+| Verdict | **APPROVE** (SOURCE-ONLY + unit EXECUTED) |
+
+## Findings
+
+- Role gates via `ml_p1_s2_current_actor_role` (not client-supplied role on RPCs).
+- Tech denied create/issue/void/write-off at client helper; void requires reason; paid blocks void.
+- Issued financial columns blocked by `ML_P1_S5_ISSUED_IMMUTABLE` (void+reissue only).
+- Create never reads `price_book`; snapshot stamps `pricebook_used=false`.
+- Mutation idempotency ledger on create/issue/void.
+
+## Residuals
+
+- Service-role can invoke SECURITY DEFINER RPCs — grants match prior slices; A3 should confirm live grants.
+- Write-off mutation path not shipped (admin capability only) — R-S5-06.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_ARCHITECTURE_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_ARCHITECTURE_REVIEW.md
@@ -1,0 +1,17 @@
+# ML-P1 S5 Planning — Round 1 Review (Architecture / Scope / Source-of-Truth)
+
+| Field | Value |
+| --- | --- |
+| Target | Slice 5 planning docs on `plan/ml-p1-s5-invoice-generation` vs main `e9cc331` |
+| Verdict | **APPROVED** with residuals deferred to coding |
+
+## Findings
+
+- **No P0/P1.** Ratified PD-S5-01…07 are consistently reflected in decision packet, brief, design, and architecture.
+- Source-of-truth: planning base SHA updated from stale `3bb175e` → `e9cc331`; live invoice counts revalidated.
+- Scope boundary clear: no Stripe/S5b, no historical rewrite, `final` only, `sent` persist / “Issued” display.
+- Writer inventory still correctly denies parallel creators; auto-draft companion added for PD-S5-01 C without auto-issue.
+
+## Residual
+
+Coding must close R-S5-01/02 (ensure-create / direct insert). Not blockers for planning merge.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_OPS_UX_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_OPS_UX_REVIEW.md
@@ -1,0 +1,15 @@
+# ML-P1 S5 Planning — Round 3 Review (Usability / Ops / Founder Interruptions)
+
+| Field | Value |
+| --- | --- |
+| Target | Same planning package |
+| Verdict | **APPROVED** |
+
+## Findings
+
+- Hybrid create (PD-S5-01 C) reduces missed billing without customer spam (no auto-send).
+- “Issued” label with stored `sent` avoids disruptive rename migration (PD-S5-02 C) — good ops choice.
+- Office void + admin write-off matches day-to-day vs finance escalation.
+- Next Founder ask is **one** coding-authorization line after this PR merges — avoids re-asking PD-S5.
+
+## No CHANGES_REQUIRED for planning merge.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_SECURITY_FINANCIAL_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S5_PLANNING_SECURITY_FINANCIAL_REVIEW.md
@@ -1,0 +1,15 @@
+# ML-P1 S5 Planning — Round 2 Review (Security / Financial Integrity / Adversarial)
+
+| Field | Value |
+| --- | --- |
+| Target | Same planning package |
+| Verdict | **APPROVED** |
+
+## Findings
+
+- Financial integrity: quote-snapshot tax + draft-only correct + freeze on issue (PD-S5-04) prevents silent pricebook recalculation — especially important after HCP price-book merge.
+- Adversarial: void+reissue (PD-S5-06) blocks in-place mutation of issued unpaid invoices; grandfather (PD-S5-07) blocks historical reprice.
+- Authority: tech never voids/writes-off/edits money (PD-S5-05); write-off admin-only.
+- Security: planning docs do not introduce new public endpoints or secret handling; coding must keep SECURITY DEFINER role checks.
+
+## No CHANGES_REQUIRED for planning merge.

--- a/command-center/src/components/crm/jobs/OfficeInvoicePanel.jsx
+++ b/command-center/src/components/crm/jobs/OfficeInvoicePanel.jsx
@@ -1,0 +1,171 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/components/ui/use-toast';
+import { formatInvoiceStatusLabel, canPerformS5 } from '@/lib/mlP1S5InvoiceAuthz';
+import { createMlP1S5InvoiceService } from '@/services/mlP1S5InvoiceService';
+import { supabase } from '@/lib/customSupabaseClient';
+
+/**
+ * Office invoice panel for completed jobs (ML-P1 S5).
+ * Create draft / issue (persists sent, shows Issued) / void with reason.
+ */
+export default function OfficeInvoicePanel({ job, role = 'office', onUpdated }) {
+  const { toast } = useToast();
+  const service = useMemo(() => createMlP1S5InvoiceService({ supabase }), []);
+  const [busy, setBusy] = useState(false);
+  const [readiness, setReadiness] = useState(null);
+  const [invoices, setInvoices] = useState([]);
+  const [taxRate, setTaxRate] = useState('');
+  const [voidReason, setVoidReason] = useState('');
+
+  const active = invoices.find((i) => String(i.status).toLowerCase() !== 'void') || null;
+  const canCreate = canPerformS5(role, 'create');
+  const canIssue = canPerformS5(role, 'issue');
+  const canVoid = canPerformS5(role, 'void');
+
+  const load = async () => {
+    if (!job?.id) return;
+    const [ready, rows] = await Promise.all([
+      service.readiness(job.id).catch(() => null),
+      service.getByJob(job.id),
+    ]);
+    setReadiness(ready);
+    setInvoices(rows);
+    const draft = rows.find((r) => String(r.status).toLowerCase() === 'draft');
+    if (draft?.tax_rate != null) setTaxRate(String(draft.tax_rate));
+  };
+
+  useEffect(() => {
+    load().catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [job?.id]);
+
+  const run = async (fn, title) => {
+    setBusy(true);
+    try {
+      const result = await fn();
+      toast({
+        title,
+        description: result?.display_status || formatInvoiceStatusLabel(result?.status),
+      });
+      await load();
+      onUpdated?.(result);
+    } catch (err) {
+      toast({ variant: 'destructive', title: 'Failed', description: err?.message || 'Request failed' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!job?.id) return null;
+  if (String(job.status || '').toLowerCase() !== 'completed' && !active) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600">
+        Invoice actions unlock when the job is completed (or when a draft already exists).
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border border-slate-200 bg-white p-4">
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <div className="text-sm font-semibold">Slice 5 invoice</div>
+          <div className="text-xs text-slate-500">Final only · office issues · never auto-send</div>
+        </div>
+        {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+      </div>
+
+      {readiness && !readiness.eligible && !active ? (
+        <div className="text-xs text-amber-700">
+          Blocked: {(readiness.blockers || []).map((b) => b.code).join(', ') || 'not eligible'}
+        </div>
+      ) : null}
+
+      {active ? (
+        <div className="space-y-2 text-sm">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline">{formatInvoiceStatusLabel(active.status)}</Badge>
+            <span className="font-mono text-xs">{active.invoice_number || active.id}</span>
+            <span>${Number(active.total_amount || 0).toFixed(2)}</span>
+          </div>
+          {String(active.status).toLowerCase() === 'draft' && canIssue ? (
+            <div className="flex flex-wrap items-end gap-2">
+              <div>
+                <div className="text-xs text-slate-500">Tax rate (draft)</div>
+                <Input
+                  className="h-8 w-28"
+                  value={taxRate}
+                  onChange={(e) => setTaxRate(e.target.value)}
+                  placeholder="0.00"
+                />
+              </div>
+              <Button
+                size="sm"
+                variant="secondary"
+                disabled={busy}
+                onClick={() =>
+                  run(
+                    () =>
+                      service.draftUpdate(active.id, {
+                        taxRate: taxRate === '' ? null : Number(taxRate),
+                      }),
+                    'Draft tax updated',
+                  )
+                }
+              >
+                Save tax
+              </Button>
+              <Button
+                size="sm"
+                disabled={busy}
+                onClick={() => run(() => service.issue(active.id), 'Invoice issued')}
+              >
+                Issue
+              </Button>
+            </div>
+          ) : null}
+          {canVoid && ['draft', 'sent'].includes(String(active.status).toLowerCase()) ? (
+            <div className="space-y-2">
+              <Textarea
+                placeholder="Void reason (required)"
+                value={voidReason}
+                onChange={(e) => setVoidReason(e.target.value)}
+                rows={2}
+              />
+              <Button
+                size="sm"
+                variant="destructive"
+                disabled={busy || !voidReason.trim()}
+                onClick={() =>
+                  run(() => service.void(active.id, voidReason.trim()), 'Invoice voided')
+                }
+              >
+                Void (reissue required for corrections)
+              </Button>
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <div>
+          {canCreate ? (
+            <Button
+              size="sm"
+              disabled={busy || readiness?.eligible === false}
+              onClick={() => run(() => service.create(job.id), 'Draft invoice created')}
+            >
+              Create draft invoice
+            </Button>
+          ) : (
+            <div className="text-xs text-slate-500">No create permission for role {role}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/command-center/src/components/crm/jobs/OfficeJobExecutionPanel.jsx
+++ b/command-center/src/components/crm/jobs/OfficeJobExecutionPanel.jsx
@@ -73,7 +73,7 @@ export default function OfficeJobExecutionPanel({ job, tenantId, technicians = [
             {isDispatchedDerived(job) ? ' · Dispatched (derived)' : ''}
           </div>
         </div>
-        <Badge variant="outline">No invoice on complete</Badge>
+        <Badge variant="outline">Invoice via Slice 5 (no auto-send)</Badge>
       </div>
 
       <div className="grid gap-2 md:grid-cols-3">

--- a/command-center/src/lib/mlP1S5InvoiceAuthz.js
+++ b/command-center/src/lib/mlP1S5InvoiceAuthz.js
@@ -1,0 +1,33 @@
+/**
+ * ML-P1 Slice 5 — client authz helpers for invoice actions.
+ */
+
+export const ML_P1_S5_CAPABILITIES = {
+  create: ['office', 'manager', 'admin', 'csr'],
+  draftUpdate: ['office', 'manager', 'admin', 'csr'],
+  issue: ['office', 'manager', 'admin', 'csr'],
+  void: ['office', 'manager', 'admin', 'csr'],
+  writeOff: ['admin'],
+};
+
+export function normalizeS5Role(role) {
+  const r = String(role || '').trim().toLowerCase();
+  if (r === 'csr') return 'office';
+  return r || 'unauthenticated';
+}
+
+export function canPerformS5(role, capability) {
+  const allowed = ML_P1_S5_CAPABILITIES[capability] || [];
+  const r = normalizeS5Role(role);
+  return allowed.includes(r) || (r === 'office' && allowed.includes('csr'));
+}
+
+export function formatInvoiceStatusLabel(status) {
+  const s = String(status || '').toLowerCase();
+  if (s === 'sent') return 'Issued';
+  if (s === 'draft') return 'Draft';
+  if (s === 'void') return 'Void';
+  if (s === 'paid') return 'Paid';
+  if (s === 'partial' || s === 'partially_paid') return 'Partially paid';
+  return status || 'Unknown';
+}

--- a/command-center/src/pages/crm/Invoices.jsx
+++ b/command-center/src/pages/crm/Invoices.jsx
@@ -243,7 +243,7 @@ const Invoices = () => {
       case 'paid': return <Badge className="bg-green-100 text-green-800 border-green-200">Paid</Badge>;
       case 'partial': return <Badge className="bg-blue-100 text-blue-800 border-blue-200">Partial</Badge>;
       case 'overdue': return <Badge className="bg-red-100 text-red-800 border-red-200">Overdue</Badge>;
-      case 'sent': return <Badge className="bg-yellow-100 text-yellow-800 border-yellow-200">Sent</Badge>;
+      case 'sent': return <Badge className="bg-yellow-100 text-yellow-800 border-yellow-200">Issued</Badge>;
       case 'approved':
       case 'accepted':
         return <Badge className="bg-emerald-100 text-emerald-800 border-emerald-200">Accepted</Badge>;

--- a/command-center/src/pages/crm/Jobs.jsx
+++ b/command-center/src/pages/crm/Jobs.jsx
@@ -9,6 +9,7 @@ import {
 } from '@/lib/jobStatus';
 import { jobService } from '@/services/jobService';
 import OfficeJobExecutionPanel from '@/components/crm/jobs/OfficeJobExecutionPanel';
+import OfficeInvoicePanel from '@/components/crm/jobs/OfficeInvoicePanel';
 import { formatS4StatusLabel } from '@/lib/mlP1S4RoleAuthz';
 import { useToast } from '@/components/ui/use-toast';
 import { Button } from '@/components/ui/button';
@@ -989,6 +990,13 @@ const Jobs = () => {
                 job={recordJob}
                 tenantId={tenantId}
                 technicians={technicians}
+                onUpdated={() => {
+                  fetchJobs();
+                }}
+              />
+              <OfficeInvoicePanel
+                job={recordJob}
+                role="office"
                 onUpdated={() => {
                   fetchJobs();
                 }}

--- a/command-center/src/pages/crm/MyMoney.jsx
+++ b/command-center/src/pages/crm/MyMoney.jsx
@@ -241,80 +241,11 @@ const MyMoney = () => {
   };
 
   const createInvoice = async () => {
-    if (!invoice.lead_id) {
-      toast({ variant: 'destructive', title: 'Pick a customer' });
-      return;
-    }
-    if (!invoice.description) {
-      toast({ variant: 'destructive', title: 'Missing line item', description: 'Add a description.' });
-      return;
-    }
-
-    setCreatingInvoice(true);
-    try {
-      const qty = Math.max(1, safeNumber(invoice.quantity, 1));
-      const price = Math.max(0, safeNumber(invoice.unit_price, 0));
-      const subtotal = qty * price;
-      const issueDate = new Date().toISOString().slice(0, 10);
-      const dueDate = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-
-      const invoicePayload = {
-        tenant_id: tenantId,
-        lead_id: invoice.lead_id,
-        invoice_number: String(Math.floor(100000 + Math.random() * 900000)),
-        status: 'sent',
-        issue_date: issueDate,
-        due_date: dueDate,
-        subtotal,
-        tax_rate: 0,
-        tax_amount: 0,
-        total_amount: subtotal,
-        amount_paid: 0,
-        balance_due: subtotal,
-        notes: 'Thank you for your business.',
-        terms: 'Payment is due within 14 days.',
-        sent_at: new Date().toISOString()
-      };
-
-      let inv = null;
-      const attempt = await supabase
-        .from('invoices')
-        .insert([invoicePayload])
-        .select('id, public_token, invoice_number, status, total_amount, created_at')
-        .single();
-      if (attempt.error) {
-        const message = attempt.error?.message || '';
-        if (message.toLowerCase().includes('balance_due')) {
-          const { balance_due, ...payloadNoBalance } = invoicePayload;
-          const retry = await supabase
-            .from('invoices')
-            .insert([payloadNoBalance])
-            .select('id, public_token, invoice_number, status, total_amount, created_at')
-            .single();
-          if (retry.error) throw retry.error;
-          inv = retry.data;
-        } else {
-          throw attempt.error;
-        }
-      } else {
-        inv = attempt.data;
-      }
-
-      const { error: iErr } = await supabase.from('invoice_items').insert([
-        { invoice_id: inv.id, description: invoice.description, quantity: qty, unit_price: price, total_price: subtotal }
-      ]);
-      if (iErr) throw iErr;
-
-      setCreatedInvoice(inv);
-      setInvoice((p) => ({ ...p, description: '', quantity: 1, unit_price: 0 }));
-      toast({ title: 'Invoice created', description: 'Copy/share the payment link to send it.' });
-      await loadQueue();
-    } catch (error) {
-      console.error('MoneyLoop: create invoice failed', error);
-      toast({ variant: 'destructive', title: 'Could not create invoice', description: error.message });
-    } finally {
-      setCreatingInvoice(false);
-    }
+    toast({
+      variant: 'destructive',
+      title: 'Use Slice 5 invoice flow',
+      description: 'ML_P1_S5_ALT_WRITER_DENY: create invoices from the completed job panel (canonical RPC).',
+    });
   };
 
   const quoteLink = createdQuote?.public_token ? `${window.location.origin}/quotes/${createdQuote.public_token}` : '';

--- a/command-center/src/services/mlP1S5InvoiceService.js
+++ b/command-center/src/services/mlP1S5InvoiceService.js
@@ -1,0 +1,86 @@
+/**
+ * ML-P1 Slice 5 — client facade for canonical invoice RPCs.
+ * No direct invoices inserts. No Stripe.
+ */
+
+const newMutationId = () =>
+  typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `s5-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+const rpcError = (error, fallback) => {
+  const err = new Error(error?.message || fallback);
+  err.code = error?.code || 'ML_P1_S5_RPC_ERROR';
+  err.details = error?.details;
+  throw err;
+};
+
+export function createMlP1S5InvoiceService({ supabase } = {}) {
+  if (!supabase) throw new Error('mlP1S5InvoiceService requires supabase');
+
+  return {
+    readiness: async (jobId) => {
+      const { data, error } = await supabase.rpc('ml_p1_s5_invoice_readiness', {
+        p_job_id: jobId,
+      });
+      if (error) rpcError(error, 'Invoice readiness failed');
+      return data;
+    },
+
+    create: async (jobId, { clientMutationId = null, system = false } = {}) => {
+      const { data, error } = await supabase.rpc('ml_p1_s5_invoice_create', {
+        p_job_id: jobId,
+        p_client_mutation_id: clientMutationId || newMutationId(),
+        p_system: Boolean(system),
+      });
+      if (error) rpcError(error, 'Invoice create failed');
+      return data;
+    },
+
+    draftUpdate: async (
+      invoiceId,
+      { taxRate = null, taxAmount = null, discountAmount = null, notes = null, clientMutationId = null } = {},
+    ) => {
+      const { data, error } = await supabase.rpc('ml_p1_s5_invoice_draft_update', {
+        p_invoice_id: invoiceId,
+        p_client_mutation_id: clientMutationId || newMutationId(),
+        p_tax_rate: taxRate,
+        p_tax_amount: taxAmount,
+        p_discount_amount: discountAmount,
+        p_notes: notes,
+      });
+      if (error) rpcError(error, 'Draft update failed');
+      return data;
+    },
+
+    issue: async (invoiceId, { clientMutationId = null } = {}) => {
+      const { data, error } = await supabase.rpc('ml_p1_s5_invoice_issue', {
+        p_invoice_id: invoiceId,
+        p_client_mutation_id: clientMutationId || newMutationId(),
+      });
+      if (error) rpcError(error, 'Issue failed');
+      return data;
+    },
+
+    void: async (invoiceId, reason, { clientMutationId = null } = {}) => {
+      const { data, error } = await supabase.rpc('ml_p1_s5_invoice_void', {
+        p_invoice_id: invoiceId,
+        p_client_mutation_id: clientMutationId || newMutationId(),
+        p_reason: reason,
+      });
+      if (error) rpcError(error, 'Void failed');
+      return data;
+    },
+
+    getByJob: async (jobId) => {
+      const { data, error } = await supabase
+        .from('invoices')
+        .select('id, status, invoice_number, total_amount, tax_amount, tax_rate, discount_amount, subtotal, amount_paid, sent_at, void_reason, s5_created, created_at')
+        .eq('job_id', jobId)
+        .order('created_at', { ascending: false })
+        .limit(5);
+      if (error) rpcError(error, 'Load invoices failed');
+      return data || [];
+    },
+  };
+}

--- a/command-center/supabase/functions/work-order-update/index.ts
+++ b/command-center/supabase/functions/work-order-update/index.ts
@@ -448,98 +448,23 @@ const findSchedulingConflict = async (
   }) || null;
 };
 
-const createInvoiceForCompletedJob = async (job: Record<string, unknown>, tenantId: string) => {
-  const leadId = asNullableString(job.lead_id);
-  const quoteId = asNullableString(job.quote_id);
-  const customerType =
-    normalizeCustomerTypeSnapshot(job.customer_type_snapshot) ||
-    await loadLeadCustomerType(leadId, tenantId);
-  const paymentTerms =
-    normalizePaymentTerms(job.payment_terms) ||
-    defaultPaymentTermsForCustomerType(customerType);
-  const dueDays = paymentTermsDueDays(paymentTerms);
-  const workOrderLabel =
-    asNullableString(job.work_order_number) ||
-    asNullableString(job.job_number) ||
-    asNullableString(job.id) ||
-    'completed work order';
-
-  const [jobItems, recipientEmail] = await Promise.all([
-    loadJobItems(asString(job.id)),
-    loadLeadEmail(leadId, tenantId),
-  ]);
-
-  const invoiceItems = jobItems.length > 0 ? jobItems : await loadQuoteItems(quoteId, tenantId);
-  const subtotalFromItems = invoiceItems.reduce((sum, item) => sum + (item.total_price || 0), 0);
-  const contractTotal = asNullableNumber(job.total_amount) ?? subtotalFromItems;
-  const subtotal = subtotalFromItems > 0 ? subtotalFromItems : contractTotal;
-  const taxAmount = Math.max(contractTotal - subtotal, 0);
-  const totalAmount = subtotal + taxAmount;
-  const nowIso = new Date().toISOString();
-
-  const invoiceInsert: Record<string, unknown> = {
-    tenant_id: tenantId,
-    lead_id: leadId,
-    quote_id: quoteId,
-    job_id: asString(job.id),
-    invoice_number: randomInvoiceNumber(),
-    status: 'draft',
-    subtotal,
-    tax_amount: taxAmount,
-    total_amount: totalAmount,
-    amount_paid: 0,
-    balance_due: totalAmount,
-    issue_date: dateOnlyFromNow(0),
-    due_date: dateOnlyFromNow(dueDays),
-    notes: `Generated automatically from ${workOrderLabel}.`,
-    terms: paymentTermsDescription(paymentTerms),
-    customer_email: recipientEmail || null,
-    created_at: nowIso,
-    updated_at: nowIso,
-  };
-
-  const invoice = await insertInvoiceRow(invoiceInsert);
-
-  if (invoiceItems.length > 0) {
-    const lineRows = invoiceItems.map((item) => ({
-      invoice_id: invoice.id,
-      description: item.description,
-      quantity: item.quantity,
-      unit_price: item.unit_price,
-      total_price: item.total_price,
-    }));
-
-    const { error: itemsError } = await supabaseAdmin.from('invoice_items').insert(lineRows);
-    if (itemsError) {
-      throw new Error(itemsError.message || 'Failed to create invoice line items.');
-    }
-  }
-
-  return { invoice, recipientEmail };
+const createInvoiceForCompletedJob = async (_job: Record<string, unknown>, _tenantId: string) => {
+  // ML-P1 S5: alternate Edge create denied — use ml_p1_s5_invoice_create RPC only.
+  throw new Error('ML_P1_S5_ALT_WRITER_DENY: use canonical ml_p1_s5_invoice_create');
 };
 
-const ensureInvoiceForCompletedJob = async (job: Record<string, unknown>, tenantId: string) => {
-  const existingInvoice = await fetchExistingInvoice(asString(job.id), tenantId);
-
-  if (existingInvoice?.id) {
+const ensureInvoiceForCompletedJob = async (job: Record<string, unknown>, _tenantId: string) => {
+  const existing = await fetchExistingInvoice(asString(job.id));
+  if (existing) {
     return {
-      invoice: existingInvoice,
+      invoice: existing,
       created: false,
       sent: false,
-      skipped: existingInvoice.sent_at ? 'already_sent' : 'draft_exists',
+      skipped: existing.sent_at ? 'already_sent' : 'draft_exists',
+      recipient_email: null,
     };
   }
-
-  const created = await createInvoiceForCompletedJob(job, tenantId);
-  const refreshed = await fetchInvoiceById(created.invoice.id, tenantId);
-
-  return {
-    invoice: refreshed || created.invoice,
-    created: true,
-    sent: false,
-    recipient_email: created.recipientEmail || null,
-    skipped: 'draft_created',
-  };
+  throw new Error('ML_P1_S5_ALT_WRITER_DENY: use canonical ml_p1_s5_invoice_create');
 };
 
 const syncInvoiceForPayment = async (params: {

--- a/command-center/supabase/migrations/20260723120000_ml_p1_s5_invoice_schema.sql
+++ b/command-center/supabase/migrations/20260723120000_ml_p1_s5_invoice_schema.sql
@@ -1,0 +1,49 @@
+-- ML-P1 Slice 5 — additive invoice lineage + mutation ledger + void audit columns
+-- SOURCE ONLY for this PR. Do not apply to production until Founder A3 auth.
+
+ALTER TABLE public.invoices
+  ADD COLUMN IF NOT EXISTS source_quote_version integer,
+  ADD COLUMN IF NOT EXISTS approved_change_order_ids uuid[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS calculation_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS void_reason text,
+  ADD COLUMN IF NOT EXISTS voided_at timestamptz,
+  ADD COLUMN IF NOT EXISTS voided_by uuid,
+  ADD COLUMN IF NOT EXISTS write_off_reason text,
+  ADD COLUMN IF NOT EXISTS written_off_at timestamptz,
+  ADD COLUMN IF NOT EXISTS written_off_by uuid,
+  ADD COLUMN IF NOT EXISTS s5_created boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.invoice_items
+  ADD COLUMN IF NOT EXISTS source_kind text,
+  ADD COLUMN IF NOT EXISTS source_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'invoice_items_source_kind_check'
+  ) THEN
+    ALTER TABLE public.invoice_items
+      ADD CONSTRAINT invoice_items_source_kind_check
+      CHECK (source_kind IS NULL OR source_kind IN ('quote', 'change_order', 'manual'));
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.invoice_execution_mutations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id text,
+  job_id uuid REFERENCES public.jobs(id) ON DELETE CASCADE,
+  invoice_id uuid REFERENCES public.invoices(id) ON DELETE SET NULL,
+  action text NOT NULL,
+  client_mutation_id text NOT NULL,
+  actor_user_id uuid,
+  actor_role text,
+  result jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT invoice_execution_mutations_job_mut_uq UNIQUE (job_id, client_mutation_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_invoice_execution_mutations_invoice
+  ON public.invoice_execution_mutations (invoice_id);
+
+COMMENT ON TABLE public.invoice_execution_mutations IS 'ML-P1 S5 idempotency ledger for invoice create/issue/void';
+COMMENT ON COLUMN public.invoices.s5_created IS 'True when created by canonical S5 writer; grandfathered rows remain false';

--- a/command-center/supabase/migrations/20260723121000_ml_p1_s5_invoice_rpcs.sql
+++ b/command-center/supabase/migrations/20260723121000_ml_p1_s5_invoice_rpcs.sql
@@ -1,0 +1,676 @@
+-- ML-P1 Slice 5 — canonical invoice RPCs (create / draft update / issue / void / readiness)
+-- Implements PD-S5-01..07. SOURCE ONLY — no prod apply in this PR.
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s5_role_can_invoice_create(p_role text)
+RETURNS boolean
+LANGUAGE sql IMMUTABLE AS $$
+  SELECT lower(coalesce(p_role, '')) IN ('office', 'manager', 'admin', 'csr');
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s5_role_can_void(p_role text)
+RETURNS boolean
+LANGUAGE sql IMMUTABLE AS $$
+  SELECT lower(coalesce(p_role, '')) IN ('office', 'manager', 'admin', 'csr');
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s5_role_can_write_off(p_role text)
+RETURNS boolean
+LANGUAGE sql IMMUTABLE AS $$
+  SELECT lower(coalesce(p_role, '')) = 'admin';
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s5_round_money(p_amount numeric)
+RETURNS numeric
+LANGUAGE sql IMMUTABLE AS $$
+  SELECT round(coalesce(p_amount, 0)::numeric, 2);
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s5_invoice_readiness(p_job_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_job public.jobs%ROWTYPE;
+  v_ready jsonb;
+  v_blockers jsonb := '[]'::jsonb;
+  v_existing uuid;
+  v_quote public.quotes%ROWTYPE;
+  v_pending int;
+BEGIN
+  SELECT * INTO v_job FROM public.jobs WHERE id = p_job_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('job_id', p_job_id, 'eligible', false, 'blockers', jsonb_build_array(jsonb_build_object('code', 'ML_P1_S5_JOB_NOT_FOUND')));
+  END IF;
+
+  IF lower(coalesce(v_job.status, '')) <> 'completed' THEN
+    v_blockers := v_blockers || jsonb_build_array(jsonb_build_object('code', 'ML_P1_S5_JOB_NOT_COMPLETED', 'detail', v_job.status));
+  END IF;
+
+  v_ready := public.ml_p1_s4_completion_readiness(p_job_id);
+  IF coalesce((v_ready->>'ready')::boolean, false) IS NOT TRUE THEN
+    v_blockers := v_blockers || jsonb_build_array(jsonb_build_object('code', 'ML_P1_S5_COMPLETION_NOT_READY', 'detail', v_ready->'blockers'));
+  END IF;
+
+  SELECT count(*)::int INTO v_pending
+  FROM public.change_orders
+  WHERE job_id = p_job_id AND status IN ('proposed', 'pending_approval');
+  IF v_pending > 0 THEN
+    v_blockers := v_blockers || jsonb_build_array(jsonb_build_object('code', 'ML_P1_S5_PENDING_CHANGE_ORDER', 'detail', v_pending));
+  END IF;
+
+  IF v_job.quote_id IS NULL THEN
+    v_blockers := v_blockers || jsonb_build_array(jsonb_build_object('code', 'ML_P1_S5_QUOTE_REQUIRED'));
+  ELSE
+    SELECT * INTO v_quote FROM public.quotes WHERE id = v_job.quote_id;
+    IF NOT FOUND OR lower(coalesce(v_quote.status, '')) NOT IN ('accepted', 'approved') THEN
+      v_blockers := v_blockers || jsonb_build_array(jsonb_build_object('code', 'ML_P1_S5_QUOTE_REQUIRED', 'detail', coalesce(v_quote.status, 'missing')));
+    END IF;
+  END IF;
+
+  SELECT id INTO v_existing
+  FROM public.invoices
+  WHERE job_id = p_job_id
+    AND lower(coalesce(status, '')) IS DISTINCT FROM 'void'
+  ORDER BY created_at DESC NULLS LAST
+  LIMIT 1;
+  IF v_existing IS NOT NULL THEN
+    v_blockers := v_blockers || jsonb_build_array(jsonb_build_object('code', 'ML_P1_S5_INVOICE_EXISTS', 'invoice_id', v_existing));
+  END IF;
+
+  RETURN jsonb_build_object(
+    'job_id', p_job_id,
+    'eligible', jsonb_array_length(v_blockers) = 0,
+    'blockers', v_blockers,
+    'existing_invoice_id', v_existing,
+    's4_readiness', v_ready
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s5_invoice_create(
+  p_job_id uuid,
+  p_client_mutation_id text,
+  p_system boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role text := public.ml_p1_s2_current_actor_role();
+  v_mut text := nullif(btrim(coalesce(p_client_mutation_id, '')), '');
+  v_prior public.invoice_execution_mutations%ROWTYPE;
+  v_job public.jobs%ROWTYPE;
+  v_quote public.quotes%ROWTYPE;
+  v_ready jsonb;
+  v_invoice_id uuid;
+  v_subtotal numeric := 0;
+  v_tax_rate numeric := 0;
+  v_tax_amount numeric := 0;
+  v_discount numeric := 0;
+  v_total numeric := 0;
+  v_co_ids uuid[] := '{}';
+  v_snapshot jsonb := '{}'::jsonb;
+  v_item record;
+  v_sort int := 100;
+  v_inv_number text;
+  v_now timestamptz := now();
+BEGIN
+  IF v_mut IS NULL THEN
+    RAISE EXCEPTION 'ML_P1_S5_MUTATION_ID_REQUIRED' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF NOT coalesce(p_system, false) AND NOT public.ml_p1_s5_role_can_invoice_create(v_role) THEN
+    RAISE EXCEPTION 'ML_P1_S5_ROLE_DENY' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF coalesce(p_system, false) THEN
+    v_role := coalesce(nullif(v_role, 'unauthenticated'), 'system');
+  END IF;
+
+  SELECT * INTO v_prior
+  FROM public.invoice_execution_mutations
+  WHERE job_id = p_job_id AND client_mutation_id = v_mut;
+  IF FOUND THEN
+    RETURN v_prior.result;
+  END IF;
+
+  SELECT * INTO v_job FROM public.jobs WHERE id = p_job_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ML_P1_S5_JOB_NOT_FOUND' USING ERRCODE = 'P0001';
+  END IF;
+  IF lower(coalesce(v_job.status, '')) = 'cancelled' THEN
+    RAISE EXCEPTION 'ML_P1_S5_CANCELLED_JOB' USING ERRCODE = 'P0001';
+  END IF;
+  IF lower(coalesce(v_job.status, '')) <> 'completed' THEN
+    RAISE EXCEPTION 'ML_P1_S5_JOB_NOT_COMPLETED' USING ERRCODE = 'P0001';
+  END IF;
+
+  v_ready := public.ml_p1_s4_completion_readiness(p_job_id);
+  IF coalesce((v_ready->>'ready')::boolean, false) IS NOT TRUE THEN
+    RAISE EXCEPTION 'ML_P1_S5_COMPLETION_NOT_READY: %', v_ready->>'blockers' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.change_orders
+    WHERE job_id = p_job_id AND status IN ('proposed', 'pending_approval')
+  ) THEN
+    RAISE EXCEPTION 'ML_P1_S5_PENDING_CHANGE_ORDER' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_job.quote_id IS NULL THEN
+    RAISE EXCEPTION 'ML_P1_S5_QUOTE_REQUIRED' USING ERRCODE = 'P0001';
+  END IF;
+  SELECT * INTO v_quote FROM public.quotes WHERE id = v_job.quote_id;
+  IF NOT FOUND OR lower(coalesce(v_quote.status, '')) NOT IN ('accepted', 'approved') THEN
+    RAISE EXCEPTION 'ML_P1_S5_QUOTE_REQUIRED' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.invoices
+    WHERE job_id = p_job_id AND lower(coalesce(status, '')) IS DISTINCT FROM 'void'
+  ) THEN
+    RAISE EXCEPTION 'ML_P1_S5_INVOICE_EXISTS' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT coalesce(array_agg(id ORDER BY created_at), '{}') INTO v_co_ids
+  FROM public.change_orders
+  WHERE job_id = p_job_id AND status = 'approved';
+
+  -- Quote lines collected during insert below (stored prices only — never price_book)
+
+  v_tax_rate := coalesce(v_quote.tax_rate, 0);
+  v_inv_number := 'INV-' || to_char(v_now, 'YYMMDD') || '-' || substr(replace(gen_random_uuid()::text, '-', ''), 1, 6);
+
+  -- Compute subtotal from quote + approved CO items
+  SELECT coalesce(sum(public.ml_p1_s5_round_money(coalesce(qi.total_price, coalesce(qi.quantity, 1) * coalesce(qi.unit_price, 0)))), 0)
+    INTO v_subtotal
+  FROM public.quote_items qi
+  WHERE qi.quote_id = v_quote.id;
+
+  SELECT v_subtotal + coalesce(sum(public.ml_p1_s5_round_money((coalesce(ci.line_delta_cents, 0)::numeric / 100.0))), 0)
+    INTO v_subtotal
+  FROM public.change_order_items ci
+  JOIN public.change_orders co ON co.id = ci.change_order_id
+  WHERE co.job_id = p_job_id AND co.status = 'approved';
+
+  v_discount := 0;
+  IF coalesce(v_tax_rate, 0) > 0 THEN
+    v_tax_amount := public.ml_p1_s5_round_money(GREATEST(v_subtotal - v_discount, 0) * v_tax_rate);
+  ELSIF v_quote.tax_amount IS NOT NULL THEN
+    v_tax_amount := public.ml_p1_s5_round_money(v_quote.tax_amount);
+  ELSE
+    v_tax_amount := 0;
+  END IF;
+
+  v_total := public.ml_p1_s5_round_money(v_subtotal - v_discount + v_tax_amount);
+  v_snapshot := jsonb_build_object(
+    'subtotal', v_subtotal,
+    'discount_amount', v_discount,
+    'tax_rate', v_tax_rate,
+    'tax_amount', v_tax_amount,
+    'total_amount', v_total,
+    'quote_id', v_quote.id,
+    'quote_version', coalesce(v_job.source_quote_version, v_quote.quote_version),
+    'approved_change_order_ids', to_jsonb(v_co_ids),
+    'pricebook_used', false
+  );
+
+  INSERT INTO public.invoices (
+    tenant_id, lead_id, quote_id, job_id, invoice_number, status, invoice_type,
+    subtotal, tax_rate, tax_amount, discount_amount, total_amount,
+    amount_paid, balance_due, issue_date, notes,
+    customer_email, customer_name, customer_phone,
+    source_quote_version, approved_change_order_ids, calculation_snapshot,
+    s5_created, created_at, updated_at
+  ) VALUES (
+    coalesce(v_job.tenant_id, 'default'),
+    v_job.lead_id,
+    v_quote.id,
+    v_job.id,
+    v_inv_number,
+    'draft',
+    'final',
+    v_subtotal,
+    v_tax_rate,
+    v_tax_amount,
+    v_discount,
+    v_total,
+    0,
+    v_total,
+    (v_now::date),
+    'ML-P1 S5 draft from completed job (quote + approved change orders).',
+    v_quote.customer_email,
+    v_quote.customer_name,
+    v_quote.customer_phone,
+    coalesce(v_job.source_quote_version, v_quote.quote_version),
+    v_co_ids,
+    v_snapshot,
+    true,
+    v_now,
+    v_now
+  )
+  RETURNING id INTO v_invoice_id;
+
+  FOR v_item IN
+    SELECT qi.id, qi.description, qi.quantity, qi.unit_price,
+           public.ml_p1_s5_round_money(coalesce(qi.total_price, coalesce(qi.quantity, 1) * coalesce(qi.unit_price, 0))) AS total_price
+    FROM public.quote_items qi
+    WHERE qi.quote_id = v_quote.id
+    ORDER BY qi.created_at NULLS LAST
+  LOOP
+    INSERT INTO public.invoice_items (
+      invoice_id, description, quantity, unit_price, total_price, line_type, sort_order, source_kind, source_id
+    ) VALUES (
+      v_invoice_id,
+      coalesce(v_item.description, 'Quote line'),
+      coalesce(v_item.quantity, 1),
+      coalesce(v_item.unit_price, 0),
+      v_item.total_price,
+      CASE WHEN v_item.total_price < 0 THEN 'discount' ELSE 'service' END,
+      v_sort,
+      'quote',
+      v_item.id
+    );
+    v_sort := v_sort + 10;
+  END LOOP;
+
+  FOR v_item IN
+    SELECT ci.id, ci.description, ci.quantity,
+           public.ml_p1_s5_round_money(coalesce(ci.unit_price_cents, 0)::numeric / 100.0) AS unit_price,
+           public.ml_p1_s5_round_money(coalesce(ci.line_delta_cents, 0)::numeric / 100.0) AS total_price,
+           ci.is_credit
+    FROM public.change_order_items ci
+    JOIN public.change_orders co ON co.id = ci.change_order_id
+    WHERE co.job_id = p_job_id AND co.status = 'approved'
+    ORDER BY co.created_at NULLS LAST, ci.sort_order NULLS LAST
+  LOOP
+    INSERT INTO public.invoice_items (
+      invoice_id, description, quantity, unit_price, total_price, line_type, sort_order, source_kind, source_id
+    ) VALUES (
+      v_invoice_id,
+      coalesce(v_item.description, 'Change order line'),
+      coalesce(v_item.quantity, 1),
+      v_item.unit_price,
+      v_item.total_price,
+      CASE WHEN v_item.is_credit OR v_item.total_price < 0 THEN 'discount' ELSE 'service' END,
+      v_sort,
+      'change_order',
+      v_item.id
+    );
+    v_sort := v_sort + 10;
+  END LOOP;
+
+  PERFORM public.ml_p1_s4_emit_job_event(
+    coalesce(v_job.tenant_id, 'default'),
+    v_job.id,
+    'InvoiceCreated',
+    v_role,
+    jsonb_build_object(
+      'slice', 'ml-p1-s5',
+      'invoice_id', v_invoice_id,
+      'invoice_number', v_inv_number,
+      'total_amount', v_total,
+      'system', coalesce(p_system, false),
+      'client_mutation_id', v_mut,
+      'calculation_snapshot', v_snapshot
+    )
+  );
+
+  INSERT INTO public.invoice_execution_mutations (
+    tenant_id, job_id, invoice_id, action, client_mutation_id, actor_user_id, actor_role, result
+  ) VALUES (
+    coalesce(v_job.tenant_id, 'default'),
+    v_job.id,
+    v_invoice_id,
+    CASE WHEN coalesce(p_system, false) THEN 'auto_create' ELSE 'create' END,
+    v_mut,
+    auth.uid(),
+    v_role,
+    jsonb_build_object(
+      'invoice_id', v_invoice_id,
+      'invoice_created', true,
+      'status', 'draft',
+      'invoice_type', 'final',
+      'total_amount', v_total,
+      'display_status', 'Draft'
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'invoice_id', v_invoice_id,
+    'invoice_created', true,
+    'status', 'draft',
+    'display_status', 'Draft',
+    'invoice_type', 'final',
+    'total_amount', v_total,
+    'job_id', v_job.id
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s5_invoice_draft_update(
+  p_invoice_id uuid,
+  p_client_mutation_id text,
+  p_tax_rate numeric DEFAULT NULL,
+  p_tax_amount numeric DEFAULT NULL,
+  p_discount_amount numeric DEFAULT NULL,
+  p_notes text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role text := public.ml_p1_s2_current_actor_role();
+  v_mut text := nullif(btrim(coalesce(p_client_mutation_id, '')), '');
+  v_inv public.invoices%ROWTYPE;
+  v_subtotal numeric;
+  v_discount numeric;
+  v_tax_rate numeric;
+  v_tax_amount numeric;
+  v_total numeric;
+BEGIN
+  IF v_mut IS NULL THEN
+    RAISE EXCEPTION 'ML_P1_S5_MUTATION_ID_REQUIRED' USING ERRCODE = 'P0001';
+  END IF;
+  IF NOT public.ml_p1_s5_role_can_invoice_create(v_role) THEN
+    RAISE EXCEPTION 'ML_P1_S5_ROLE_DENY' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT * INTO v_inv FROM public.invoices WHERE id = p_invoice_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ML_P1_S5_INVOICE_NOT_FOUND' USING ERRCODE = 'P0001';
+  END IF;
+  IF lower(coalesce(v_inv.status, '')) <> 'draft' THEN
+    RAISE EXCEPTION 'ML_P1_S5_NOT_DRAFT' USING ERRCODE = 'P0001';
+  END IF;
+
+  v_subtotal := coalesce(v_inv.subtotal, 0);
+  v_discount := coalesce(p_discount_amount, v_inv.discount_amount, 0);
+  v_tax_rate := coalesce(p_tax_rate, v_inv.tax_rate, 0);
+  IF p_tax_amount IS NOT NULL THEN
+    v_tax_amount := public.ml_p1_s5_round_money(p_tax_amount);
+  ELSE
+    v_tax_amount := public.ml_p1_s5_round_money(GREATEST(v_subtotal - v_discount, 0) * v_tax_rate);
+  END IF;
+  v_total := public.ml_p1_s5_round_money(v_subtotal - v_discount + v_tax_amount);
+
+  UPDATE public.invoices SET
+    tax_rate = v_tax_rate,
+    tax_amount = v_tax_amount,
+    discount_amount = v_discount,
+    total_amount = v_total,
+    balance_due = public.ml_p1_s5_round_money(v_total - coalesce(amount_paid, 0)),
+    notes = coalesce(p_notes, notes),
+    calculation_snapshot = coalesce(calculation_snapshot, '{}'::jsonb) || jsonb_build_object(
+      'tax_rate', v_tax_rate,
+      'tax_amount', v_tax_amount,
+      'discount_amount', v_discount,
+      'total_amount', v_total,
+      'draft_adjusted', true
+    ),
+    updated_at = now()
+  WHERE id = p_invoice_id;
+
+  RETURN jsonb_build_object(
+    'invoice_id', p_invoice_id,
+    'status', 'draft',
+    'display_status', 'Draft',
+    'tax_rate', v_tax_rate,
+    'tax_amount', v_tax_amount,
+    'discount_amount', v_discount,
+    'total_amount', v_total
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s5_invoice_issue(
+  p_invoice_id uuid,
+  p_client_mutation_id text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role text := public.ml_p1_s2_current_actor_role();
+  v_mut text := nullif(btrim(coalesce(p_client_mutation_id, '')), '');
+  v_inv public.invoices%ROWTYPE;
+  v_prior public.invoice_execution_mutations%ROWTYPE;
+  v_result jsonb;
+  v_now timestamptz := now();
+BEGIN
+  IF v_mut IS NULL THEN
+    RAISE EXCEPTION 'ML_P1_S5_MUTATION_ID_REQUIRED' USING ERRCODE = 'P0001';
+  END IF;
+  IF NOT public.ml_p1_s5_role_can_invoice_create(v_role) THEN
+    RAISE EXCEPTION 'ML_P1_S5_ROLE_DENY' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT * INTO v_inv FROM public.invoices WHERE id = p_invoice_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ML_P1_S5_INVOICE_NOT_FOUND' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_inv.job_id IS NOT NULL THEN
+    SELECT * INTO v_prior
+    FROM public.invoice_execution_mutations
+    WHERE job_id = v_inv.job_id AND client_mutation_id = v_mut;
+    IF FOUND THEN
+      RETURN v_prior.result;
+    END IF;
+  END IF;
+
+  IF lower(coalesce(v_inv.status, '')) = 'sent' THEN
+    RETURN jsonb_build_object(
+      'invoice_id', v_inv.id,
+      'status', 'sent',
+      'display_status', 'Issued',
+      'already_issued', true,
+      'sent_at', v_inv.sent_at,
+      'public_token', v_inv.public_token,
+      'total_amount', v_inv.total_amount
+    );
+  END IF;
+  IF lower(coalesce(v_inv.status, '')) <> 'draft' THEN
+    RAISE EXCEPTION 'ML_P1_S5_NOT_DRAFT' USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.invoices SET
+    status = 'sent',
+    sent_at = coalesce(sent_at, v_now),
+    public_token = coalesce(public_token, gen_random_uuid()),
+    updated_at = v_now
+  WHERE id = p_invoice_id
+  RETURNING * INTO v_inv;
+
+  IF v_inv.job_id IS NOT NULL THEN
+    PERFORM public.ml_p1_s4_emit_job_event(
+      coalesce(v_inv.tenant_id, 'default'),
+      v_inv.job_id,
+      'InvoiceIssued',
+      v_role,
+      jsonb_build_object(
+        'slice', 'ml-p1-s5',
+        'invoice_id', v_inv.id,
+        'status', 'sent',
+        'display_status', 'Issued',
+        'total_amount', v_inv.total_amount,
+        'client_mutation_id', v_mut
+      )
+    );
+  END IF;
+
+  v_result := jsonb_build_object(
+    'invoice_id', v_inv.id,
+    'status', 'sent',
+    'display_status', 'Issued',
+    'sent_at', v_inv.sent_at,
+    'public_token', v_inv.public_token,
+    'total_amount', v_inv.total_amount
+  );
+
+  IF v_inv.job_id IS NOT NULL THEN
+    INSERT INTO public.invoice_execution_mutations (
+      tenant_id, job_id, invoice_id, action, client_mutation_id, actor_user_id, actor_role, result
+    ) VALUES (
+      coalesce(v_inv.tenant_id, 'default'),
+      v_inv.job_id,
+      v_inv.id,
+      'issue',
+      v_mut,
+      auth.uid(),
+      v_role,
+      v_result
+    );
+  END IF;
+
+  RETURN v_result;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s5_invoice_void(
+  p_invoice_id uuid,
+  p_client_mutation_id text,
+  p_reason text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role text := public.ml_p1_s2_current_actor_role();
+  v_mut text := nullif(btrim(coalesce(p_client_mutation_id, '')), '');
+  v_reason text := nullif(btrim(coalesce(p_reason, '')), '');
+  v_inv public.invoices%ROWTYPE;
+  v_prior public.invoice_execution_mutations%ROWTYPE;
+  v_result jsonb;
+  v_now timestamptz := now();
+BEGIN
+  IF v_mut IS NULL THEN
+    RAISE EXCEPTION 'ML_P1_S5_MUTATION_ID_REQUIRED' USING ERRCODE = 'P0001';
+  END IF;
+  IF v_reason IS NULL THEN
+    RAISE EXCEPTION 'ML_P1_S5_VOID_REASON_REQUIRED' USING ERRCODE = 'P0001';
+  END IF;
+  IF NOT public.ml_p1_s5_role_can_void(v_role) THEN
+    RAISE EXCEPTION 'ML_P1_S5_ROLE_DENY' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT * INTO v_inv FROM public.invoices WHERE id = p_invoice_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ML_P1_S5_INVOICE_NOT_FOUND' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_inv.job_id IS NOT NULL THEN
+    SELECT * INTO v_prior
+    FROM public.invoice_execution_mutations
+    WHERE job_id = v_inv.job_id AND client_mutation_id = v_mut;
+    IF FOUND THEN
+      RETURN v_prior.result;
+    END IF;
+  END IF;
+
+  IF lower(coalesce(v_inv.status, '')) = 'void' THEN
+    RETURN jsonb_build_object('invoice_id', v_inv.id, 'status', 'void', 'display_status', 'Void', 'already_void', true);
+  END IF;
+  IF lower(coalesce(v_inv.status, '')) = 'paid' OR coalesce(v_inv.amount_paid, 0) > 0 THEN
+    RAISE EXCEPTION 'ML_P1_S5_VOID_NOT_ALLOWED_AFTER_PAYMENT' USING ERRCODE = 'P0001';
+  END IF;
+  IF lower(coalesce(v_inv.status, '')) NOT IN ('draft', 'sent') THEN
+    RAISE EXCEPTION 'ML_P1_S5_VOID_STATUS_DENY' USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.invoices SET
+    status = 'void',
+    void_reason = v_reason,
+    voided_at = v_now,
+    voided_by = auth.uid(),
+    updated_at = v_now
+  WHERE id = p_invoice_id
+  RETURNING * INTO v_inv;
+
+  IF v_inv.job_id IS NOT NULL THEN
+    PERFORM public.ml_p1_s4_emit_job_event(
+      coalesce(v_inv.tenant_id, 'default'),
+      v_inv.job_id,
+      'InvoiceVoided',
+      v_role,
+      jsonb_build_object(
+        'slice', 'ml-p1-s5',
+        'invoice_id', v_inv.id,
+        'reason', v_reason,
+        'client_mutation_id', v_mut
+      )
+    );
+  END IF;
+
+  v_result := jsonb_build_object(
+    'invoice_id', v_inv.id,
+    'status', 'void',
+    'display_status', 'Void',
+    'void_reason', v_reason,
+    'voided_at', v_inv.voided_at
+  );
+
+  IF v_inv.job_id IS NOT NULL THEN
+    INSERT INTO public.invoice_execution_mutations (
+      tenant_id, job_id, invoice_id, action, client_mutation_id, actor_user_id, actor_role, result
+    ) VALUES (
+      coalesce(v_inv.tenant_id, 'default'),
+      v_inv.job_id,
+      v_inv.id,
+      'void',
+      v_mut,
+      auth.uid(),
+      v_role,
+      v_result
+    );
+  END IF;
+
+  RETURN v_result;
+END;
+$$;
+
+-- Freeze issued financials (PD-S5-04 / PD-S5-06)
+CREATE OR REPLACE FUNCTION public.ml_p1_s5_guard_invoice_financial_immutability()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE'
+     AND lower(coalesce(OLD.status, '')) = 'sent'
+     AND lower(coalesce(NEW.status, '')) = 'sent'
+  THEN
+    IF NEW.subtotal IS DISTINCT FROM OLD.subtotal
+       OR NEW.tax_rate IS DISTINCT FROM OLD.tax_rate
+       OR NEW.tax_amount IS DISTINCT FROM OLD.tax_amount
+       OR NEW.discount_amount IS DISTINCT FROM OLD.discount_amount
+       OR NEW.total_amount IS DISTINCT FROM OLD.total_amount
+    THEN
+      RAISE EXCEPTION 'ML_P1_S5_ISSUED_IMMUTABLE: void and reissue required'
+        USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_ml_p1_s5_invoice_immutable ON public.invoices;
+CREATE TRIGGER trg_ml_p1_s5_invoice_immutable
+  BEFORE UPDATE ON public.invoices
+  FOR EACH ROW
+  EXECUTE FUNCTION public.ml_p1_s5_guard_invoice_financial_immutability();
+
+GRANT EXECUTE ON FUNCTION public.ml_p1_s5_invoice_readiness(uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ml_p1_s5_invoice_create(uuid, text, boolean) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ml_p1_s5_invoice_draft_update(uuid, text, numeric, numeric, numeric, text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ml_p1_s5_invoice_issue(uuid, text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ml_p1_s5_invoice_void(uuid, text, text) TO authenticated, service_role;

--- a/command-center/supabase/migrations/20260723122000_ml_p1_s5_auto_draft_trigger.sql
+++ b/command-center/supabase/migrations/20260723122000_ml_p1_s5_auto_draft_trigger.sql
@@ -1,0 +1,63 @@
+-- ML-P1 S5 — auto-draft on job completed (PD-S5-01 C). Never auto-issue.
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s5_job_completed_auto_draft()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_mut text;
+  v_result jsonb;
+BEGIN
+  IF NEW.status IS NOT DISTINCT FROM OLD.status THEN
+    RETURN NEW;
+  END IF;
+  IF lower(coalesce(NEW.status, '')) <> 'completed' THEN
+    RETURN NEW;
+  END IF;
+  IF lower(coalesce(OLD.status, '')) = 'completed' THEN
+    RETURN NEW;
+  END IF;
+
+  -- Skip if non-void invoice already exists
+  IF EXISTS (
+    SELECT 1 FROM public.invoices
+    WHERE job_id = NEW.id AND lower(coalesce(status, '')) IS DISTINCT FROM 'void'
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  v_mut := 's5-auto:' || NEW.id::text || ':' || coalesce(NEW.completed_at, now())::text;
+  BEGIN
+    v_result := public.ml_p1_s5_invoice_create(NEW.id, v_mut, true);
+  EXCEPTION
+    WHEN OTHERS THEN
+      -- Soft-fail auto-draft: job completion must not roll back (office can create manually)
+      INSERT INTO public.events (
+        tenant_id, entity_type, entity_id, event_type, actor_type, actor_id, payload
+      ) VALUES (
+        coalesce(NEW.tenant_id, 'default'),
+        'job',
+        NEW.id,
+        'InvoiceAutoDraftFailed',
+        'system',
+        NULL,
+        jsonb_build_object(
+          'slice', 'ml-p1-s5',
+          'sqlstate', SQLSTATE,
+          'message', SQLERRM
+        )
+      );
+      RETURN NEW;
+  END;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_ml_p1_s5_job_completed_auto_draft ON public.jobs;
+CREATE TRIGGER trg_ml_p1_s5_job_completed_auto_draft
+  AFTER UPDATE OF status ON public.jobs
+  FOR EACH ROW
+  EXECUTE FUNCTION public.ml_p1_s5_job_completed_auto_draft();

--- a/command-center/tests/unit/ml-p1-s5-invoice.test.mjs
+++ b/command-center/tests/unit/ml-p1-s5-invoice.test.mjs
@@ -1,0 +1,140 @@
+/**
+ * ML-P1 Slice 5 — source guards + client authz (SOURCE/unit).
+ * Run: node --test tests/unit/ml-p1-s5-invoice.test.mjs
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  canPerformS5,
+  formatInvoiceStatusLabel,
+  ML_P1_S5_CAPABILITIES,
+  normalizeS5Role,
+} from '../../src/lib/mlP1S5InvoiceAuthz.js';
+import { createMlP1S5InvoiceService } from '../../src/services/mlP1S5InvoiceService.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(__dirname, '../..');
+const read = (rel) => fs.readFileSync(path.join(root, rel), 'utf8');
+
+describe('ML-P1 S5 migration source guards', () => {
+  const schema = read('supabase/migrations/20260723120000_ml_p1_s5_invoice_schema.sql');
+  const rpcs = read('supabase/migrations/20260723121000_ml_p1_s5_invoice_rpcs.sql');
+  const auto = read('supabase/migrations/20260723122000_ml_p1_s5_auto_draft_trigger.sql');
+
+  it('adds lineage / void / mutation ledger columns', () => {
+    assert.match(schema, /source_quote_version/);
+    assert.match(schema, /approved_change_order_ids/);
+    assert.match(schema, /calculation_snapshot/);
+    assert.match(schema, /void_reason/);
+    assert.match(schema, /s5_created/);
+    assert.match(schema, /CREATE TABLE IF NOT EXISTS public\.invoice_execution_mutations/);
+    assert.match(schema, /source_kind/);
+  });
+
+  it('defines canonical RPCs with PD-S5 gates', () => {
+    assert.match(rpcs, /ml_p1_s5_invoice_readiness/);
+    assert.match(rpcs, /ml_p1_s5_invoice_create/);
+    assert.match(rpcs, /ml_p1_s5_invoice_draft_update/);
+    assert.match(rpcs, /ml_p1_s5_invoice_issue/);
+    assert.match(rpcs, /ml_p1_s5_invoice_void/);
+    assert.match(rpcs, /invoice_type',\s*'final'/);
+    assert.match(rpcs, /status = 'sent'/);
+    assert.match(rpcs, /display_status', 'Issued'/);
+    assert.match(rpcs, /ML_P1_S5_ISSUED_IMMUTABLE/);
+    assert.match(rpcs, /ML_P1_S5_VOID_REASON_REQUIRED/);
+    assert.match(rpcs, /ML_P1_S5_VOID_NOT_ALLOWED_AFTER_PAYMENT/);
+    assert.match(rpcs, /pricebook_used', false/);
+    assert.equal(/FROM\s+public\.price_book/i.test(rpcs), false);
+    assert.match(rpcs, /ml_p1_s5_role_can_write_off/);
+  });
+
+  it('auto-drafts on completed without auto-issue', () => {
+    assert.match(auto, /ml_p1_s5_job_completed_auto_draft/);
+    assert.match(auto, /ml_p1_s5_invoice_create\(NEW\.id, v_mut, true\)/);
+    assert.match(auto, /InvoiceAutoDraftFailed/);
+    assert.equal(/ml_p1_s5_invoice_issue/.test(auto), false);
+    assert.equal(/status\s*=\s*'sent'/.test(auto), false);
+  });
+});
+
+describe('ML-P1 S5 alternate writer denials', () => {
+  const edge = read('supabase/functions/work-order-update/index.ts');
+  const money = read('src/pages/crm/MyMoney.jsx');
+  const invoices = read('src/pages/crm/Invoices.jsx');
+  const panel = read('src/components/crm/jobs/OfficeInvoicePanel.jsx');
+  const jobs = read('src/pages/crm/Jobs.jsx');
+
+  it('denies Edge ensure/create invoice writers', () => {
+    assert.match(edge, /ML_P1_S5_ALT_WRITER_DENY/);
+    assert.match(edge, /use canonical ml_p1_s5_invoice_create/);
+    assert.match(edge, /ML_P1_S4_INVOICE_ON_COMPLETE_ENABLED = false/);
+  });
+
+  it('denies MyMoney direct invoice create', () => {
+    assert.match(money, /ML_P1_S5_ALT_WRITER_DENY/);
+    assert.equal(/\.from\('invoices'\)\s*\n\s*\.insert\(/.test(money), false);
+  });
+
+  it('displays Issued for sent and wires office panel', () => {
+    assert.match(invoices, />Issued</);
+    assert.match(panel, /createMlP1S5InvoiceService/);
+    assert.match(panel, /formatInvoiceStatusLabel/);
+    assert.match(jobs, /OfficeInvoicePanel/);
+  });
+});
+
+describe('ML-P1 S5 role authz (PD-S5-05)', () => {
+  it('maps csr to office capabilities', () => {
+    assert.equal(normalizeS5Role('csr'), 'office');
+    assert.equal(canPerformS5('csr', 'create'), true);
+    assert.equal(canPerformS5('office', 'issue'), true);
+    assert.equal(canPerformS5('manager', 'void'), true);
+  });
+
+  it('technician never creates/issues/voids/write-offs', () => {
+    assert.equal(canPerformS5('technician', 'create'), false);
+    assert.equal(canPerformS5('technician', 'issue'), false);
+    assert.equal(canPerformS5('technician', 'void'), false);
+    assert.equal(canPerformS5('technician', 'writeOff'), false);
+  });
+
+  it('write-off is admin only', () => {
+    assert.deepEqual(ML_P1_S5_CAPABILITIES.writeOff, ['admin']);
+    assert.equal(canPerformS5('admin', 'writeOff'), true);
+    assert.equal(canPerformS5('office', 'writeOff'), false);
+    assert.equal(canPerformS5('manager', 'writeOff'), false);
+  });
+
+  it('formats sent as Issued (PD-S5-02)', () => {
+    assert.equal(formatInvoiceStatusLabel('sent'), 'Issued');
+    assert.equal(formatInvoiceStatusLabel('draft'), 'Draft');
+    assert.equal(formatInvoiceStatusLabel('void'), 'Void');
+  });
+});
+
+describe('ML-P1 S5 client service facade', () => {
+  it('calls only S5 RPCs (no direct invoices insert)', async () => {
+    const calls = [];
+    const supabase = {
+      rpc: async (name, args) => {
+        calls.push({ name, args });
+        return { data: { ok: true, name }, error: null };
+      },
+      from: () => {
+        throw new Error('direct table access unexpected in create path');
+      },
+    };
+    const svc = createMlP1S5InvoiceService({ supabase });
+    await svc.create('job-1', { clientMutationId: 'm1' });
+    await svc.issue('inv-1', { clientMutationId: 'm2' });
+    await svc.void('inv-1', 'wrong total', { clientMutationId: 'm3' });
+    assert.equal(calls[0].name, 'ml_p1_s5_invoice_create');
+    assert.equal(calls[0].args.p_system, false);
+    assert.equal(calls[1].name, 'ml_p1_s5_invoice_issue');
+    assert.equal(calls[2].name, 'ml_p1_s5_invoice_void');
+    assert.equal(calls[2].args.p_reason, 'wrong total');
+  });
+});


### PR DESCRIPTION
## Summary
- Implements ratified PD-S5-01..07 on `ml/p1-s5-invoice-collection` @ base `8505a89`: canonical invoice create/draft-update/issue/void RPCs, auto-draft on job completed, alternate-writer denials, office panel + Issued label.
- Three coding peer-review rounds + A2 evidence/docs updated.
- **SOURCE only** — does not apply production migrations, Hostinger deploy, or Stripe/Braintree.

## Test plan
- [x] `node --test tests/unit/ml-p1-s5-invoice.test.mjs` (11/11)
- [ ] Founder exact-head merge approval (required)
- [ ] Do **not** apply S5 migrations or deploy until separate A3 auth

## Halt
Merge requires exact-head Founder approval. No prod apply / Stripe in this PR.

Made with [Cursor](https://cursor.com)