### PR TITLE
docs(ml-p1-s8): pin A3 closeout Hostinger tip

### DIFF
--- a/command-center/docs/stabilization/releases/ML-P1_SLICE8_REMEDIATION_A3_CLOSEOUT.md
+++ b/command-center/docs/stabilization/releases/ML-P1_SLICE8_REMEDIATION_A3_CLOSEOUT.md
@@ -7,7 +7,7 @@
 | Merge commit | `98cdee15c09ed5511f16cff9ea116cab052c92f8` |
 | Migration `20260723200000` | **APPLIED** · SHA-256 `7EBAB73E39F48B8B6A4058C476456A2751A15C08DE3DF15369E157E1A5349CBE` |
 | Hotfix `20260723201000` | **APPLIED** · SHA-256 `3B7F975AB64EB121D17896A800FB9E0796CE1403636429F7E6AF4CC54828DEC4` |
-| Hostinger | **HEALTHY** @ `98cdee15c09ed5511f16cff9ea116cab052c92f8` · `migrationVersion=20260723200000` (UI tip; DB includes `201000`) |
+| Hostinger | **HEALTHY** @ `fcc1fccf0388fc896e29e13f0b6261265f60e9d5` · `migrationVersion=20260723201000` |
 | Project | `wwyxohjnyqnegzbxtuxs` |
 
 ## Hotfix note (auth integrity)


### PR DESCRIPTION
Pins SLICE8 A3 closeout Hostinger identity to `fcc1fcc` / migrationVersion `20260723201000` after closeout redeploy.

Made with [Cursor](https://cursor.com)