### PR TITLE
ML-P1 S6 A2: Payment & Invoicing settings + settlement gates (SOURCE)

### DIFF
--- a/command-center/docs/governance/decisions/ML-P1_SLICE6_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/ML-P1_SLICE6_DECISION_PACKET.md
@@ -2,12 +2,10 @@
 
 | Field | Value |
 | --- | --- |
-| Disposition | **SLICE6_PLANNING_READY_FOR_FOUNDER_REVIEW** |
-| Planning base (`origin/main`) | `a7e1f63781cca7fcba5d706a7a97bd62a17a4c3b` |
-| Branch | `plan/ml-p1-s6-stripe-settlement` |
-| Prior | S5 A3 CLOSED @ deploy `2b37985`; docs tip `a7e1f63` |
-| Coding | **Not authorized** — requires Founder **Category-C** on exact SHA after this planning PR |
-| Naming | Maps historical roadmap **S5b** → this **S6**; follow-up → **S7** |
+| Disposition | **SLICE6_A2_CODING** (PD-S6-01…07 as recommended; Category-C coding auth 2026-07-23) |
+| Coding base SHA | `6b300e40747cfceaf743b264d9f58bf7eede079a` |
+| Branch | `ml/p1-s6-stripe-settlement` |
+| Coding | **Authorized** — A2 SOURCE; **no A3** secret rotate / webhook live-attach / auto-charge enable |
 
 ## Purpose
 

--- a/command-center/docs/governance/decisions/ML-P1_SLICE6_DECISION_PACKET.md
+++ b/command-center/docs/governance/decisions/ML-P1_SLICE6_DECISION_PACKET.md
@@ -1,0 +1,130 @@
+# Decision Packet — ML-P1 Slice 6 (Stripe settlement & payment posting)
+
+| Field | Value |
+| --- | --- |
+| Disposition | **SLICE6_PLANNING_READY_FOR_FOUNDER_REVIEW** |
+| Planning base (`origin/main`) | `a7e1f63781cca7fcba5d706a7a97bd62a17a4c3b` |
+| Branch | `plan/ml-p1-s6-stripe-settlement` |
+| Prior | S5 A3 CLOSED @ deploy `2b37985`; docs tip `a7e1f63` |
+| Coding | **Not authorized** — requires Founder **Category-C** on exact SHA after this planning PR |
+| Naming | Maps historical roadmap **S5b** → this **S6**; follow-up → **S7** |
+
+## Purpose
+
+Safe Stripe settlement and payment posting on issued invoices, proving one canonical paid writer (G-09), without enabling automatic card charges.
+
+## Live baseline (2026-07-23)
+
+| Fact | Evidence |
+| --- | --- |
+| `payments_mode` | `stripe` |
+| Invoices | 25 · paid status 9 · provider_payment_id 9 · amount_paid>0 10 |
+| Spine | `public-pay` → Checkout → `payment-webhook` → `record_stripe_webhook_payment` |
+| Offline | `record_offline_manual_payment` present |
+| Refunds in webhook | Explicitly ignored today |
+
+---
+
+## Product decisions (DRAFT — recommended for Founder Category-C)
+
+### PD-S6-01 — Stripe account linkage & secrets → **A (recommended)**
+
+| Option | Description |
+| --- | --- |
+| **A** | Single TVG Stripe account; secrets only in Edge/env (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`); no Stripe Connect; no client-publishable charge keys in Vite |
+| B | Stripe Connect / multi-account |
+| C | Move secrets into DB config UI |
+
+**Recommend A.** Matches live spine and single-tenant.  
+**Escalate if:** Connect, multi-region accounts, or client-side secret exposure.
+
+### PD-S6-02 — Capture / settlement flow → **A (recommended)**
+
+| Option | Description |
+| --- | --- |
+| **A** | Manual collection only: customer opens pay link → Stripe Checkout → **immediate capture**; office may post offline payment; **no** scheduled capture; **no** auto-charge on issue/send |
+| B | Auth-then-capture (manual capture queue) |
+| C | Auto-charge saved cards on invoice issue / schedule |
+
+**Recommend A.** Preserves current Checkout `mode: payment`.  
+**Major Decision #3 if choosing C** (auto-charge ON).  
+**Escalate if:** B introduces new customer-visible hold behavior without prior HCP parity.
+
+### PD-S6-03 — Payment-method storage → **A (recommended)**
+
+| Option | Description |
+| --- | --- |
+| **A** | **None** — hosted Checkout only; do not vault cards; do not persist PaymentMethod IDs for reuse |
+| B | Stripe Customer + optional saved PM for office-initiated reuse |
+| C | Customer portal vault + field Terminal |
+
+**Recommend A** for this slice (PCI surface stays at Stripe-hosted).  
+**Major Decision #2/#5 if B/C** (net-new flows / PCI scope).
+
+### PD-S6-04 — Refund / dispute surfaces → **A (recommended)**
+
+| Option | Description |
+| --- | --- |
+| **A** | Office-initiated **full and partial refunds** via canonical refund RPC → Stripe API → ledger; `charge.dispute.*` / unmatched refund webhooks → **quarantine task** (no silent rewrite); no auto-refund |
+| B | Full dispute/chargeback product automation |
+| C | Defer all refunds again |
+
+**Recommend A** (roadmap required refunds; disputes = human queue).  
+**Escalate if:** automatic refunds to customers without office action.
+
+### PD-S6-05 — Invoice state × payment → **A (recommended)**
+
+| Option | Description |
+| --- | --- |
+| **A** | `draft` → `sent` (S5) → `partially_paid` (optional) → `paid`; **only** canonical paid/refund writers mutate settlement fields; unpaid void remains S5 rules; paid invoices are not voided in-place (refund path instead) |
+| B | Allow free UI status toggles to `paid` |
+| C | Collapse partial into `sent` forever |
+
+**Recommend A.** Proves G-09 / KI-07.  
+**Escalate if:** historical status rewrite of the 25 grandfathered invoices.
+
+### PD-S6-06 — Field / customer payment UX → **A (recommended)**
+
+| Option | Description |
+| --- | --- |
+| **A** | Customer: existing `/pay/:token` → Checkout; Office: send pay link + Record Payment (offline); Technician: **view balance / copy pay link only** — no card entry on tech device |
+| B | In-app Stripe Elements on CRM/tech |
+| C | Stripe Terminal / tap-to-pay in field |
+
+**Recommend A.**  
+**Major Decision #2 if B/C.**
+
+### PD-S6-07 — Reporting / reconciliation → **A (recommended)**
+
+| Option | Description |
+| --- | --- |
+| **A** | Prove single paid writer; office recon view of mismatches; retain/use `provider_payment_observations` + webhook quarantine tasks; daily/on-demand sweep; export-ready settlement fields — **no** new QB product ownership |
+| B | Expand QuickBooks as system of record for settlement |
+| C | External data warehouse pipeline |
+
+**Recommend A.**
+
+---
+
+## Explicit non-scope (S6)
+
+Autonomous follow-up / dunning journeys (**S7**) · Braintree · autopay · auto-charge · visual workflow builder · multi-tenancy · TIS · G2.3 · invoice create (S5) · pricebook · historical financial rewrite.
+
+## Escalation digest (Founder sign-off required)
+
+| Trigger | Policy # | Packet impact |
+| --- | --- | --- |
+| Auto-charge / scheduled charge ON | ③ | Reject PD-S6-02 C without Founder |
+| Customer portal / saved cards / Terminal | ②⑤ | Reject PD-S6-03 B/C, PD-S6-06 B/C without Founder |
+| PCI Elements on our origin | ⑤ | Architecture halt |
+| Drop columns / rewrite paid history | ④ | Forbidden in S6 migrations |
+| Prod money FAIL unfixable | ⑥ | Halt A3 |
+
+## Coding gate
+
+After this planning PR is CI-green and Founder grants **Category-C** on exact head: open coding branch `ml/p1-s6-stripe-settlement` from that SHA.  
+**This planning PR must not be treated as coding auth. Do not merge to advance A2 without Category-C** (Founder instruction 2026-07-23).
+
+## Supersedes
+
+Informal “S5b next” ledger wording; aligns slice number with Delegated-Authority Policy (S6 = Stripe, S7 = follow-up).

--- a/command-center/docs/stabilization/releases/ML-P1_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/stabilization/releases/ML-P1_EVIDENCE_MANIFEST.md
@@ -39,4 +39,5 @@ Paths relative to `command-center/`; SHA-256 over path + newline + file bytes, c
 | Slice 4 evidence | `ML-P1_SLICE4_EVIDENCE_MANIFEST.md` |
 | Slice 4 state | `ML-P1_SLICE4_STATE_LEDGER.md` |
 | Slice 5 planning evidence | `ML-P1_SLICE5_EVIDENCE_MANIFEST.md` |
+| Slice 6 planning evidence | `ML-P1_SLICE6_EVIDENCE_MANIFEST.md` |
 | Program state | `ML-P1_STATE_LEDGER.md` |

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE6_A2_CODING_EVIDENCE.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE6_A2_CODING_EVIDENCE.md
@@ -1,0 +1,24 @@
+# ML-P1 Slice 6 — A2 Coding Evidence
+
+> Coding authorized on `ml/p1-s6-stripe-settlement` @ base `6b300e40747cfceaf743b264d9f58bf7eede079a`.
+>
+> **Does not authorize** prod Stripe secret rotate, webhook live-attach, auto-charge enable, saved-card/portal, QuickBooks, or A3 synth on live Stripe.
+
+## Delivered (SOURCE)
+
+| Item | Note |
+| --- | --- |
+| Settings migration | `20260723140000_ml_p1_s6_payment_settings.sql` |
+| Six flags | checkout · offline · refunds · recon · auto_send(OFF) · auto_charge(OFF) |
+| UI | Settings › Billing & Payments |
+| Writers | public-pay gate; offline via `ml_p1_s6_record_offline_manual_payment`; webhook dispute/refund quarantine; refund RPC |
+| Auto-charge | UI blocks ON; SQL `ML_P1_S6_AUTO_CHARGE_DENY` helper; no charge path |
+| Tests | `tests/unit/ml-p1-s6-payment.test.mjs` |
+
+## PD mapping
+
+PD-S6-01…07 recommended set implemented as SOURCE gates/settings (G-09 offline wrapper; Checkout-only; no vault).
+
+## Stopped
+
+A3 apply · secret rotate · webhook live-attach · auto-charge enable · portal/saved cards · QB export

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE6_ARCHITECTURE_FINDINGS.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE6_ARCHITECTURE_FINDINGS.md
@@ -1,0 +1,82 @@
+# ML-P1 Slice 6 — Architecture Findings (Stripe settlement)
+
+| Field | Value |
+| --- | --- |
+| Evidence date | 2026-07-23 |
+| Main SHA | `a7e1f63781cca7fcba5d706a7a97bd62a17a4c3b` |
+| Project | `wwyxohjnyqnegzbxtuxs` |
+| Class | Planning / architecture (EXECUTED live reads; no mutations) |
+
+## Naming reconciliation
+
+| Historical roadmap | This packet (Founder-aligned) |
+| --- | --- |
+| S5b Stripe payment operations | **S6** Stripe settlement & payment posting |
+| S6 autonomous follow-up | **S7** (deferred) |
+
+Do not open branch `ml/p1-s5b-*` for this work; use `ml/p1-s6-stripe-settlement` (coding, later).
+
+## Live posture (EXECUTED)
+
+| Fact | Value |
+| --- | --- |
+| `global_config.payments_mode` | `stripe` |
+| Invoices | 25 total · `amount_paid>0` = 10 · `provider_payment_id` set = 9 · `status=paid` = 9 |
+| Tables present | `stripe_webhook_events`, `public_payment_attempts` |
+| S5 invoice create | Live (canonical RPCs); issue persists `sent` / display Issued |
+
+## Existing spine (SOURCE)
+
+```mermaid
+flowchart LR
+  issued[Invoice sent/Issued] --> paylink["/pay/:token"]
+  paylink --> publicPay[public-pay Edge]
+  publicPay --> checkout[Stripe Checkout Session]
+  checkout --> webhook[payment-webhook]
+  webhook --> writer[record_stripe_webhook_payment]
+  office[Office Record Payment] --> offline[record_offline_manual_payment]
+  offline --> writer2[same settlement projection]
+  writer --> inv[invoices amount_paid / paid]
+  writer2 --> inv
+```
+
+| Component | Role | Gap |
+| --- | --- | --- |
+| `public-pay` | Creates Checkout (`mode: payment`, card) | Immediate capture only; no auth-hold product |
+| `payment-webhook` / `stripe-webhook` | Settles via RPC; signed | Refunds/disputes ignored today |
+| `record_offline_manual_payment` | Cash/check posting | Must remain under G-09 |
+| `send-invoice` | Pay link + optional hosted Stripe Invoice | Dual initiation surface risk |
+| `create-payment-intent/` | CORS stub only | Not a product path |
+| Client Stripe.js / Elements | Absent | Good for PCI minimization |
+
+## Secrets / linkage (names only)
+
+- Env: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `PUBLIC_PAY_BASE_URL`
+- No `VITE_STRIPE_*` (correct for hosted Checkout)
+- Stripe Customer created/listed by email in `send-invoice` — no durable CRM `stripe_customer_id` column in use
+- Single-account (no Connect) matches TVG single-tenant
+
+## Money-state interaction with S5
+
+| S5 | S6 |
+| --- | --- |
+| Creates/issues/voids invoices | Does not create invoices |
+| Freezes financials on `sent` | Settles `amount_paid` / status via paid writers only |
+| Void unpaid | Refund after paid (new) does not “unvoid”; uses refund + status rules |
+| Never auto-send | Never auto-charge |
+
+## Risks
+
+1. **G-09 incomplete** — alternate paid paths (UI direct status update, hosted Invoice side effects) must be inventory + deny.  
+2. **Dual initiation** — Checkout Session vs optional Stripe Invoice objects.  
+3. **Job vs invoice payment_status** (KI-06) still divergence-prone.  
+4. **Partial pay** supported in contracts but weakly exercised live.  
+5. **Refund ignore** in webhook leaves Stripe refunds desynced from CRM.  
+6. **PCI creep** if Elements/Terminal introduced without Major Decision.
+
+## Recommended architecture target (pending PD ratification)
+
+- Keep hosted Checkout as sole card collection UX.  
+- Canonical writers only: Stripe webhook RPC + offline manual RPC (+ optional explicit refund RPC calling Stripe then ledger).  
+- Quarantine tasks for disputes / unmatched events.  
+- No SetupIntent vault; no auto-charge; no Connect.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE6_BRIEF.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE6_BRIEF.md
@@ -1,0 +1,47 @@
+# ML-P1 Slice 6 — Brief
+
+| Field | Value |
+| --- | --- |
+| Slice | **ML-P1-S6** Stripe settlement & payment posting |
+| Planning base | `a7e1f63781cca7fcba5d706a7a97bd62a17a4c3b` (`origin/main`) |
+| Branch | `plan/ml-p1-s6-stripe-settlement` |
+| Product decisions | **PD-S6-01…07 DRAFT → Founder Category-C review** (not coding-authorized) |
+| Coding / migrate / deploy | **Blocked** until Founder Category-C |
+| Naming | Roadmap historically called this **S5b**; Founder delegated policy + this packet rename it **S6**. Former roadmap S6 (autonomous follow-up) → **S7**. |
+
+## One-sentence goal
+
+Collect payment on issued invoices via Stripe (and offline posting) with a single canonical paid writer, without enabling automatic card charges or new customer autopay portals.
+
+## In / out
+
+| In | Out (this slice) |
+| --- | --- |
+| Prove G-09 one paid writer (webhook + offline) | Auto-charge / autopay / scheduled capture |
+| Harden Checkout pay-link settlement | New payment providers (Braintree, etc.) |
+| Office full/partial refund surface + Stripe API | Full chargeback automation product |
+| Dispute webhook → quarantine / task only | Card vault / SetupIntent / Elements field collect |
+| Partial-pay status coherence (`partially_paid`) | Autonomous follow-up / dunning journeys (S7) |
+| Recon exception queue + observations sweep | QuickBooks ownership expansion |
+| Tech: share pay link / view balance only | Tech device card entry / Terminal |
+
+## Success criteria (when coding later authorized)
+
+1. All Stripe settlements and offline payments converge on the same paid writer(s); no alternate paid mutators.  
+2. Customer pay remains hosted Checkout via `/pay/:token`; no auto-charge.  
+3. Refunds (full/partial) office-initiated with audit; disputes create exceptions, not silent money edits.  
+4. Invoice/job payment status stay coherent after settlement.  
+5. Synthetic validation only; no real-customer mutation in synth.
+
+## Escalation triggers (Founder Major Decision)
+
+- Turning **auto-send** or **auto-charge** ON for real customers  
+- Net-new customer portal / saved-card / Terminal field flows  
+- PCI scope expansion (Elements on our domain) or data-residency changes  
+- Destructive schema / historical financial rewrite  
+
+## Related artifacts
+
+- Decision packet: `docs/governance/decisions/ML-P1_SLICE6_DECISION_PACKET.md`  
+- Architecture: `docs/stabilization/releases/ML-P1_SLICE6_ARCHITECTURE_FINDINGS.md`  
+- Reviews: `docs/stabilization/releases/reviews/ML-P1_S6_PLANNING_*_REVIEW.md`

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE6_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE6_EVIDENCE_MANIFEST.md
@@ -1,0 +1,29 @@
+# Evidence Manifest — ML-P1 Slice 6 Planning
+
+| Field | Value |
+| --- | --- |
+| Scope | Planning only — Stripe settlement & payment posting |
+| Exact main SHA | `a7e1f63781cca7fcba5d706a7a97bd62a17a4c3b` |
+| Branch | `plan/ml-p1-s6-stripe-settlement` |
+| Disposition | Docs PR ready for Founder Category-C review; **no coding auth** |
+
+## Artifacts
+
+| Path | Role |
+| --- | --- |
+| `docs/governance/decisions/ML-P1_SLICE6_DECISION_PACKET.md` | PD-S6-01…07 (recommended) |
+| `docs/stabilization/releases/ML-P1_SLICE6_BRIEF.md` | Brief |
+| `docs/stabilization/releases/ML-P1_SLICE6_ARCHITECTURE_FINDINGS.md` | Architecture |
+| `docs/stabilization/releases/ML-P1_SLICE6_RESIDUAL_REGISTER.md` | Residuals |
+| `docs/stabilization/releases/ML-P1_SLICE6_STATE_LEDGER.md` | S6 state |
+| `docs/stabilization/releases/reviews/ML-P1_S6_PLANNING_*_REVIEW.md` | Three critique rounds |
+
+## EXECUTED (read-only)
+
+- `payments_mode=stripe`
+- Invoice settlement snapshot: 25 / paid 9 / provider_id 9 / amount_paid>0 10
+- Confirmed `stripe_webhook_events`, `public_payment_attempts` present
+
+## Explicit non-claims
+
+No code · no migrations · no deploys · no Stripe API mutations · no PD ratification · no A2 coding.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE6_RESIDUAL_REGISTER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE6_RESIDUAL_REGISTER.md
@@ -1,0 +1,14 @@
+# ML-P1 Slice 6 — Residual Register (planning)
+
+| ID | Severity | Status | Note |
+| --- | --- | --- | --- |
+| R-S6-01 | High | Open (coding) | G-09 / KI-07 — prove sole paid writers; inventory alternate paid mutators |
+| R-S6-02 | Medium | Open (coding) | Dual initiation: Checkout Session vs optional Stripe Invoice in `send-invoice` |
+| R-S6-03 | Medium | Open (coding) | Webhook ignores refunds today — must gain explicit refund path under PD-S6-04 A |
+| R-S6-04 | Medium | Open (coding) | KI-06 job.payment_status vs invoice settlement coherence |
+| R-S6-05 | Low | Open (product) | Partial-pay under-exercised live (`partially_paid`) |
+| R-S6-06 | Info | Closed (planning) | Naming: roadmap S5b → packet S6; follow-up → S7 |
+| R-S6-07 | Info | Open (Founder) | PD-S6-01…07 recommended, not Category-C ratified |
+| R-S5-08 | Low | Carry | Write-off RPC deferred — may touch S6b/admin money if needed |
+
+No residual authorizes auto-charge, vaulting, Terminal, or historical rewrite.

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE6_STATE_LEDGER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE6_STATE_LEDGER.md
@@ -1,0 +1,13 @@
+# ML-P1 Slice 6 — Active State Ledger
+
+| Field | Value |
+| --- | --- |
+| Active slice | **ML-P1-S6** (planning) |
+| Stage | Planning docs → Founder Category-C review |
+| Exact main SHA | `a7e1f63781cca7fcba5d706a7a97bd62a17a4c3b` |
+| Branch | `plan/ml-p1-s6-stripe-settlement` |
+| Migration status | None for S6 |
+| Deploy status | N/A |
+| Open decisions | PD-S6-01…07 recommended; await Founder Category-C |
+| Next Founder auth | Category-C on exact planning head → then coding auth on exact base SHA |
+| Explicitly not started | Implementation · migrations · auto-charge · vault · S7 |

--- a/command-center/docs/stabilization/releases/ML-P1_SLICE6_STATE_LEDGER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE6_STATE_LEDGER.md
@@ -2,12 +2,10 @@
 
 | Field | Value |
 | --- | --- |
-| Active slice | **ML-P1-S6** (planning) |
-| Stage | Planning docs → Founder Category-C review |
-| Exact main SHA | `a7e1f63781cca7fcba5d706a7a97bd62a17a4c3b` |
-| Branch | `plan/ml-p1-s6-stripe-settlement` |
-| Migration status | None for S6 |
-| Deploy status | N/A |
-| Open decisions | PD-S6-01…07 recommended; await Founder Category-C |
-| Next Founder auth | Category-C on exact planning head → then coding auth on exact base SHA |
-| Explicitly not started | Implementation · migrations · auto-charge · vault · S7 |
+| Active slice | **ML-P1-S6** (coding A2) |
+| Stage | SOURCE coding — PR pending merge; **no A3** |
+| Exact coding base | `6b300e40747cfceaf743b264d9f58bf7eede079a` |
+| Branch | `ml/p1-s6-stripe-settlement` |
+| Migration status | SOURCE only (not applied) |
+| Next | Peer reviews + Bugbot → Founder exact-head merge → separate A3 |
+| Halt | Secret rotate · webhook live-attach · auto-charge · portal · QB |

--- a/command-center/docs/stabilization/releases/ML-P1_STATE_LEDGER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_STATE_LEDGER.md
@@ -4,23 +4,22 @@
 | --- | --- |
 | Updated | 2026-07-23 |
 | Repo | https://github.com/faydog127/BHFOS |
-| Current main (deployed) | `2b37985e25f2afbd6ac209982f724aadd4da404d` |
+| Current main | `a7e1f63781cca7fcba5d706a7a97bd62a17a4c3b` |
 | Authority | Founder Delegated-Authority Policy v2026-07-22 |
-| Evidence (price-book) | `260C5CB28EE1A7F5E4E76A488C38749926CDC8435608F83A1B421808E90A4158` |
+| Active planning branch | `plan/ml-p1-s6-stripe-settlement` |
 
 ## Slice / gate posture
 
 | Slice | Gate | Status |
 | --- | --- | --- |
-| S4 | CLOSED ✔ | A3 PASS |
-| Price-book | A2-MERGED ✔ | PR #100 |
-| **S5** | **A3 CLOSED ✔** | PR #101 merged; migrations applied; Hostinger HEALTHY |
-| S6 | NEXT | Stripe settlement — under delegated auth; **no auto-charge** without Major Decision |
+| S5 | A3 CLOSED ✔ | Hostinger HEALTHY @ `2b37985` |
+| **S6** | **Planning** | PD-S6-01…07 recommended; docs PR for Founder Category-C; **no A2** |
+| S7 | Not started | Autonomous follow-up (former roadmap S6) |
 
 ## Waiting on Founder
 
-None for non-major work. Escalate only per Delegated-Authority Policy (pricing ±3%, new customer flows, auto-send/charge ON, destructive migrations, regulatory, money FAIL, cost gates).
+- **Category-C** review/ratification of PD-S6-01…07 (or amendments) before any S6 coding
 
-## Halt / non-scope (until Major Decision or S6 PD)
+## Halt / non-scope
 
-Auto-send · auto-charge · historical financial rewrite · column/table drops · TIS · G2.3 reopen.
+No S6 code/migrations/deploys · no auto-charge · no card vault · no merge-to-coding without Category-C.

--- a/command-center/docs/stabilization/releases/ML-P1_STATE_LEDGER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_STATE_LEDGER.md
@@ -4,22 +4,18 @@
 | --- | --- |
 | Updated | 2026-07-23 |
 | Repo | https://github.com/faydog127/BHFOS |
-| Current main | `a7e1f63781cca7fcba5d706a7a97bd62a17a4c3b` |
-| Authority | Founder Delegated-Authority Policy v2026-07-22 |
-| Active planning branch | `plan/ml-p1-s6-stripe-settlement` |
+| S6 coding base | `6b300e40747cfceaf743b264d9f58bf7eede079a` |
+| Branch | `ml/p1-s6-stripe-settlement` |
+| Authority | Delegated + Category-C coding auth for S6 |
 
 ## Slice / gate posture
 
 | Slice | Gate | Status |
 | --- | --- | --- |
-| S5 | A3 CLOSED ✔ | Hostinger HEALTHY @ `2b37985` |
-| **S6** | **Planning** | PD-S6-01…07 recommended; docs PR for Founder Category-C; **no A2** |
-| S7 | Not started | Autonomous follow-up (former roadmap S6) |
+| S5 | A3 CLOSED ✔ | |
+| **S6** | **A2 coding** | SOURCE on branch; stop before A3 secret/webhook/auto-charge |
+| S7 | Not started | Follow-up |
 
-## Waiting on Founder
+## Halt
 
-- **Category-C** review/ratification of PD-S6-01…07 (or amendments) before any S6 coding
-
-## Halt / non-scope
-
-No S6 code/migrations/deploys · no auto-charge · no card vault · no merge-to-coding without Category-C.
+No prod Stripe secret rotate · no webhook live-attach · no auto-charge enable · no portal · no QB export until separate auth.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S6_CODING_ARCHITECTURE_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S6_CODING_ARCHITECTURE_REVIEW.md
@@ -1,0 +1,6 @@
+# ML-P1 S6 Coding — Round 1 (Architecture)
+
+| Verdict | **APPROVE** (SOURCE-ONLY) |
+| --- | --- |
+| Findings | Runtime flags in `global_config`; writers read without redeploy; Checkout-only; recon queue additive; S5 invoice create untouched. |
+| Residual | Prod apply / Edge redeploy remain A3. |

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S6_CODING_BUGBOT_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S6_CODING_BUGBOT_REVIEW.md
@@ -1,0 +1,27 @@
+# ML-P1 S6 Coding — Bugbot Critique
+
+| Field | Value |
+| --- | --- |
+| Target | `ml/p1-s6-stripe-settlement` uncommitted A2 |
+| Agent | [Bugbot](34936228-d368-46a2-8efa-7af7201b6795) |
+
+## Findings remediated
+
+| Severity | Finding | Fix |
+| --- | --- | --- |
+| High | Offline RPC missing role authz | Role + JWT tenant checks |
+| High | Refund lacking idempotency | `payment_execution_mutations` ledger |
+| High | Refund missing tenant check | JWT tenant vs invoice.tenant_id |
+| High | Recon queue missing RLS | ENABLE RLS + tenant select policy |
+| Medium | Auto-charge flag settable ON | Setter raises `ML_P1_S6_AUTO_CHARGE_DENY` |
+| Medium | Checkout kill-switch fail-open | Fail closed on config read error |
+
+## Accepted residual
+
+| Severity | Finding | Disposition |
+| --- | --- | --- |
+| Medium | Full refund → `sent` allows recollect | **ACCEPT** — intentional (office may collect again after refund; not silent reopen) |
+
+## Verdict
+
+**PASS after remediation** (SOURCE-ONLY)

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S6_CODING_OPS_UX_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S6_CODING_OPS_UX_REVIEW.md
@@ -1,0 +1,6 @@
+# ML-P1 S6 Coding — Round 3 (Ops / UX)
+
+| Verdict | **APPROVE** (SOURCE-ONLY) |
+| --- | --- |
+| Findings | Billing & Payments tab with six labeled flags; recon open list; tech cannot edit settings. |
+| Residual | Office refund Stripe API call still Edge-side for A3; ledger RPC ready. |

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S6_CODING_SECURITY_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S6_CODING_SECURITY_REVIEW.md
@@ -1,0 +1,6 @@
+# ML-P1 S6 Coding — Round 2 (Security / Financial)
+
+| Verdict | **APPROVE** (SOURCE-ONLY + unit EXECUTED) |
+| --- | --- |
+| Findings | Auto-charge default OFF and UI/SQL deny; settings edit office/admin only; refunds require reason; disputes quarantine not silent rewrite; secrets stay Edge env (no rotate in A2). |
+| Residual | Enabling auto_charge flag still cannot charge until separate Major Decision + implementation. |

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S6_PLANNING_ARCHITECTURE_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S6_PLANNING_ARCHITECTURE_REVIEW.md
@@ -1,0 +1,19 @@
+# ML-P1 S6 Planning — Round 3 Review (Architecture)
+
+| Field | Value |
+| --- | --- |
+| Target | Existing spine vs target architecture; scope boundary |
+| Verdict | **APPROVE** |
+
+## Findings
+
+- Architecture findings match EXECUTED live reads and SOURCE inventory (Checkout + webhook + offline RPC).
+- Recommended target reuses spine rather than inventing PaymentIntent/Elements — lower re-work.
+- Clear S5 vs S6 writer boundary (create/issue/void vs settle/refund).
+- Non-scope keeps S7 follow-up and provider sprawl out.
+- Stub `create-payment-intent` correctly treated as non-product.
+
+## Residual
+
+- KI-06 job/invoice payment_status coherence needs an explicit coding acceptance test.
+- Prove webhook idempotency + refund ledger under load in A2/A3, not claimed here.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S6_PLANNING_PRODUCT_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S6_PLANNING_PRODUCT_REVIEW.md
@@ -1,0 +1,18 @@
+# ML-P1 S6 Planning — Round 1 Review (Product)
+
+| Field | Value |
+| --- | --- |
+| Target | Slice 6 planning docs vs main `a7e1f63` |
+| Verdict | **APPROVE** |
+
+## Findings
+
+- Goal matches Founder ask: settlement/posting **without** automatic card charges.
+- PD-S6-01…07 cover linkage, capture, vault, refunds/disputes, state machine, field UX, recon.
+- Naming clash (roadmap S5b vs policy S6) explicitly reconciled; follow-up deferred to S7.
+- Recommended options keep HCP-like pay-link + office offline posting; tech does not take cards.
+- Auto-charge / portal / Terminal correctly flagged as Major Decisions — not smuggled into defaults.
+
+## Residual
+
+Founder Category-C still required before coding; recommendations ≠ ratification.

--- a/command-center/docs/stabilization/releases/reviews/ML-P1_S6_PLANNING_SECURITY_REVIEW.md
+++ b/command-center/docs/stabilization/releases/reviews/ML-P1_S6_PLANNING_SECURITY_REVIEW.md
@@ -1,0 +1,19 @@
+# ML-P1 S6 Planning — Round 2 Review (Security / PCI / Financial Control)
+
+| Field | Value |
+| --- | --- |
+| Target | Secrets, PCI surface, paid-writer integrity, refunds/disputes |
+| Verdict | **APPROVE** |
+
+## Findings
+
+- PD-S6-01 A keeps secrets server-side; no Vite publishable charge path — correct for Checkout-only.
+- PD-S6-03 A avoids card vault / Elements → minimizes PCI SAQ scope creep.
+- PD-S6-05 A + G-09 focus is mandatory; alternate paid writers are the top money-integrity risk.
+- Refunds as office-initiated + dispute quarantine avoids silent webhook money edits.
+- Escalation table correctly binds auto-charge, portal/Terminal, and historical rewrite.
+
+## Residual
+
+- Live `payments_mode=stripe` means misconfigured coding could charge real cards — A2 must keep feature flags / synth gates.
+- Dual Stripe Invoice path in `send-invoice` needs coding inventory (R-S6-02).

--- a/command-center/src/components/crm/settings/BillingPaymentsSettings.jsx
+++ b/command-center/src/components/crm/settings/BillingPaymentsSettings.jsx
@@ -1,0 +1,187 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Loader2, AlertTriangle } from 'lucide-react';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/use-toast';
+import { supabase } from '@/lib/customSupabaseClient';
+import { useAuth } from '@/contexts/SupabaseAuthContext';
+import {
+  ML_P1_S6_PAYMENT_FLAGS,
+  ML_P1_S6_FLAG_DEFAULTS,
+  canEditPaymentSettings,
+} from '@/lib/mlP1S6PaymentSettings';
+import { createMlP1S6PaymentService } from '@/services/mlP1S6PaymentService';
+
+/**
+ * Settings › Billing & Payments — Payment & Invoicing flags (ML-P1 S6).
+ * Runtime flips via global_config; writers read flags without redeploy.
+ */
+export default function BillingPaymentsSettings({ role: roleProp }) {
+  const { toast } = useToast();
+  const { user } = useAuth();
+  const service = useMemo(() => createMlP1S6PaymentService({ supabase }), []);
+  const [flags, setFlags] = useState({ ...ML_P1_S6_FLAG_DEFAULTS });
+  const [recon, setRecon] = useState([]);
+  const [busy, setBusy] = useState(false);
+  const [role, setRole] = useState(roleProp || 'office');
+
+  const canEdit = canEditPaymentSettings(role);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (roleProp) {
+        setRole(roleProp);
+      } else if (user?.id) {
+        const { data } = await supabase
+          .from('app_user_roles')
+          .select('role')
+          .eq('user_id', user.id)
+          .maybeSingle();
+        if (!cancelled && data?.role) setRole(data.role);
+      }
+      try {
+        const [f, q] = await Promise.all([
+          service.getFlags(),
+          service.listReconOpen().catch(() => []),
+        ]);
+        if (!cancelled) {
+          setFlags({ ...ML_P1_S6_FLAG_DEFAULTS, ...f });
+          setRecon(q);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          toast({ variant: 'destructive', title: 'Could not load payment settings', description: err.message });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.id, roleProp, service, toast]);
+
+  const toggle = async (key, next) => {
+    if (!canEdit) {
+      toast({ variant: 'destructive', title: 'Not allowed', description: 'Office or admin role required.' });
+      return;
+    }
+    if (key === 'invoice_auto_charge_enabled' && next === true) {
+      toast({
+        variant: 'destructive',
+        title: 'Auto-charge blocked',
+        description: 'Major Decision required. S6 keeps auto-charge OFF (writers deny).',
+      });
+      return;
+    }
+    setBusy(true);
+    try {
+      const updated = await service.setFlags({ [key]: next });
+      setFlags({ ...ML_P1_S6_FLAG_DEFAULTS, ...updated });
+      toast({ title: 'Saved', description: `${key} → ${next ? 'ON' : 'OFF'}` });
+    } catch (err) {
+      toast({ variant: 'destructive', title: 'Save failed', description: err.message });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold tracking-tight">Billing & Payments</h2>
+        <p className="text-sm text-slate-500">
+          Payment & Invoicing flags (Slice 6). Changes apply at runtime — no redeploy.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Payment & Invoicing</CardTitle>
+          <CardDescription>
+            Single Stripe account · Checkout capture · no card vault. Auto-charge stays OFF by default.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {ML_P1_S6_PAYMENT_FLAGS.map((f) => {
+            const on = Boolean(flags[f.key]);
+            return (
+              <div
+                key={f.key}
+                className="flex items-start justify-between gap-4 rounded-lg border border-slate-200 bg-white p-4"
+              >
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <Label htmlFor={f.key} className="font-semibold cursor-pointer">
+                      {f.label}
+                    </Label>
+                    {!f.defaultValue && (
+                      <Badge variant="outline" className="text-[10px]">
+                        Default OFF
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="text-xs text-slate-500">{f.description}</p>
+                  <div className="text-[10px] font-mono text-slate-400">{f.key}</div>
+                </div>
+                <Switch
+                  id={f.key}
+                  checked={on}
+                  disabled={!canEdit || busy}
+                  onCheckedChange={(checked) => toggle(f.key, checked)}
+                />
+              </div>
+            );
+          })}
+          {!canEdit && (
+            <p className="text-xs text-amber-700 flex items-center gap-2">
+              <AlertTriangle className="h-3.5 w-3.5" />
+              Read-only for your role ({role}). Office/admin can edit.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Reconciliation queue</CardTitle>
+          <CardDescription>Open dispute / unmatched payment quarantines.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {recon.length === 0 ? (
+            <p className="text-sm text-slate-500">No open recon items.</p>
+          ) : (
+            <ul className="space-y-2 text-sm">
+              {recon.map((row) => (
+                <li key={row.id} className="rounded border border-slate-200 px-3 py-2">
+                  <div className="font-medium">{row.event_type}</div>
+                  <div className="text-xs text-slate-500">{row.reason}</div>
+                  <div className="text-[10px] font-mono text-slate-400">{row.provider_payment_id || row.id}</div>
+                </li>
+              ))}
+            </ul>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-3"
+            disabled={busy}
+            onClick={async () => {
+              setBusy(true);
+              try {
+                setRecon(await service.listReconOpen());
+              } finally {
+                setBusy(false);
+              }
+            }}
+          >
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Refresh'}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/command-center/src/lib/mlP1S6PaymentSettings.js
+++ b/command-center/src/lib/mlP1S6PaymentSettings.js
@@ -1,0 +1,52 @@
+/**
+ * ML-P1 Slice 6 — Payment & Invoicing settings (runtime flags).
+ * Defaults: checkout/offline/refunds/recon ON; auto-send/auto-charge OFF.
+ */
+
+export const ML_P1_S6_PAYMENT_FLAGS = [
+  {
+    key: 'stripe_checkout_enabled',
+    label: 'Stripe Checkout pay links',
+    description: 'Allow customer /pay/:token → Stripe Checkout (immediate capture).',
+    defaultValue: true,
+  },
+  {
+    key: 'offline_payments_enabled',
+    label: 'Offline / office record payment',
+    description: 'Allow office to post cash/check/manual payments.',
+    defaultValue: true,
+  },
+  {
+    key: 'refunds_enabled',
+    label: 'Office refunds',
+    description: 'Allow office/admin full or partial refunds with audit.',
+    defaultValue: true,
+  },
+  {
+    key: 'recon_queue_enabled',
+    label: 'Reconciliation / dispute queue',
+    description: 'Quarantine disputes and unmatched payment events for office review.',
+    defaultValue: true,
+  },
+  {
+    key: 'invoice_auto_send_enabled',
+    label: 'Invoice auto-send',
+    description: 'Automatically send invoices to customers (OFF by default; Major Decision to use).',
+    defaultValue: false,
+  },
+  {
+    key: 'invoice_auto_charge_enabled',
+    label: 'Invoice auto-charge',
+    description: 'Automatically charge cards (OFF by default; not implemented in S6 A2).',
+    defaultValue: false,
+  },
+];
+
+export const ML_P1_S6_FLAG_DEFAULTS = Object.fromEntries(
+  ML_P1_S6_PAYMENT_FLAGS.map((f) => [f.key, f.defaultValue]),
+);
+
+export function canEditPaymentSettings(role) {
+  const r = String(role || '').trim().toLowerCase();
+  return ['office', 'manager', 'admin', 'csr'].includes(r);
+}

--- a/command-center/src/pages/crm/Settings.jsx
+++ b/command-center/src/pages/crm/Settings.jsx
@@ -5,6 +5,7 @@ import FeatureFlagManager from '@/components/crm/settings/FeatureFlagManager';
 import SecretsManager from '@/components/crm/settings/SecretsManager';
 import SystemDiagnostics from '@/components/crm/settings/SystemDiagnostics';
 import TrainingDataSettings from '@/components/crm/settings/TrainingDataSettings';
+import BillingPaymentsSettings from '@/components/crm/settings/BillingPaymentsSettings';
 import SYSTEM_VERSION from '@/config/version';
 
 const SettingsPage = () => {
@@ -15,15 +16,19 @@ const SettingsPage = () => {
         <p className="text-slate-500 mt-2">Configuration, security, and feature management.</p>
       </div>
 
-      <Tabs defaultValue="general" className="space-y-6">
-        <TabsList className="grid w-full grid-cols-4 lg:w-[600px]">
+      <Tabs defaultValue="billing" className="space-y-6">
+        <TabsList className="grid w-full grid-cols-5 lg:w-[720px]">
+          <TabsTrigger value="billing">Billing & Payments</TabsTrigger>
           <TabsTrigger value="general">General</TabsTrigger>
           <TabsTrigger value="features">Features</TabsTrigger>
           <TabsTrigger value="secrets">Secrets</TabsTrigger>
           <TabsTrigger value="diagnostics">Diagnostics</TabsTrigger>
         </TabsList>
 
-        {/* GENERAL TAB */}
+        <TabsContent value="billing" className="space-y-6">
+          <BillingPaymentsSettings />
+        </TabsContent>
+
         <TabsContent value="general" className="space-y-6">
           <TrainingDataSettings />
           

--- a/command-center/src/services/mlP1S6PaymentService.js
+++ b/command-center/src/services/mlP1S6PaymentService.js
@@ -1,0 +1,57 @@
+/**
+ * ML-P1 Slice 6 — payment settings + refund / recon client facade.
+ */
+
+const rpcError = (error, fallback) => {
+  const err = new Error(error?.message || fallback);
+  err.code = error?.code || 'ML_P1_S6_RPC_ERROR';
+  throw err;
+};
+
+const newMutationId = () =>
+  typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `s6-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+export function createMlP1S6PaymentService({ supabase } = {}) {
+  if (!supabase) throw new Error('mlP1S6PaymentService requires supabase');
+
+  return {
+    getFlags: async () => {
+      const { data, error } = await supabase.rpc('ml_p1_s6_payment_flags');
+      if (error) rpcError(error, 'Load payment flags failed');
+      return data || {};
+    },
+
+    setFlags: async (flags) => {
+      const { data, error } = await supabase.rpc('ml_p1_s6_set_payment_flags', {
+        p_flags: flags,
+      });
+      if (error) rpcError(error, 'Save payment flags failed');
+      return data;
+    },
+
+    recordRefund: async (invoiceId, amount, reason, { providerRefundId = null, clientMutationId = null } = {}) => {
+      const { data, error } = await supabase.rpc('ml_p1_s6_record_refund', {
+        p_invoice_id: invoiceId,
+        p_amount: amount,
+        p_reason: reason,
+        p_client_mutation_id: clientMutationId || newMutationId(),
+        p_provider_refund_id: providerRefundId,
+      });
+      if (error) rpcError(error, 'Refund failed');
+      return data;
+    },
+
+    listReconOpen: async (limit = 50) => {
+      const { data, error } = await supabase
+        .from('payment_recon_queue')
+        .select('id, invoice_id, event_type, reason, provider_payment_id, status, created_at, payload')
+        .eq('status', 'open')
+        .order('created_at', { ascending: false })
+        .limit(limit);
+      if (error) rpcError(error, 'Load recon queue failed');
+      return data || [];
+    },
+  };
+}

--- a/command-center/supabase/functions/invoice-update-status/index.ts
+++ b/command-center/supabase/functions/invoice-update-status/index.ts
@@ -249,7 +249,7 @@ Deno.serve(async (req) => {
     }
 
     const actorUserId = asString(claims?.sub) || null;
-    const rpcResult = await supabaseAdmin.rpc('record_offline_manual_payment', {
+    const rpcResult = await supabaseAdmin.rpc('ml_p1_s6_record_offline_manual_payment', {
       p_tenant_id: jwtTenantId,
       p_invoice_id: invoiceId,
       p_amount: paymentAmount,

--- a/command-center/supabase/functions/payment-webhook/index.ts
+++ b/command-center/supabase/functions/payment-webhook/index.ts
@@ -79,7 +79,63 @@ Deno.serve(async (req) => {
   const REVERSAL_EVENTS = new Set(['charge.refunded', 'charge.refund.updated', 'payment_intent.canceled']);
 
   if (REVERSAL_EVENTS.has(event.type)) {
-    return respondJson({ received: true, ignored: 'reversal_not_supported' }, 200);
+    // PD-S6-04: refunds/disputes → quarantine (no silent money rewrite from webhook alone)
+    await supabaseAdmin.rpc('ml_p1_s6_enqueue_recon', {
+      p_event_type: event.type,
+      p_reason: 'reversal_or_refund_event',
+      p_provider_event_id: event.id,
+      p_provider_payment_id: providerPaymentId,
+      p_invoice_id: invoiceIdFromMetadata,
+      p_tenant_id: null,
+      p_payload: event as unknown as Record<string, unknown>,
+    }).catch(() => null);
+
+    await createMoneyLoopTask({
+      tenantId: null,
+      sourceType: invoiceIdFromMetadata ? 'invoice' : 'webhook',
+      sourceId: invoiceIdFromMetadata ? String(invoiceIdFromMetadata) : String(providerPaymentId),
+      title: 'Payment Reversal / Refund — Reconcile',
+      leadId: null,
+      metadata: {
+        provider: 'stripe',
+        provider_payment_id: providerPaymentId,
+        gateway_event_id: event.id,
+        event_type: event.type,
+        slice: 'ml-p1-s6',
+      },
+    });
+
+    return respondJson({ received: true, quarantined: true, reason: 'reversal_queued' }, 200);
+  }
+
+  // Dispute events (PD-S6-04)
+  if (String(event.type || '').startsWith('charge.dispute')) {
+    await supabaseAdmin.rpc('ml_p1_s6_enqueue_recon', {
+      p_event_type: event.type,
+      p_reason: 'dispute_quarantine',
+      p_provider_event_id: event.id,
+      p_provider_payment_id: providerPaymentId,
+      p_invoice_id: invoiceIdFromMetadata,
+      p_tenant_id: null,
+      p_payload: event as unknown as Record<string, unknown>,
+    }).catch(() => null);
+
+    await createMoneyLoopTask({
+      tenantId: null,
+      sourceType: invoiceIdFromMetadata ? 'invoice' : 'webhook',
+      sourceId: invoiceIdFromMetadata ? String(invoiceIdFromMetadata) : String(providerPaymentId),
+      title: 'Stripe Dispute — Quarantine',
+      leadId: null,
+      metadata: {
+        provider: 'stripe',
+        provider_payment_id: providerPaymentId,
+        gateway_event_id: event.id,
+        event_type: event.type,
+        slice: 'ml-p1-s6',
+      },
+    });
+
+    return respondJson({ received: true, quarantined: true, reason: 'dispute_queued' }, 200);
   }
 
   if (!FINAL_SUCCESS_EVENTS.has(event.type) && !NON_FINAL_EVENTS.has(event.type)) {

--- a/command-center/supabase/functions/public-pay/index.ts
+++ b/command-center/supabase/functions/public-pay/index.ts
@@ -261,6 +261,7 @@ Deno.serve(async (req) => {
   }
 
   let paymentsMode: string | null = null;
+  let stripeCheckoutEnabled: boolean | null = null;
   try {
     const { data: modeRow } = await supabaseAdmin
       .from('global_config')
@@ -270,6 +271,43 @@ Deno.serve(async (req) => {
     paymentsMode = typeof modeRow?.value === 'string' ? modeRow.value.trim().toLowerCase() : null;
   } catch (err) {
     console.error('Failed to read payments_mode:', formatError(err));
+  }
+
+  try {
+    const { data: flagRow, error: flagErr } = await supabaseAdmin
+      .from('global_config')
+      .select('value')
+      .eq('key', 'payment_invoicing.stripe_checkout_enabled')
+      .maybeSingle();
+    if (flagErr) {
+      return respondJson(
+        { error: 'ML_P1_S6_CHECKOUT_CONFIG_UNAVAILABLE: cannot verify Checkout setting' },
+        503,
+        cors.headers,
+      );
+    }
+    if (flagRow == null) {
+      stripeCheckoutEnabled = true; // seeded default when row not yet migrated
+    } else if (typeof flagRow.value === 'string') {
+      stripeCheckoutEnabled = /^(true|1|yes|on)$/i.test(flagRow.value.trim());
+    } else {
+      stripeCheckoutEnabled = false;
+    }
+  } catch (err) {
+    console.error('Failed to read stripe_checkout_enabled:', formatError(err));
+    return respondJson(
+      { error: 'ML_P1_S6_CHECKOUT_CONFIG_UNAVAILABLE: cannot verify Checkout setting' },
+      503,
+      cors.headers,
+    );
+  }
+
+  if (stripeCheckoutEnabled !== true) {
+    return respondJson(
+      { error: 'ML_P1_S6_CHECKOUT_OFF: Stripe Checkout pay links are disabled in Billing & Payments settings.' },
+      403,
+      cors.headers,
+    );
   }
 
   if (paymentsMode && paymentsMode.startsWith('stripe')) {

--- a/command-center/supabase/migrations/20260723140000_ml_p1_s6_payment_settings.sql
+++ b/command-center/supabase/migrations/20260723140000_ml_p1_s6_payment_settings.sql
@@ -1,0 +1,399 @@
+-- ML-P1 Slice 6 — Payment & Invoicing settings + settlement helpers (SOURCE)
+-- PD-S6-01..07. Do not rotate prod Stripe secrets / live-attach webhooks in this PR (A3).
+
+-- Six flags (Payment & Invoicing group; auto-charge/auto-send default OFF)
+INSERT INTO public.global_config (key, value) VALUES
+  ('payment_invoicing.stripe_checkout_enabled', 'true'),
+  ('payment_invoicing.offline_payments_enabled', 'true'),
+  ('payment_invoicing.refunds_enabled', 'true'),
+  ('payment_invoicing.recon_queue_enabled', 'true'),
+  ('payment_invoicing.invoice_auto_send_enabled', 'false'),
+  ('payment_invoicing.invoice_auto_charge_enabled', 'false')
+ON CONFLICT (key) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s6_payment_flag(p_key text)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_raw text;
+  v_default boolean;
+BEGIN
+  v_default := CASE lower(coalesce(p_key, ''))
+    WHEN 'stripe_checkout_enabled' THEN true
+    WHEN 'offline_payments_enabled' THEN true
+    WHEN 'refunds_enabled' THEN true
+    WHEN 'recon_queue_enabled' THEN true
+    WHEN 'invoice_auto_send_enabled' THEN false
+    WHEN 'invoice_auto_charge_enabled' THEN false
+    ELSE false
+  END;
+
+  SELECT value INTO v_raw
+  FROM public.global_config
+  WHERE key = 'payment_invoicing.' || p_key
+  LIMIT 1;
+
+  IF v_raw IS NULL THEN
+    RETURN v_default;
+  END IF;
+  RETURN lower(btrim(v_raw)) IN ('true', '1', 'yes', 'on');
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s6_payment_flags()
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'stripe_checkout_enabled', public.ml_p1_s6_payment_flag('stripe_checkout_enabled'),
+    'offline_payments_enabled', public.ml_p1_s6_payment_flag('offline_payments_enabled'),
+    'refunds_enabled', public.ml_p1_s6_payment_flag('refunds_enabled'),
+    'recon_queue_enabled', public.ml_p1_s6_payment_flag('recon_queue_enabled'),
+    'invoice_auto_send_enabled', public.ml_p1_s6_payment_flag('invoice_auto_send_enabled'),
+    'invoice_auto_charge_enabled', public.ml_p1_s6_payment_flag('invoice_auto_charge_enabled')
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s6_assert_payment_flag(p_key text, p_code text DEFAULT NULL)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT public.ml_p1_s6_payment_flag(p_key) THEN
+    RAISE EXCEPTION '%', coalesce(nullif(btrim(p_code), ''), 'ML_P1_S6_SETTING_OFF:' || p_key)
+      USING ERRCODE = 'P0001';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s6_assert_auto_charge_off()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- A2: auto-charge path not implemented; always deny even if flag flipped.
+  RAISE EXCEPTION 'ML_P1_S6_AUTO_CHARGE_DENY: auto-charge not enabled for this slice'
+    USING ERRCODE = 'P0001';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s6_set_payment_flags(p_flags jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role text := public.ml_p1_s2_current_actor_role();
+  v_key text;
+  v_val boolean;
+  v_allowed text[] := ARRAY[
+    'stripe_checkout_enabled',
+    'offline_payments_enabled',
+    'refunds_enabled',
+    'recon_queue_enabled',
+    'invoice_auto_send_enabled',
+    'invoice_auto_charge_enabled'
+  ];
+BEGIN
+  IF lower(coalesce(v_role, '')) NOT IN ('office', 'manager', 'admin', 'csr') THEN
+    RAISE EXCEPTION 'ML_P1_S6_ROLE_DENY' USING ERRCODE = 'P0001';
+  END IF;
+  IF p_flags IS NULL OR jsonb_typeof(p_flags) <> 'object' THEN
+    RAISE EXCEPTION 'ML_P1_S6_FLAGS_REQUIRED' USING ERRCODE = 'P0001';
+  END IF;
+
+  FOREACH v_key IN ARRAY v_allowed LOOP
+    IF p_flags ? v_key THEN
+      v_val := CASE
+        WHEN jsonb_typeof(p_flags -> v_key) = 'boolean' THEN (p_flags ->> v_key)::boolean
+        ELSE lower(coalesce(p_flags ->> v_key, '')) IN ('true', '1', 'yes', 'on')
+      END;
+      -- Major Decision gate: refuse persisting auto-charge ON in S6 A2
+      IF v_key = 'invoice_auto_charge_enabled' AND v_val IS TRUE THEN
+        RAISE EXCEPTION 'ML_P1_S6_AUTO_CHARGE_DENY: cannot enable auto-charge without Founder Major Decision'
+          USING ERRCODE = 'P0001';
+      END IF;
+      INSERT INTO public.global_config (key, value, updated_at)
+      VALUES ('payment_invoicing.' || v_key, CASE WHEN v_val THEN 'true' ELSE 'false' END, now())
+      ON CONFLICT (key) DO UPDATE
+        SET value = EXCLUDED.value, updated_at = now();
+    END IF;
+  END LOOP;
+
+  RETURN public.ml_p1_s6_payment_flags();
+END;
+$$;
+
+CREATE TABLE IF NOT EXISTS public.payment_recon_queue (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id text,
+  invoice_id uuid REFERENCES public.invoices(id) ON DELETE SET NULL,
+  provider text NOT NULL DEFAULT 'stripe',
+  provider_event_id text,
+  provider_payment_id text,
+  event_type text NOT NULL,
+  reason text NOT NULL,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  status text NOT NULL DEFAULT 'open',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  resolved_at timestamptz,
+  resolved_by uuid,
+  CONSTRAINT payment_recon_queue_status_check CHECK (status IN ('open', 'resolved', 'ignored'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS payment_recon_queue_event_uq
+  ON public.payment_recon_queue (provider, provider_event_id)
+  WHERE provider_event_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS payment_recon_queue_open_idx
+  ON public.payment_recon_queue (status, created_at DESC);
+
+ALTER TABLE public.payment_recon_queue ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS payment_recon_queue_tenant_select ON public.payment_recon_queue;
+CREATE POLICY payment_recon_queue_tenant_select
+  ON public.payment_recon_queue FOR SELECT TO authenticated
+  USING (
+    tenant_id IS NOT DISTINCT FROM (auth.jwt() -> 'app_metadata' ->> 'tenant_id')
+    OR lower(coalesce(public.ml_p1_s2_current_actor_role(), '')) = 'admin'
+  );
+
+DROP POLICY IF EXISTS payment_recon_queue_service_all ON public.payment_recon_queue;
+CREATE POLICY payment_recon_queue_service_all
+  ON public.payment_recon_queue FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+CREATE TABLE IF NOT EXISTS public.payment_execution_mutations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  invoice_id uuid NOT NULL REFERENCES public.invoices(id) ON DELETE CASCADE,
+  client_mutation_id text NOT NULL,
+  action text NOT NULL,
+  actor_user_id uuid,
+  actor_role text,
+  result jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT payment_execution_mutations_uq UNIQUE (invoice_id, client_mutation_id)
+);
+
+ALTER TABLE public.payment_execution_mutations ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS payment_execution_mutations_deny_client ON public.payment_execution_mutations;
+CREATE POLICY payment_execution_mutations_deny_client
+  ON public.payment_execution_mutations FOR ALL TO authenticated
+  USING (false) WITH CHECK (false);
+DROP POLICY IF EXISTS payment_execution_mutations_service ON public.payment_execution_mutations;
+CREATE POLICY payment_execution_mutations_service
+  ON public.payment_execution_mutations FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s6_enqueue_recon(
+  p_event_type text,
+  p_reason text,
+  p_provider_event_id text DEFAULT NULL,
+  p_provider_payment_id text DEFAULT NULL,
+  p_invoice_id uuid DEFAULT NULL,
+  p_tenant_id text DEFAULT NULL,
+  p_payload jsonb DEFAULT '{}'::jsonb
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_id uuid;
+BEGIN
+  IF NOT public.ml_p1_s6_payment_flag('recon_queue_enabled') THEN
+    RETURN NULL;
+  END IF;
+
+  BEGIN
+    INSERT INTO public.payment_recon_queue (
+      tenant_id, invoice_id, provider_event_id, provider_payment_id, event_type, reason, payload
+    ) VALUES (
+      p_tenant_id, p_invoice_id, p_provider_event_id, p_provider_payment_id,
+      coalesce(p_event_type, 'unknown'), coalesce(p_reason, 'unspecified'), coalesce(p_payload, '{}'::jsonb)
+    )
+    RETURNING id INTO v_id;
+  EXCEPTION
+    WHEN unique_violation THEN
+      SELECT id INTO v_id FROM public.payment_recon_queue
+      WHERE provider = 'stripe' AND provider_event_id IS NOT DISTINCT FROM p_provider_event_id
+      LIMIT 1;
+  END;
+
+  RETURN v_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s6_record_offline_manual_payment(
+  p_tenant_id text,
+  p_invoice_id uuid,
+  p_amount numeric,
+  p_payment_method text,
+  p_manual_reference_raw text,
+  p_actor_user_id uuid,
+  p_request_id text DEFAULT NULL
+)
+RETURNS TABLE (
+  ok boolean,
+  duplicate boolean,
+  transaction_id uuid,
+  payment_attempt_id uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role text := public.ml_p1_s2_current_actor_role();
+  v_jwt_tenant text := nullif(btrim(coalesce(auth.jwt() -> 'app_metadata' ->> 'tenant_id', '')), '');
+  v_is_service boolean := coalesce(auth.role(), '') = 'service_role';
+BEGIN
+  PERFORM public.ml_p1_s6_assert_payment_flag('offline_payments_enabled', 'ML_P1_S6_OFFLINE_PAYMENTS_OFF');
+  IF NOT v_is_service AND lower(coalesce(v_role, '')) NOT IN ('office', 'manager', 'admin', 'csr') THEN
+    RAISE EXCEPTION 'ML_P1_S6_ROLE_DENY' USING ERRCODE = 'P0001';
+  END IF;
+  IF NOT v_is_service AND v_jwt_tenant IS NOT NULL AND p_tenant_id IS DISTINCT FROM v_jwt_tenant THEN
+    RAISE EXCEPTION 'ML_P1_S6_TENANT_DENY' USING ERRCODE = 'P0001';
+  END IF;
+  RETURN QUERY
+  SELECT * FROM public.record_offline_manual_payment(
+    p_tenant_id, p_invoice_id, p_amount, p_payment_method,
+    p_manual_reference_raw, p_actor_user_id, p_request_id
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ml_p1_s6_record_refund(
+  p_invoice_id uuid,
+  p_amount numeric,
+  p_reason text,
+  p_client_mutation_id text,
+  p_provider_refund_id text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role text := public.ml_p1_s2_current_actor_role();
+  v_jwt_tenant text := nullif(btrim(coalesce(auth.jwt() -> 'app_metadata' ->> 'tenant_id', '')), '');
+  v_is_service boolean := coalesce(auth.role(), '') = 'service_role';
+  v_inv public.invoices%ROWTYPE;
+  v_mut text := nullif(btrim(coalesce(p_client_mutation_id, '')), '');
+  v_prior public.payment_execution_mutations%ROWTYPE;
+  v_amount numeric;
+  v_new_paid numeric;
+  v_status text;
+  v_result jsonb;
+BEGIN
+  PERFORM public.ml_p1_s6_assert_payment_flag('refunds_enabled', 'ML_P1_S6_REFUNDS_OFF');
+  IF NOT v_is_service AND lower(coalesce(v_role, '')) NOT IN ('office', 'manager', 'admin', 'csr') THEN
+    RAISE EXCEPTION 'ML_P1_S6_ROLE_DENY' USING ERRCODE = 'P0001';
+  END IF;
+  IF v_mut IS NULL THEN
+    RAISE EXCEPTION 'ML_P1_S6_MUTATION_ID_REQUIRED' USING ERRCODE = 'P0001';
+  END IF;
+  IF p_amount IS NULL OR p_amount <= 0 OR p_amount <> round(p_amount, 2) THEN
+    RAISE EXCEPTION 'ML_P1_S6_REFUND_AMOUNT_INVALID' USING ERRCODE = 'P0001';
+  END IF;
+  IF nullif(btrim(coalesce(p_reason, '')), '') IS NULL THEN
+    RAISE EXCEPTION 'ML_P1_S6_REFUND_REASON_REQUIRED' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT * INTO v_prior
+  FROM public.payment_execution_mutations
+  WHERE invoice_id = p_invoice_id AND client_mutation_id = v_mut;
+  IF FOUND THEN
+    RETURN v_prior.result;
+  END IF;
+
+  SELECT * INTO v_inv FROM public.invoices WHERE id = p_invoice_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ML_P1_S6_INVOICE_NOT_FOUND' USING ERRCODE = 'P0001';
+  END IF;
+  IF NOT v_is_service AND v_jwt_tenant IS NOT NULL AND v_inv.tenant_id IS DISTINCT FROM v_jwt_tenant THEN
+    RAISE EXCEPTION 'ML_P1_S6_TENANT_DENY' USING ERRCODE = 'P0001';
+  END IF;
+  IF coalesce(v_inv.amount_paid, 0) <= 0 THEN
+    RAISE EXCEPTION 'ML_P1_S6_NOTHING_TO_REFUND' USING ERRCODE = 'P0001';
+  END IF;
+
+  v_amount := least(p_amount, coalesce(v_inv.amount_paid, 0));
+  v_new_paid := public.ml_p1_s5_round_money(coalesce(v_inv.amount_paid, 0) - v_amount);
+  -- Full refund returns invoice to Issued/sent so office may collect again intentionally (not a silent reopen bug).
+  IF v_new_paid <= 0 THEN
+    v_status := 'sent';
+    v_new_paid := 0;
+  ELSIF v_new_paid < coalesce(v_inv.total_amount, 0) THEN
+    v_status := 'partially_paid';
+  ELSE
+    v_status := lower(coalesce(v_inv.status, 'paid'));
+  END IF;
+
+  UPDATE public.invoices SET
+    amount_paid = v_new_paid,
+    balance_due = public.ml_p1_s5_round_money(coalesce(total_amount, 0) - v_new_paid),
+    status = v_status,
+    paid_at = CASE WHEN v_new_paid <= 0 THEN NULL ELSE paid_at END,
+    updated_at = now()
+  WHERE id = p_invoice_id
+  RETURNING * INTO v_inv;
+
+  v_result := jsonb_build_object(
+    'invoice_id', v_inv.id,
+    'status', v_inv.status,
+    'amount_refunded', v_amount,
+    'amount_paid', v_inv.amount_paid,
+    'balance_due', v_inv.balance_due,
+    'display_status', CASE WHEN v_inv.status = 'sent' THEN 'Issued' ELSE v_inv.status END
+  );
+
+  INSERT INTO public.payment_execution_mutations (
+    invoice_id, client_mutation_id, action, actor_user_id, actor_role, result
+  ) VALUES (
+    p_invoice_id, v_mut, 'refund', auth.uid(), v_role, v_result
+  );
+
+  PERFORM public.ml_p1_s6_enqueue_recon(
+    'office_refund',
+    p_reason,
+    v_mut,
+    p_provider_refund_id,
+    p_invoice_id,
+    v_inv.tenant_id,
+    jsonb_build_object(
+      'amount', v_amount,
+      'client_mutation_id', v_mut,
+      'actor_role', v_role,
+      'provider_refund_id', p_provider_refund_id
+    )
+  );
+
+  RETURN v_result;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.ml_p1_s6_payment_flag(text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ml_p1_s6_payment_flags() TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ml_p1_s6_set_payment_flags(jsonb) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ml_p1_s6_assert_payment_flag(text, text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ml_p1_s6_enqueue_recon(text, text, text, text, uuid, text, jsonb) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ml_p1_s6_record_offline_manual_payment(text, uuid, numeric, text, text, uuid, text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ml_p1_s6_record_refund(uuid, numeric, text, text, text) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.ml_p1_s6_payment_flags() IS 'ML-P1 S6 Payment & Invoicing flags (runtime; no redeploy to flip)';
+COMMENT ON TABLE public.payment_recon_queue IS 'ML-P1 S6 dispute/refund/recon quarantine queue';

--- a/command-center/tests/unit/ml-p1-s6-payment.test.mjs
+++ b/command-center/tests/unit/ml-p1-s6-payment.test.mjs
@@ -1,0 +1,110 @@
+/**
+ * ML-P1 Slice 6 — source guards + settings authz (SOURCE/unit).
+ * Run: node --test tests/unit/ml-p1-s6-payment.test.mjs
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  ML_P1_S6_PAYMENT_FLAGS,
+  ML_P1_S6_FLAG_DEFAULTS,
+  canEditPaymentSettings,
+} from '../../src/lib/mlP1S6PaymentSettings.js';
+import { createMlP1S6PaymentService } from '../../src/services/mlP1S6PaymentService.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(__dirname, '../..');
+const read = (rel) => fs.readFileSync(path.join(root, rel), 'utf8');
+
+describe('ML-P1 S6 Payment & Invoicing flags', () => {
+  it('defines exactly six flags with auto-charge/auto-send default OFF', () => {
+    assert.equal(ML_P1_S6_PAYMENT_FLAGS.length, 6);
+    assert.equal(ML_P1_S6_FLAG_DEFAULTS.invoice_auto_charge_enabled, false);
+    assert.equal(ML_P1_S6_FLAG_DEFAULTS.invoice_auto_send_enabled, false);
+    assert.equal(ML_P1_S6_FLAG_DEFAULTS.stripe_checkout_enabled, true);
+    assert.equal(ML_P1_S6_FLAG_DEFAULTS.offline_payments_enabled, true);
+    assert.equal(ML_P1_S6_FLAG_DEFAULTS.refunds_enabled, true);
+    assert.equal(ML_P1_S6_FLAG_DEFAULTS.recon_queue_enabled, true);
+  });
+
+  it('office/admin can edit; technician cannot', () => {
+    assert.equal(canEditPaymentSettings('office'), true);
+    assert.equal(canEditPaymentSettings('admin'), true);
+    assert.equal(canEditPaymentSettings('technician'), false);
+  });
+});
+
+describe('ML-P1 S6 migration source guards', () => {
+  const mig = read('supabase/migrations/20260723140000_ml_p1_s6_payment_settings.sql');
+
+  it('seeds six payment_invoicing keys and runtime RPCs', () => {
+    assert.match(mig, /payment_invoicing\.stripe_checkout_enabled/);
+    assert.match(mig, /payment_invoicing\.invoice_auto_charge_enabled',\s*'false'/);
+    assert.match(mig, /ml_p1_s6_payment_flags/);
+    assert.match(mig, /ml_p1_s6_set_payment_flags/);
+    assert.match(mig, /ml_p1_s6_record_offline_manual_payment/);
+    assert.match(mig, /ml_p1_s6_record_refund/);
+    assert.match(mig, /payment_recon_queue/);
+    assert.match(mig, /ML_P1_S6_AUTO_CHARGE_DENY/);
+    assert.match(mig, /ML_P1_S6_TENANT_DENY/);
+    assert.match(mig, /payment_execution_mutations/);
+    assert.match(mig, /ENABLE ROW LEVEL SECURITY/);
+  });
+});
+
+describe('ML-P1 S6 edge gates', () => {
+  const pay = read('supabase/functions/public-pay/index.ts');
+  const webhook = read('supabase/functions/payment-webhook/index.ts');
+  const invoiceStatus = read('supabase/functions/invoice-update-status/index.ts');
+  const settingsUi = read('src/pages/crm/Settings.jsx');
+  const billing = read('src/components/crm/settings/BillingPaymentsSettings.jsx');
+
+  it('public-pay checks stripe_checkout_enabled', () => {
+    assert.match(pay, /payment_invoicing\.stripe_checkout_enabled/);
+    assert.match(pay, /ML_P1_S6_CHECKOUT_OFF/);
+  });
+
+  it('webhook quarantines refunds and disputes', () => {
+    assert.match(webhook, /ml_p1_s6_enqueue_recon/);
+    assert.match(webhook, /dispute_quarantine/);
+    assert.match(webhook, /reversal_queued/);
+  });
+
+  it('offline payments use S6 gated wrapper', () => {
+    assert.match(invoiceStatus, /ml_p1_s6_record_offline_manual_payment/);
+  });
+
+  it('Settings exposes Billing & Payments page', () => {
+    assert.match(settingsUi, /Billing & Payments/);
+    assert.match(settingsUi, /BillingPaymentsSettings/);
+    assert.match(billing, /Auto-charge blocked/);
+  });
+});
+
+describe('ML-P1 S6 client service', () => {
+  it('calls settings RPCs only', async () => {
+    const calls = [];
+    const supabase = {
+      rpc: async (name, args) => {
+        calls.push({ name, args });
+        return { data: { stripe_checkout_enabled: true }, error: null };
+      },
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            order: () => ({
+              limit: async () => ({ data: [], error: null }),
+            }),
+          }),
+        }),
+      }),
+    };
+    const svc = createMlP1S6PaymentService({ supabase });
+    await svc.getFlags();
+    await svc.setFlags({ refunds_enabled: false });
+    assert.equal(calls[0].name, 'ml_p1_s6_payment_flags');
+    assert.equal(calls[1].name, 'ml_p1_s6_set_payment_flags');
+  });
+});


### PR DESCRIPTION
## Summary
- Implements PD-S6-01..07 (recommended) as SOURCE: runtime Payment & Invoicing **six flags**, Settings › Billing & Payments UI, Checkout/offline gates, refund RPC + dispute/refund recon queue.
- Auto-charge/auto-send **default OFF**; setter + UI refuse enabling auto-charge.
- Three coding peer reviews + Bugbot (findings remediated).

## Six flags
1. `stripe_checkout_enabled` (ON)
2. `offline_payments_enabled` (ON)
3. `refunds_enabled` (ON)
4. `recon_queue_enabled` (ON)
5. `invoice_auto_send_enabled` (OFF)
6. `invoice_auto_charge_enabled` (OFF)

## Stopped (not in this PR)
- Prod Stripe secret rotate / webhook live-attach (A3)
- Auto-charge enable
- Saved-card / portal
- QuickBooks export

## Test plan
- [x] `node --test tests/unit/ml-p1-s6-payment.test.mjs` (8/8)
- [ ] CI green
- [ ] Founder exact-head merge approval
- [ ] A3 later: apply migration + Edge deploy + test-Stripe synth

Made with [Cursor](https://cursor.com)