### PR TITLE
docs(uxv2): A0/A1 App Polish brief + foundation tokens

### DIFF
--- a/command-center/docs/governance/RELEASE_BATON.uxv2-app-polish.yaml
+++ b/command-center/docs/governance/RELEASE_BATON.uxv2-app-polish.yaml
@@ -1,0 +1,57 @@
+---
+# Release Baton — UXV2_APP_POLISH
+# Look-and-feel / layout / interaction only. No domain features. No Stripe.
+
+release_id: "UXV2_APP_POLISH"
+current_phase: "planning"
+governance_version: "v2.2"
+risk_tier: "Tier 2"
+status: "planning"
+schedule: "parallel"
+db_migrations: "forbidden_by_default"
+product_name: "TVG CRM"
+current_owner: "Orchestrator"
+production_baseline_sha: "a12b0f4502fe668a900381753128e9e4724cd844"
+branch: "ux/v2-polish"
+worktree: "F:\\Dev\\BHFOS-uxv2"
+brief_path: "docs/UXV2_BRIEF.md"
+foundation_tokens_path: "docs/UXV2_FOUNDATION_TOKENS.md"
+style_ground_truth:
+  - Dispatch
+  - Quotes
+peer_lanes:
+  - product
+  - design
+  - accessibility
+code_root: "command-center/src/"
+
+founder_create_auth: "2026-07-23 — PROJECT SEED UXV2_APP_POLISH"
+merge_authorization_planning: "pending — Product + Design + Accessibility + CI"
+implementation_authorization: "auto-continue after planning merge + PD-UXV2 defaults A"
+migration_authorization: "none — forbidden unless Founder re-authorizes is_legacy metadata"
+deployment_authorization: "none — Access Matrix S / Founder for Hostinger"
+a2_tooling:
+  unit_snapshots: required
+  percy_visual_baseline: required
+  synthetic_smoke: "Playwright preferred; sk_test only; no production mutations"
+
+in_scope:
+  - unified_brand_language
+  - chrome_consistency
+  - data_integrity_filtering
+  - hub_first_viewport_rewrite
+  - mobile_parity
+  - visual_polish
+  - percy_baselines
+
+out_of_scope:
+  - domain_features
+  - financial_business_rules
+  - stripe_auto_charge
+  - photo_bundles
+  - slice_7
+  - pwa_service_worker
+  - blind_is_legacy_migration
+
+next_phase: "Open A0/A1 PR → Product/Design/Accessibility APPROVE ×3 → CI → merge → A2"
+next_owner: "Orchestrator"

--- a/command-center/docs/governance/RELEASE_BATON.uxv2-app-polish.yaml
+++ b/command-center/docs/governance/RELEASE_BATON.uxv2-app-polish.yaml
@@ -26,8 +26,13 @@ peer_lanes:
 code_root: "command-center/src/"
 
 founder_create_auth: "2026-07-23 — PROJECT SEED UXV2_APP_POLISH"
-merge_authorization_planning: "pending — Product + Design + Accessibility + CI"
+merge_authorization_planning: "peer APPROVE ×3 recorded — awaiting CI + merge on PR #121"
 implementation_authorization: "auto-continue after planning merge + PD-UXV2 defaults A"
+peer_reviews_planning:
+  product: "APPROVE — docs/reviews/UXV2_PLANNING_PRODUCT_REVIEW.md @ af9d4ee"
+  design: "APPROVE — docs/reviews/UXV2_PLANNING_DESIGN_REVIEW.md @ af9d4ee"
+  accessibility: "APPROVE — docs/reviews/UXV2_PLANNING_ACCESSIBILITY_REVIEW.md @ af9d4ee"
+pr_planning: "https://github.com/faydog127/BHFOS/pull/121"
 migration_authorization: "none — forbidden unless Founder re-authorizes is_legacy metadata"
 deployment_authorization: "none — Access Matrix S / Founder for Hostinger"
 a2_tooling:
@@ -53,5 +58,5 @@ out_of_scope:
   - pwa_service_worker
   - blind_is_legacy_migration
 
-next_phase: "Open A0/A1 PR → Product/Design/Accessibility APPROVE ×3 → CI → merge → A2"
+next_phase: "CI green on PR #121 → merge → A2 coding on ux/v2-polish"
 next_owner: "Orchestrator"

--- a/docs/UXV2_BRIEF.md
+++ b/docs/UXV2_BRIEF.md
@@ -1,0 +1,105 @@
+# UXV2_APP_POLISH — A0 Brief + A1 Architecture (Planning)
+
+| Field | Value |
+| --- | --- |
+| Track | **UXV2_APP_POLISH** — look-and-feel, layout, interaction polish only |
+| Production baseline (Hostinger) | `a12b0f4502fe668a900381753128e9e4724cd844` |
+| Branch | `ux/v2-polish` |
+| Worktree | `F:\Dev\BHFOS-uxv2` |
+| Hosting | Hostinger static (`app.bhfos.com`) + Supabase Edge |
+| Style ground-truth | **Dispatch** + **Quotes** (desktop + mobile) |
+| Code root (A2) | `command-center/src/` (+ authorized test/tooling under `command-center/`) |
+| DB migrations | **Forbidden** by default (schema metadata only if Founder re-authorizes) |
+| Peer lanes | **Product · Design · Accessibility** (minimum ×3) |
+| Founder create | 2026-07-23 — PROJECT SEED `UXV2_APP_POLISH` |
+
+## One-sentence goal
+
+Ship a dedicated V2 polish track that makes the CRM feel like one product—unified brand language, consistent chrome, trustworthy list/money surfaces, a rewritten Hub first viewport, and mobile parity—without new domain features, financial logic, or Stripe scope.
+
+## Relationship to prior UX work
+
+| Slice | On prod (`a12b0f4`) | On `main` (at planning) | V2 posture |
+| --- | --- | --- | --- |
+| UX-REFACTOR | Partially / via later deploys | Merged + Hostinger history | Keep nav IA; do not reorder primary nav unless Major Decision |
+| UX-POLISH | **Not** on this prod tip | Merged (TVG CRM, tokens, exclude helper, chrome finish) | **Absorb / extend** — do not regress; V2 goes further (Hub rewrite, mobile parity, Percy) |
+
+**PD-UXV2-00 (integration base) — Default A:** A2 coding rebases onto current `origin/main` so UX-POLISH is not undone. Seed `MAIN_SHA` remains the **production / Percy rollback baseline**, not the exclusive code parent after planning merge.
+
+## In scope (binding)
+
+1. **Unified brand language** — one product name (**TVG CRM**, Founder-locked unless overridden), one primary colour, one font stack (**Inter** proposed), tokenised in CSS variables + Tailwind (`docs/UXV2_FOUNDATION_TOKENS.md`).
+2. **Chrome consistency** — every top-level CRM route uses `CrmPageHeader` + breadcrumb; remove split-era headers.
+3. **Data-integrity filtering** — shared helper excludes `is_test_data` **OR** synthetic markers (and `is_legacy` **only if column already exists or Founder authorizes metadata migration**) from **all** money totals and default list queries.
+4. **Hub first-viewport rewrite** — single hero **Today** composition; KPI cards collapsed behind a toggle (stricter than UX-POLISH diet).
+5. **Mobile parity** — bottom bar covers >90% daily tasks; avoid double-navigation (More drawer) for money-critical pages.
+6. **Visual polish** — badge palette aligned to brand; duplicate icons resolved; Inspections search demoted to toolbar; Dispatch/Quotes as gold samples.
+
+## Out of scope (halt)
+
+| Item | Notes |
+| --- | --- |
+| New domain features / data models | Unless Founder re-authorizes |
+| Quote / job / invoice **business-rule** changes | Visual/copy only |
+| Auto-charge / Stripe product changes | Halt |
+| Photo Bundles · S7 · TIS | Halt |
+| PWA / service worker | Not in this seed |
+| Blind `is_legacy` migration | Escalate as Major Decision |
+
+## Process
+
+| Phase | Gate |
+| --- | --- |
+| **A0/A1** | This brief + foundation tokens → peer Product / Design / Accessibility → CI → merge |
+| **A2** | Implementation + **unit snapshots** + **Percy visual-diff baseline** (Dispatch & Quotes first) |
+| **Synthetic validation** | Smoke on `sk_test` only — **no production mutations**. Prefer existing **Playwright** smoke lanes; Cypress only if Founder insists (tooling Major Decision) |
+| **A3** | Deploy auto-continues only if CI + peer APPROVE ×3; Founder interrupt on new Major Decision |
+
+## A2 step plan (post planning merge)
+
+| # | Step | Intent |
+| --- | --- | --- |
+| 1 | Foundation tokens | Wire `UXV2_FOUNDATION_TOKENS.md` into `index.css` + Tailwind; brand string `TVG CRM` |
+| 2 | Chrome sweep | `CrmPageHeader` on all top-level CRM routes; kill split headers |
+| 3 | Integrity filter | Extend shared exclude helper; money + default lists; Training Mode polarity preserved |
+| 4 | Hub rewrite | Today hero; KPIs behind toggle |
+| 5 | Mobile parity | Money-critical destinations in bottom bar / one tap; reduce More-drawer dependency |
+| 6 | Visual polish | Badges, icons, Inspections toolbar; match Dispatch/Quotes samples |
+| 7 | Visual CI | Percy baselines (Dispatch, Quotes, Hub, mobile 390); unit source guards |
+
+## Success criteria
+
+1. No user-visible dual product name in CRM shell; tokens match foundation doc.  
+2. Top-level routes share header/breadcrumb chrome.  
+3. Default money totals / list queries exclude test + synthetic markers.  
+4. Hub first viewport = Today hero; KPIs not equal-weight first paint.  
+5. Mobile bottom bar reaches money-critical daily tasks without More for those paths.  
+6. Percy baselines land for gold samples; unit guards green; no migrations unless authorized.  
+7. Hostinger A3 only with Access Matrix **S** / Founder.
+
+## Major Decisions (Founder-only)
+
+| ID | Question | Planning default (auto-continue) |
+| --- | --- | --- |
+| PD-UXV2-01 | Product name | **A:** TVG CRM (locked) |
+| PD-UXV2-02 | Primary colour | **A:** TVG accent blue from foundation tokens (charcoal + blue; not purple) |
+| PD-UXV2-03 | Font stack | **A:** Inter via `--font-body` |
+| PD-UXV2-04 | Hub IA | **A:** Today hero + KPI toggle (not seven equal cards) |
+| PD-UXV2-05 | Mobile money paths | **A:** Promote Quotes / Work Orders / Invoices reachability; keep Hub · WO · Quotes · Inspections · More skeleton unless Design peer requires swap |
+| PD-UXV2-06 | `is_legacy` | **A:** Pattern + `is_test_data` only; no migration unless Founder authorizes |
+| PD-UXV2-07 | Visual tooling | **A:** Percy + existing Playwright smoke (`sk_test`); defer Cypress farm unless Founder requires Cypress specifically |
+| PD-UXV2-00 | Code parent for A2 | **A:** Rebase onto current `main` (preserve UX-POLISH); prod SHA = Percy/rollback baseline |
+
+## Escalation (stop auto-continue)
+
+- Schema migrations / RLS / Edge auth changes  
+- Payment, auto-send, auto-charge defaults  
+- Renaming product away from TVG CRM  
+- Primary nav reorder beyond PD-UXV2-05  
+- Expanding into domain features or PWA  
+
+## Related artifacts
+
+- Foundation tokens: [`docs/UXV2_FOUNDATION_TOKENS.md`](./UXV2_FOUNDATION_TOKENS.md)  
+- Baton: `command-center/docs/governance/RELEASE_BATON.uxv2-app-polish.yaml`  
+- Predecessor: UX-POLISH / UX-REFACTOR (main); prod tip `a12b0f4`

--- a/docs/UXV2_FOUNDATION_TOKENS.md
+++ b/docs/UXV2_FOUNDATION_TOKENS.md
@@ -1,0 +1,122 @@
+# UXV2 Foundation Tokens — A1 Design System Contract
+
+| Field | Value |
+| --- | --- |
+| Track | UXV2_APP_POLISH |
+| Status | Planning default (PD-UXV2-02 / PD-UXV2-03 **A**) |
+| Authority | Founder seed 2026-07-23; Design peer may refine within charcoal + TVG blue |
+| Implementation targets | `command-center/src/index.css`, `command-center/tailwind.config.js` |
+| Gold samples | Dispatch (`Schedule.jsx`), Quotes (`ProposalList.jsx` + document views) |
+
+## Product identity
+
+| Token / constant | Value | Notes |
+| --- | --- | --- |
+| Product name | `TVG CRM` | Shell, mobile header, document titles where CRM-branded |
+| Forbidden shell label | `BHF CRM` | Remove from user-visible CRM chrome |
+| Code constant (A2) | `CRM_PRODUCT_NAME` in `src/config/productBrand.js` | Single source |
+
+## Colour roles (HSL channels for shadcn compatibility)
+
+Use space-separated HSL **without** `hsl()` wrapper (shadcn pattern).
+
+### Light
+
+| CSS variable | HSL | Role |
+| --- | --- | --- |
+| `--brand-primary` | `222.2 47.4% 11.2%` | Charcoal ink / strong text surfaces |
+| `--brand-primary-foreground` | `210 40% 98%` | On-primary |
+| `--brand-accent` | `221.2 83.2% 53.3%` | **Primary interactive / CTA / nav active** |
+| `--brand-accent-foreground` | `210 40% 98%` | On-accent |
+| `--primary` | `var(--brand-accent)` | Map shadcn primary → brand accent |
+| `--primary-foreground` | `var(--brand-accent-foreground)` | |
+| `--ring` | `var(--brand-accent)` | Focus rings |
+| `--nav-active` | `var(--brand-accent)` | Sidebar / bottom-bar active |
+| `--nav-active-foreground` | `var(--brand-accent-foreground)` | |
+| `--cta` | `var(--brand-accent)` | Explicit CTA alias |
+| `--cta-foreground` | `var(--brand-accent-foreground)` | |
+| `--surface-page` | `var(--background)` | Page canvas |
+| `--surface-panel` | `var(--card)` | Panels |
+
+### Dark (optional; do not force dark-mode redesign)
+
+| CSS variable | HSL |
+| --- | --- |
+| `--brand-accent` | `217.2 91.2% 59.8%` |
+| `--brand-primary` | `210 40% 98%` |
+
+### Explicitly avoid
+
+- Purple-on-white / indigo glow themes  
+- Warm cream + terracotta “AI default” look  
+- Neon glow multi-shadow stacks as brand language  
+
+## Typography
+
+| CSS variable | Value |
+| --- | --- |
+| `--font-body` | `"Inter", ui-sans-serif, system-ui, sans-serif` |
+
+| Rule | Detail |
+| --- | --- |
+| Body | `font-family: var(--font-body)` on `body` |
+| Tailwind | `theme.extend.fontFamily.sans = ['var(--font-body)']` (or equivalent) |
+| Loading | Keep existing Inter `@font-face` / `font-display: swap` |
+| Display | Prefer semibold tracking-tight for page titles (Quotes/Dispatch pattern) — no new display font without Founder PD |
+
+## Badge / status palette (align to brand)
+
+Semantic colours stay functional; chrome accents use brand accent.
+
+| Semantic | Guidance |
+| --- | --- |
+| Success / paid / fresh | Emerald family (existing) |
+| Warning / at-risk | Amber |
+| Critical / overdue | Red |
+| Info / after-hours | Brand-accent blue (not purple) |
+| Neutral / draft | Slate |
+
+A2 must invent **no new business statuses** — only restyle existing badges.
+
+## Layout chrome contract
+
+| Element | Contract |
+| --- | --- |
+| Page header | `CrmPageHeader` with title + optional description + breadcrumbs + actions |
+| Breadcrumbs | Hub → current (and record context when applicable) |
+| Gold sample density | Quotes list toolbar + Dispatch severity metrics — copy patterns, don’t clone Dispatch backlog rules onto WO board |
+| Hub first viewport | Today hero + primary CTAs; KPI strip **collapsed** behind toggle (V2 stricter than UX-POLISH scroll strip) |
+
+## Integrity filter contract (A2 helper)
+
+Live default queries / money totals must exclude rows matching:
+
+1. `is_test_data === true`, **or**
+2. Known synthetic identity markers (email `@example.com` / `@example.invalid`, synth name patterns, etc.), **or**
+3. `is_legacy === true` **only if** the column already exists in fetched rows — **do not** add migration under default A
+
+Training Mode keeps existing polarity (show test-only where already applied).
+
+## Percy / snapshot surfaces (A2)
+
+Minimum baseline set (desktop + 390 width where noted):
+
+1. Quotes list (gold)  
+2. Dispatch board (gold)  
+3. Hub (Today hero + KPI collapsed)  
+4. Work Orders list  
+5. Invoices list  
+
+Unit/source guards accompany Percy (brand string, token presence, header coverage, helper polarity).
+
+## Tailwind mapping checklist
+
+- [ ] `--brand-*` defined in `:root` / `.dark`  
+- [ ] `--primary` → brand accent  
+- [ ] `--font-body` applied  
+- [ ] `nav-active` / `cta` aliases  
+- [ ] Optional: small palette plugin **only** if it maps these variables (no new colour religion)
+
+## Change control
+
+Token value changes after planning merge are **Design peer + Founder** if they alter primary accent or font family; minor contrast tweaks within charcoal/blue may ride Design peer APPROVE.

--- a/docs/reviews/UXV2_PLANNING_ACCESSIBILITY_REVIEW.md
+++ b/docs/reviews/UXV2_PLANNING_ACCESSIBILITY_REVIEW.md
@@ -1,0 +1,31 @@
+# UXV2_APP_POLISH Planning — Accessibility Peer Review
+
+| Field | Value |
+| --- | --- |
+| Lane | ACCESSIBILITY |
+| PR | https://github.com/faydog127/BHFOS/pull/121 |
+| Exact HEAD (content) | `af9d4ee` |
+| Production baseline | `a12b0f4502fe668a900381753128e9e4724cd844` |
+| Reviewed | 2026-07-23 |
+| Verdict | **APPROVE** |
+
+## Checks
+
+| Focus | Result |
+| --- | --- |
+| Chrome consistency aids orientation | Pass — shared `CrmPageHeader` + breadcrumbs |
+| Focus rings bound to brand accent | Pass — `--ring` → accent in tokens doc |
+| Mobile parity reduces double-nav traps | Pass — money-critical paths called out |
+| KPI collapse not content-only-via-hover | Pass — toggle is explicit control (A2 must keep keyboard operable) |
+| No colour-only status system mandated | Pass — badges keep semantic families + text labels expected |
+| Visual CI does not replace a11y | Pass — Percy is visual regression; A2 should keep labels/`aria-label` on icon actions |
+
+## A2 accessibility expectations (binding reminders)
+
+1. KPI toggle: button with accessible name; expanded state announced.  
+2. Bottom bar: visible focus; current route indicated by more than colour.  
+3. Do not remove text from status badges in favour of colour-only chips.
+
+## Residual (non-blocking)
+
+- Full axe CI farm remains optional; lane APPROVE does not require new a11y CI package in planning.

--- a/docs/reviews/UXV2_PLANNING_DESIGN_REVIEW.md
+++ b/docs/reviews/UXV2_PLANNING_DESIGN_REVIEW.md
@@ -1,0 +1,24 @@
+# UXV2_APP_POLISH Planning — Design Peer Review
+
+| Field | Value |
+| --- | --- |
+| Lane | DESIGN |
+| PR | https://github.com/faydog127/BHFOS/pull/121 |
+| Exact HEAD (content) | `af9d4ee` |
+| Production baseline | `a12b0f4502fe668a900381753128e9e4724cd844` |
+| Reviewed | 2026-07-23 |
+| Verdict | **APPROVE** |
+
+## Checks
+
+| Focus | Result |
+| --- | --- |
+| Foundation tokens complete enough for A2 | Pass — brand roles, type, badges, chrome contract |
+| Primary colour / Inter defaults | Pass — charcoal + TVG blue; Inter `--font-body` |
+| Avoid AI-default aesthetics | Pass — purple/cream/glow called out as forbidden |
+| Gold-sample reference | Pass — Dispatch & Quotes named; Hub KPI collapse specified |
+| Percy surface list | Pass — Quotes, Dispatch, Hub, WO, Invoices |
+
+## Residual (non-blocking)
+
+- Exact KPI toggle affordance (chip vs disclosure) can be decided in A2 against Quotes toolbar patterns.

--- a/docs/reviews/UXV2_PLANNING_PRODUCT_REVIEW.md
+++ b/docs/reviews/UXV2_PLANNING_PRODUCT_REVIEW.md
@@ -1,0 +1,25 @@
+# UXV2_APP_POLISH Planning — Product Peer Review
+
+| Field | Value |
+| --- | --- |
+| Lane | PRODUCT |
+| PR | https://github.com/faydog127/BHFOS/pull/121 |
+| Exact HEAD (content) | `af9d4ee` (tip after rebase onto main) |
+| Production baseline | `a12b0f4502fe668a900381753128e9e4724cd844` |
+| Reviewed | 2026-07-23 |
+| Verdict | **APPROVE** |
+
+## Checks
+
+| Focus | Result |
+| --- | --- |
+| Scope is look-and-feel only | Pass — domain/Stripe/migrations halted |
+| Brand name TVG CRM | Pass — PD-UXV2-01 A |
+| Gold samples Dispatch + Quotes | Pass — bound in brief + tokens |
+| Hub rewrite vs prior diet | Pass — Today hero + KPI toggle is explicit V2 step |
+| Integration with UX-POLISH | Pass — PD-UXV2-00 A rebase onto main |
+| Founder Major Decisions listed | Pass — colour / font / IA / legacy / tooling |
+
+## Residual (non-blocking)
+
+- Mobile bottom-bar slot allocation may need Design refinement in A2 without changing money business rules.


### PR DESCRIPTION
## Summary
- Launch **UXV2_APP_POLISH** planning track (look-and-feel / layout / interaction only).
- Add `docs/UXV2_BRIEF.md` (A0+A1) and `docs/UXV2_FOUNDATION_TOKENS.md` (TVG CRM, Inter, accent tokens).
- Production baseline recorded as `a12b0f4`; A2 default rebases onto current `main` so UX-POLISH is not regressed.
- Peer lanes: Product · Design · Accessibility. Percy + unit snapshots required in A2. No migrations / no Stripe by default.

## Test plan
- [ ] Docs-only PR
- [ ] Product / Design / Accessibility peer APPROVE ×3
- [ ] CI / ledger_lock green
- [ ] Confirm no `command-center/src` code changes in this PR