### PR TITLE
docs(ux-refactor): Hostinger A3 deploy closeout

### DIFF
--- a/command-center/docs/governance/RELEASE_BATON.ux-refactor.yaml
+++ b/command-center/docs/governance/RELEASE_BATON.ux-refactor.yaml
@@ -3,14 +3,17 @@
 # No DB migrations. Peer review + auto-continue per ML-P1 Delegated-Authority.
 
 release_id: "UX-REFACTOR"
-current_phase: "a2_merged"
+current_phase: "a3_deployed"
 governance_version: "v2.2"
 risk_tier: "Tier 2"
-status: "merged_awaiting_deploy_auth"
+status: "production_deploy_pass"
 schedule: "parallel"
 db_migrations: "forbidden"
 current_owner: "Orchestrator"
-base_sha: "14301fc2b1d5e15b5f664a69613ff2370a91de1d"
+base_sha: "c469f7c8174642f40ca60756c124dec63a80bb10"
+deployed_sha: "c469f7c8174642f40ca60756c124dec63a80bb10"
+rollback_point: "fcc1fccf0388fc896e29e13f0b6261265f60e9d5"
+hostinger_closeout_path: "command-center/docs/stabilization/releases/UX_REFACTOR_A3_HOSTINGER_CLOSEOUT.md"
 planning_base_sha: "a12b0f4502fe668a900381753128e9e4724cd844"
 planning_merge: "PR #114 → 67423d2468c647cac17c8afc766c1bc86ff42e2d"
 a2_merge: "PR #115 → 14301fc2b1d5e15b5f664a69613ff2370a91de1d"
@@ -45,7 +48,7 @@ merge_authorization_planning: "merged PR #114"
 merge_authorization_a2: "merged PR #115 after peer APPROVE ×3 + CI green"
 implementation_authorization: "auto-continue after planning merge + PD-UX defaults A"
 migration_authorization: "none — forbidden"
-deployment_authorization: "none — separate Access Matrix S / Founder auth for Hostinger"
+deployment_authorization: "granted — Founder 2026-07-23 Hostinger UX-REFACTOR A3 @ c469f7c; HEALTHY; rollback fcc1fcc"
 
 out_of_scope:
   - photo_bundles
@@ -54,5 +57,5 @@ out_of_scope:
   - supabase_migrations
   - tis_merge
 
-next_phase: "Await Founder / Access Matrix S for Hostinger deploy of UX-REFACTOR A2; residuals remain non-blocking"
-next_owner: "Founder (deploy gate)"
+next_phase: "Idle — UX-REFACTOR production chrome live; residuals non-blocking; no migrations"
+next_owner: "Orchestrator"

--- a/command-center/docs/governance/state/ML-P1_STATE_LEDGER.md
+++ b/command-center/docs/governance/state/ML-P1_STATE_LEDGER.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | Updated | 2026-07-23 |
 | Repo | https://github.com/faydog127/BHFOS |
-| Exact `origin/main` | `14301fc2b1d5e15b5f664a69613ff2370a91de1d` (A2 #115) |
+| Exact `origin/main` / prod | `c469f7c8174642f40ca60756c124dec63a80bb10` (UX Hostinger) |
 | Authority | Precedence + Delegated-Authority auto-continue |
 
 ## Slice posture
@@ -15,7 +15,7 @@
 | **S6** | **CLOSED** — `SLICE6_PRODUCTION_VALIDATION_PASS` |
 | **S7** | **Deferred** — do not start |
 | **S8** | **SLICE8_PRODUCTION_VALIDATION_PASS** (remediation) |
-| **UX-REFACTOR** | **A2 MERGED** — parallel · no DB migrations · await Hostinger Access Matrix **S** |
+| **UX-REFACTOR** | **PRODUCTION DEPLOY PASS** — Hostinger HEALTHY @ `c469f7c` · rollback `fcc1fcc` |
 | Photo Bundles | **Deferred** |
 
 ## UX-REFACTOR entry

--- a/command-center/docs/stabilization/releases/ML-P1_STATE_LEDGER.md
+++ b/command-center/docs/stabilization/releases/ML-P1_STATE_LEDGER.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | Updated | 2026-07-23 |
 | Repo | https://github.com/faydog127/BHFOS |
-| Current main | `14301fc2b1d5e15b5f664a69613ff2370a91de1d` (UX A2 #115) |
+| Current main / prod | `c469f7c8174642f40ca60756c124dec63a80bb10` (UX Hostinger) |
 | Canonical governance copy | `docs/governance/state/ML-P1_STATE_LEDGER.md` |
 
 ## Slice / gate posture
@@ -15,12 +15,12 @@
 | **S6** | PRODUCTION VALIDATION PASS ✔ | Idle / closed |
 | **S7** | Deferred | Do not start |
 | **S8** | Remediation A3 | **SLICE8_PRODUCTION_VALIDATION_PASS** |
-| **UX-REFACTOR** | A2 merged | Parallel · no migrations · await Hostinger **S** |
+| **UX-REFACTOR** | **PRODUCTION DEPLOY PASS** | Hostinger HEALTHY @ `c469f7c` · rollback `fcc1fcc` |
 | Photo Bundles | Deferred | Do not start |
 
 ## Waiting on
 
-Founder / Access Matrix **S** authorization to deploy UX-REFACTOR A2 to Hostinger.
+Nothing for UX-REFACTOR (deployed). Photo Bundles / S7 remain deferred.
 
 ## Halt defaults
 

--- a/command-center/docs/stabilization/releases/UX_REFACTOR_A3_HOSTINGER_CLOSEOUT.md
+++ b/command-center/docs/stabilization/releases/UX_REFACTOR_A3_HOSTINGER_CLOSEOUT.md
@@ -1,0 +1,43 @@
+# UX-REFACTOR A3 — Hostinger production deploy closeout
+
+| Field | Value |
+| --- | --- |
+| Slice | UX-REFACTOR |
+| Gate | A3 Hostinger deploy |
+| Disposition | **UX_REFACTOR_PRODUCTION_DEPLOY_PASS** |
+| Authorized | Founder 2026-07-23 — Hostinger only; no DB migrations; no Stripe/auto-charge; no S7; no Photo Bundles |
+| Target | https://app.bhfos.com |
+| Deployed SHA | `c469f7c8174642f40ca60756c124dec63a80bb10` |
+| Founder typed SHA note | Typed `c469f7c0388fc…` (hybrid of tip prefix + prior prod suffix). Unique main tip `c469f7c…` resolved to full SHA above; prior prod retained as rollback. |
+| Authorization ref | `Founder-UX-REFACTOR-A3-Hostinger-c469f7c` |
+| Deployed at | 2026-07-24T01:25:29Z (build-info generatedAt) |
+| Worktree | `F:\Dev\BHFOS-ux-refactor` |
+
+## Pre-deploy snapshot (rollback point)
+
+| Field | Value |
+| --- | --- |
+| Prior prod SHA | `fcc1fccf0388fc896e29e13f0b6261265f60e9d5` |
+| Prior migrationVersion | `20260723201000` |
+| Rollback procedure | Standard snapshot rollback = redeploy retained prior SHA archive / rebuild+deploy `fcc1fcc…` via `deploy-hostinger-static.mjs --execute` (no DB reverse) |
+| Local new archive | `command-center/crm-c469f7c81746.zip` |
+
+## Bounds respected
+
+- No Supabase migrations applied
+- No Stripe / auto-charge changes
+- No S7 / Photo Bundles work
+- `migrationVersion` remained `20260723201000`
+
+## Validation
+
+| Check | Result |
+| --- | --- |
+| health-probe `https://app.bhfos.com` | **HEALTHY** |
+| build-info `commitSha` | `c469f7c8174642f40ca60756c124dec63a80bb10` |
+| build-info `migrationVersion` | `20260723201000` |
+| Shell markers | Main bundle: `Work Orders`, `crm-mobile-bottom-nav`, `crm-nav-divider`. Lazy chunk `CrmPageHeader-52e92b9d.js`: `crm-page-header` (HTTP 200 on prod). |
+
+## Next
+
+UX-REFACTOR production chrome is live. Residuals remain non-blocking. Further Hostinger deploys still require Access Matrix **S**.


### PR DESCRIPTION
## Summary
- Record UX-REFACTOR Hostinger production deploy PASS at `c469f7c8174642f40ca60756c124dec63a80bb10`.
- Rollback snapshot: `fcc1fccf0388fc896e29e13f0b6261265f60e9d5` (redeploy prior SHA; no DB reverse).
- No migrations; migrationVersion remained `20260723201000`.

## Test plan
- [x] health-probe HEALTHY @ c469f7c
- [x] Docs-only PR