### PR TITLE
docs(v1): production closeout handoff for BHFOS V2

### DIFF
--- a/command-center/docs/v2-handoff/V1_DEFERRED_SCOPE_REGISTER.md
+++ b/command-center/docs/v2-handoff/V1_DEFERRED_SCOPE_REGISTER.md
@@ -1,0 +1,28 @@
+# V1 Deferred Scope Register
+
+These items are **out of V1 required scope** unless a Founder Major Decision re-opens them. Do **not** treat as V1 defects solely because they are absent.
+
+| Item | Status | Authority / source | Notes for V2 |
+| --- | --- | --- | --- |
+| Slice 7 | Deferred — do not start | ML-P1 state ledgers | Separate program |
+| Auto-charge | Disabled by policy | PD-S6-02; auth interrupt | Major Decision to enable |
+| Saved cards / vault | Disabled / not built | PD-S6-03 | Major Decision |
+| Stripe Customer Portal | Disabled | PD-S6-06 | Major Decision |
+| Stripe Terminal | Disabled | PD-S6-06 | Major Decision |
+| Photo Bundles | Deferred / not started | S8 residual R-S8-BUNDLE-01 | Product slice |
+| Full media library | Deferred | S8 / UX residuals | Beyond evidence photos |
+| Complete PWA | Deferred (UX-PWA unauthorized) | UX-POLISH / UXV2 | Install + SW |
+| Full offline field application | Deferred | S8 cache is baseline only | Beyond 250MB cache |
+| Commercial Account Manager | Deferred | Not in ML-P1 closed slices | New product |
+| Advanced analytics | Deferred / thin now | R-S8-ANALYTICS-01 | Expand carefully |
+| QuickBooks expansion | Deferred | PD-S6-07; R-UXP-03 audit | Ops first |
+| AI / voice agent operations | Deferred | Partial inspection AI ≠ voice ops | Separate |
+| Shared multi-tenant SaaS | Excluded | Dedicated deployment architecture | Do not silently reopen |
+| Native iOS / Android rewrite | Deferred | Web/PWA path only | Separate |
+| Admin write-off RPC/UI | Deferred residual | R-S5-08 | May enter V2 as residual close |
+| Visual CI farm (Percy at scale) | Scaffold only | UXV2 | Needs `PERCY_TOKEN` + process |
+| Cypress farm | Prefer Playwright | UXV2 PD default | Tooling choice |
+
+## Halt defaults (carry forward)
+
+Auto-send · auto-charge · portal/vault · Terminal · TIS merge · Photo Bundles · S7 · Hostinger without Access Matrix **S** · production mutations on synthetic validation without `sk_test` discipline.

--- a/command-center/docs/v2-handoff/V1_EVIDENCE_MANIFEST.md
+++ b/command-center/docs/v2-handoff/V1_EVIDENCE_MANIFEST.md
@@ -1,0 +1,69 @@
+# V1 Evidence Manifest
+
+| Field | Value |
+| --- | --- |
+| Closeout date | 2026-07-24 |
+| Branch | `docs/v1-production-closeout` |
+| Repo | https://github.com/faydog127/BHFOS |
+
+## Evidence class legend
+
+| Class | Meaning |
+| --- | --- |
+| **production evidence** | Observed this session from live endpoints or validated production artifacts |
+| **repository evidence** | Present in `origin/main` / named SHA tree |
+| **documentary evidence** | Prior closeout / decision packet / residual register |
+| **reviewer report** | Peer-review or critique document |
+| **inference** | Logical conclusion from other evidence |
+| **unresolved** | Could not independently verify this session |
+
+## Session production probes (2026-07-24)
+
+| ID | Probe | Result | Class |
+| --- | --- | --- | --- |
+| E-PROD-01 | `GET https://app.bhfos.com/build-info.json` | HTTP 200 JSON | production evidence |
+| E-PROD-02 | build-info `commitSha` | `c469f7c8174642f40ca60756c124dec63a80bb10` | production evidence |
+| E-PROD-03 | build-info `migrationVersion` | `20260723201000` | production evidence |
+| E-PROD-04 | build-info `generatedAt` | `2026-07-24T01:25:29.547Z` | production evidence |
+| E-PROD-05 | build-info `frontendAssetVersion` | `12613602e4dbebdf` | production evidence |
+| E-PROD-06 | build-info `environment` | `production` | production evidence |
+| E-PROD-07 | HTML title at app root | “The Vent Guys CRM” (SPA shell) | production evidence |
+| E-PROD-08 | Cloudflare bot interstitial on naive fetch | Observed then cleared; JSON endpoint returned cleanly | production evidence |
+
+## Repository state (this session)
+
+| ID | Fact | Value | Class |
+| --- | --- | --- | --- |
+| E-REPO-01 | `git rev-parse origin/main` | `2557ba28490ae38970b3a32de95130746a5b9333` | repository evidence |
+| E-REPO-02 | `origin/main` subject | Merge PR #122 (`ux/v2-polish`) | repository evidence |
+| E-REPO-03 | Commits ahead of prod UI tip | **13** (`c469f7c…` → `2557ba2…`) | repository evidence |
+| E-REPO-04 | Code commits undeployed (src) | `0e592b2` (UX-POLISH), `db2bec9` (UXV2) | repository evidence |
+| E-REPO-05 | Latest migration filename | `20260723201000_ml_p1_s8_definer_auth_hotfix.sql` | repository evidence |
+| E-REPO-06 | SHA-256 of tip migration | `3B7F975AB64EB121D17896A800FB9E0796CE1403636429F7E6AF4CC54828DEC4` | repository evidence |
+| E-REPO-07 | SHA-256 of S8 remediation migration | `7EBAB73E39F48B8B6A4058C476456A2751A15C08DE3DF15369E157E1A5349CBE` | repository evidence |
+| E-REPO-08 | Prod UI tip still shows shell label | `"BHF CRM"` in `BHFCrmLayout.jsx` @ `c469f7c` | repository evidence |
+| E-REPO-09 | Primary worktree `F:\Dev\BHFOS` | Dirty (TIS files) @ `98e77602ece3be140be1620582607d5e33f50ef3` detached | repository evidence |
+| E-REPO-10 | Closeout worktree | `F:\Dev\BHFOS-v1-closeout` clean @ `2557ba2` | repository evidence |
+
+## Documentary production authorities (cited, not re-executed)
+
+| ID | Artifact | Claims used | Class |
+| --- | --- | --- | --- |
+| E-DOC-01 | `docs/stabilization/releases/UX_REFACTOR_A3_HOSTINGER_CLOSEOUT.md` | Hostinger deploy PASS @ `c469f7c…` | documentary evidence |
+| E-DOC-02 | `docs/stabilization/releases/ML-P1_SLICE8_REMEDIATION_A3_CLOSEOUT.md` | Migrations applied; project `wwyxohjnyqnegzbxtuxs`; checksums match E-REPO-06/07 | documentary evidence |
+| E-DOC-03 | `docs/stabilization/releases/ML-P1_SLICE6_A3_POSTAPPLY_CLOSEOUT.md` | auto-send/auto-charge OFF; checkout/offline/refunds/recon ON | documentary evidence |
+| E-DOC-04 | `docs/governance/decisions/ML-P1_SLICE5_DECISION_PACKET.md` | Invoice immutability / void / write-off authority | documentary evidence |
+| E-DOC-05 | `docs/governance/decisions/ML-P1_SLICE6_DECISION_PACKET.md` | No saved cards / portal / Terminal | documentary evidence |
+| E-DOC-06 | Evidence JSON `docs/stabilization/releases/evidence/ml-p1-s8-remediation-prod-validation-S8-VAL-1784854621806.json` | URL `https://wwyxohjnyqnegzbxtuxs.supabase.co` | documentary evidence |
+
+## Unresolved this session
+
+| ID | Item | Why unresolved |
+| --- | --- | --- |
+| E-GAP-01 | Live `schema_migrations` row listing | No Founder-authorized DB session used |
+| E-GAP-02 | Live `global_config` payment flags | Not re-queried; rely on E-DOC-03 |
+| E-GAP-03 | Edge Function deploy versions / last-updated timestamps | Supabase Management API not invoked |
+| E-GAP-04 | Whether `invoice-save` Edge remains reachable in prod routing | Source exists; prod route matrix not re-probed |
+| E-GAP-05 | QuickBooks external sync of staging invoices | Ops/Founder non-code (R-UXP-03) |
+| E-GAP-06 | Authenticated browser click-through of full money loop | Not performed this session |
+| E-GAP-07 | SECURITY DEFINER grant matrix as currently applied | Not re-queried from `pg_proc` / ACL catalogs |

--- a/command-center/docs/v2-handoff/V1_PRODUCTION_CLOSEOUT.md
+++ b/command-center/docs/v2-handoff/V1_PRODUCTION_CLOSEOUT.md
@@ -1,0 +1,61 @@
+# V1 Production Closeout — Authoritative Handoff for BHFOS V2
+
+| Field | Value |
+| --- | --- |
+| Disposition | **V1_PRODUCTION_CLOSEOUT_READY** |
+| Closeout date | 2026-07-24 |
+| Repo | https://github.com/faydog127/BHFOS |
+| Exact `origin/main` | `2557ba28490ae38970b3a32de95130746a5b9333` |
+| Production UI (`https://app.bhfos.com/build-info.json`) | `c469f7c8174642f40ca60756c124dec63a80bb10` |
+| Production `migrationVersion` | `20260723201000` |
+| Supabase project | `wwyxohjnyqnegzbxtuxs` |
+| Branch | `docs/v1-production-closeout` |
+| Authority | A0/A1 read-only + docs-only · no feature coding · no deploy |
+
+## Supporting documents (canonical set)
+
+1. [V1_PRODUCTION_STATE_MATRIX.md](./V1_PRODUCTION_STATE_MATRIX.md)  
+2. [V1_RATIFIED_DECISION_REGISTER.md](./V1_RATIFIED_DECISION_REGISTER.md)  
+3. [V1_RESIDUAL_AND_DEFECT_REGISTER.md](./V1_RESIDUAL_AND_DEFECT_REGISTER.md)  
+4. [V1_SECURITY_AND_FINANCIAL_POSTURE.md](./V1_SECURITY_AND_FINANCIAL_POSTURE.md)  
+5. [V1_UX_AND_FIELD_BASELINE.md](./V1_UX_AND_FIELD_BASELINE.md)  
+6. [V1_DEFERRED_SCOPE_REGISTER.md](./V1_DEFERRED_SCOPE_REGISTER.md)  
+7. [V1_EVIDENCE_MANIFEST.md](./V1_EVIDENCE_MANIFEST.md)  
+8. Critique rounds: [reviews/](./reviews/)
+
+## Authoritative state (independently resolved)
+
+| # | Item | Finding |
+| --- | --- | --- |
+| 1 | Exact `origin/main` | `2557ba28490ae38970b3a32de95130746a5b9333` (Merge PR #122) |
+| 2 | Production frontend SHA | `c469f7c8174642f40ca60756c124dec63a80bb10` |
+| 3 | Prod UI vs main match? | **No** — main **13 commits ahead** |
+| 4 | Production `migrationVersion` | `20260723201000` |
+| 5 | Latest applied migration (tip name) | `20260723201000_ml_p1_s8_definer_auth_hotfix.sql` (build-info tip; live `schema_migrations` not re-queried) |
+| 6 | Supabase project | `wwyxohjnyqnegzbxtuxs` |
+| 7 | Edge Functions | Source inventory present (39 function dirs); **deploy versions unresolved this session** |
+| 8 | Open PRs affecting V1/closeout | Stale planning/deploy docs PRs (#94, #87, #86, …) still open; none are this closeout |
+| 9 | Active worktrees | Many historical; closeout worktree `F:\Dev\BHFOS-v1-closeout`; uxv2 `F:\Dev\BHFOS-uxv2`; primary `F:\Dev\BHFOS` **dirty** |
+| 10 | Primary worktree clean? | **Dirty** (TIS changes) @ detached `98e77602ece3be140be1620582607d5e33f50ef3` |
+| 11 | Prod ahead of repo? | **UI no**; DB tip name aligns with repo tip |
+| 12 | Repo not deployed | UX-POLISH (`0e592b2`) + UXV2 (`db2bec9`) frontend not on Hostinger |
+
+## What V1 is (short)
+
+A dedicated TVG CRM on Hostinger + Supabase with closed ML-P1 slices **S1–S6** and **S8 remediation**, UX-REFACTOR chrome on production, money loop via Checkout/offline/refunds/recon with **auto-send and auto-charge OFF**, inspections evidence-gated, and explicit deferrals for S7 / Photo Bundles / PWA / Terminal / portal / saved cards.
+
+## What V1 is not
+
+Multi-tenant SaaS · complete offline field OS · Photo Bundles product · auto-charge · write-off UI · brand-unified prod shell · synth-hygiene UI on Hostinger.
+
+## Critique rounds completed
+
+| Round | Lens | File | Verdict |
+| --- | --- | --- | --- |
+| 1 | Source of truth / architecture | [reviews/V1_CLOSEOUT_ROUND1_ARCHITECTURE.md](./reviews/V1_CLOSEOUT_ROUND1_ARCHITECTURE.md) | PASS with drift callouts |
+| 2 | Security / financial / adversarial | [reviews/V1_CLOSEOUT_ROUND2_SECURITY.md](./reviews/V1_CLOSEOUT_ROUND2_SECURITY.md) | PASS with open risks |
+| 3 | Product / UX / Founder usability | [reviews/V1_CLOSEOUT_ROUND3_PRODUCT_UX.md](./reviews/V1_CLOSEOUT_ROUND3_PRODUCT_UX.md) | PASS — V1 usable; V2 owns polish deploy |
+
+## Non-claims
+
+This closeout does **not** authorize Hostinger deploy, migrations, Stripe changes, synthetic cleanup, or V2 feature coding.

--- a/command-center/docs/v2-handoff/V1_PRODUCTION_STATE_MATRIX.md
+++ b/command-center/docs/v2-handoff/V1_PRODUCTION_STATE_MATRIX.md
@@ -1,0 +1,63 @@
+# V1 Production State Matrix
+
+| Field | Value |
+| --- | --- |
+| Exact `origin/main` | `2557ba28490ae38970b3a32de95130746a5b9333` |
+| Production UI (`build-info.json`) | `c469f7c8174642f40ca60756c124dec63a80bb10` |
+| Match? | **NO** — main is **13 commits ahead** of production UI |
+| Production `migrationVersion` | `20260723201000` |
+| Latest repo migration | `20260723201000_ml_p1_s8_definer_auth_hotfix.sql` |
+| Migration tip match (filename ↔ build-info) | **YES** (application of row not re-queried live) |
+| Supabase project | `wwyxohjnyqnegzbxtuxs` (documentary + prior evidence JSON) |
+
+## Classification legend
+
+PRODUCTION CONFIRMED · REPOSITORY CONFIRMED — PRODUCTION UNVERIFIED · SOURCE MERGED — NOT APPLIED · DEPLOYED — ACCEPTANCE INCOMPLETE · DEFERRED · DISABLED BY POLICY · RESIDUAL / DEFECT OPEN · UNKNOWN — REQUIRES FOLLOW-UP
+
+## Capability matrix
+
+| ID | Capability | Classification | Evidence notes |
+| --- | --- | --- | --- |
+| A | Lead intake + duplicate detection | DEPLOYED — ACCEPTANCE INCOMPLETE | Intake on prod UI tip; R2 contracts in repo; full duplicate E2E not re-run this session |
+| B | Customer / service-location records | PRODUCTION CONFIRMED | Identity/property work closed in R1 docs; live app serves CRM shell |
+| C | Quote create / issue / revise / approve / reject / expire | PRODUCTION CONFIRMED | S2/S3 closeouts + public/office paths in source; dual writers residual R-COH-08 |
+| D | Public quote approval | PRODUCTION CONFIRMED | `public-quote-approve` + `ml_p1_s2_quote_approve_public` |
+| E | Approved quote → canonical job | PRODUCTION CONFIRMED | S3 writer; one job per accepted quote |
+| F | Scheduling / Calendar | PRODUCTION CONFIRMED | R3 + Calendar page on prod shell |
+| G | Dispatch | PRODUCTION CONFIRMED | Dispatch is gold-sample UX on prod tip |
+| H | Job execution statuses | PRODUCTION CONFIRMED | S4 status RPCs; Edge `work-order-update` denies status bypass |
+| I | Time / mileage tracking | REPOSITORY CONFIRMED — PRODUCTION UNVERIFIED | S4 schema/RPCs; field E2E not re-run |
+| J | Make-safe controls | PRODUCTION CONFIRMED | PD-S4-01; R-S4-05 remediated |
+| K | Change orders + customer approval | DEPLOYED — ACCEPTANCE INCOMPLETE | Server gates present; R-S4-03 customer-token UI open |
+| L | Completion readiness / job completion | PRODUCTION CONFIRMED | S4/S5 gates + auto-draft on complete |
+| M | Inspections (office) | PRODUCTION CONFIRMED | S8 remediation PASS |
+| N | Mobile inspection workflow | PRODUCTION CONFIRMED | Mobile E2E PASS in S8 remediation closeout |
+| O | Offline inspection behavior | REPOSITORY CONFIRMED — PRODUCTION UNVERIFIED | Cache/offline helpers in source; R-S8-02 mitigated |
+| P | Required photo evidence | PRODUCTION CONFIRMED | S8 evidence gates + hotfix |
+| Q | Photo Bundles | DEFERRED | Explicit halt; not started |
+| R | Pricebook | PRODUCTION CONFIRMED | S4 pricebook migrations applied (documentary) |
+| S | Invoice draft creation | PRODUCTION CONFIRMED | S5 create/draft RPCs; auto-draft on complete |
+| T | Invoice issue / void / write-off / corrections | DEPLOYED — ACCEPTANCE INCOMPLETE | Issue/void production; **write-off RPC/UI deferred** (R-S5-08) |
+| U | Stripe Checkout | PRODUCTION CONFIRMED | Flag default ON; public-pay path; S6 E2E PASS (sk_test) |
+| V | Stripe webhook settlement | PRODUCTION CONFIRMED | payment-webhook / stripe-webhook; S6 settlement hotfixes |
+| W | Refund / dispute behavior | PRODUCTION CONFIRMED | Refunds ON; disputes → recon queue |
+| X | Reconciliation queue | PRODUCTION CONFIRMED | recon flag ON |
+| Y | QuickBooks | DEFERRED / RESIDUAL | No expansion ownership; R-UXP-03 sync audit open |
+| Z | Analytics dashboard | DEPLOYED — ACCEPTANCE INCOMPLETE | Thin analytics; R-S8-ANALYTICS-01 open |
+| AA | Settings › Billing & Payments | PRODUCTION CONFIRMED | Flags UI; R-S6-UX-01 rough edges open |
+| AB | Training / synthetic-data handling | SOURCE MERGED — NOT APPLIED | Training Mode on prod tip; **`excludeSynthetic` hygiene is on main only (UX-POLISH/UXV2), not on prod UI** |
+| AC | PWA installability | DEFERRED | UX-PWA unauthorized |
+| AD | Offline job / media support | DEPLOYED — ACCEPTANCE INCOMPLETE | Partial offline cache; not full offline field app |
+| AE | Commercial Account Manager | DEFERRED | Not V1 scope |
+| AF | AI / voice workflows | DEFERRED / RESIDUAL | Partial inspection AI exists; voice agent ops not V1 product |
+
+## Drift summary
+
+| Layer | Production | `origin/main` | Drift |
+| --- | --- | --- | --- |
+| Frontend Hostinger | `c469f7c8174642f40ca60756c124dec63a80bb10` | `2557ba28490ae38970b3a32de95130746a5b9333` | Main ahead (UX-POLISH + UXV2) |
+| Product name in shell | **BHF CRM** @ prod tip | **TVG CRM** | Undeployed brand fix |
+| Hub first viewport | KPI strip (UX-REFACTOR era) | Today hero + KPI toggle (UXV2) | Undeployed |
+| Mobile bottom nav | Hub · WO · Quotes · Inspections · More | Hub · WO · Quotes · **Invoices** · More | Undeployed |
+| DB migration tip | `20260723201000` (build-info) | same filename tip | Aligned at tip name |
+| Migrations newer than tip | none in repo | none | None |

--- a/command-center/docs/v2-handoff/V1_RATIFIED_DECISION_REGISTER.md
+++ b/command-center/docs/v2-handoff/V1_RATIFIED_DECISION_REGISTER.md
@@ -1,0 +1,45 @@
+# V1 Ratified Decision Register
+
+Only decisions with packet / production-enforced evidence. Proposals not listed as ratified.
+
+| Decision ID | Plain language | Source | Implementation | Production confirmation | Reversible? | Carry to V2? | Re-ratify for V2? |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| ARCH-TVG-DEDICATED | Dedicated single-company TVG deployment (not multi-tenant SaaS) | Operating model + ML-P1 packets | Hostinger + Supabase project `wwyxohjnyqnegzbxtuxs` | Live app + project refs | Hard | **Yes** | Confirm boundary only |
+| ARCH-TENANT-RESIDUE | `tenant_id` stamping remains as residue in single-company deploy | R-S4-07 | Columns/filters still present | Documentary | Soft | Yes (as residual) | No unless multi-tenant revived |
+| PD-S3-ONE-JOB | Exactly one canonical job per accepted quote (idempotent) | Slice 3 / PR84 packet | `ml_p1_s3_ensure_job_for_accepted_quote` | S3 validation PASS (doc) | Hard | **Yes** | No |
+| PD-S2-LIFECYCLE | Quote lifecycle via server authz RPC; public approve token path | S2 packets | `ml_p1_s2_quote_lifecycle`, `ml_p1_s2_quote_approve_public` | Doc + Edge present | Medium | **Yes** | No |
+| PD-S4-01 | Make-safe only; no billable expansion without approved change order | S4 decision packet | S4 RPCs / controls | S4 PASS (doc) | Medium | **Yes** | No |
+| PD-S4-06 | Billable changes need customer approval; office break-glass audited | S4 decision packet | Change-order gates | Partial (UI residual R-S4-03) | Medium | **Yes** | UI path may need V2 |
+| PD-S4-COMPLETE | Job completion gated by readiness / evidence rules | S4/S5 | Completion RPCs + S5 auto-draft | Doc | Medium | **Yes** | No |
+| PD-S5-01 | One canonical final invoice per completed job; draft then explicit issue; never auto-issue/auto-send | S5 decision packet | `ml_p1_s5_invoice_*` | S5/S6 PASS (doc) | Hard | **Yes** | No |
+| PD-S5-04 | Issued invoice financials freeze (snapshot) | S5 packet | Issue RPC immutability | Doc | Hard | **Yes** | No |
+| PD-S5-05 | Void: office/manager/admin + reason + audit; write-off: admin-only | S5 packet | Void RPC; write-off **deferred** | Void yes; write-off no | Medium | **Yes** | Write-off needs V2 build |
+| PD-S5-06 | Unpaid issued invoices immutable; correct via void+reissue | S5 packet | Issue/void RPCs | Doc | Hard | **Yes** | No |
+| PD-S5-07 | Grandfather existing invoices; no historic rewrite | S5 packet | Policy | Doc | Soft | **Yes** | No |
+| PD-S5-VOCAB | Invoice status vocabulary as S5 enums | S5 schema migration | DB constraints | Doc | Medium | **Yes** | No |
+| PD-S6-02 | Hosted Checkout + offline record only; no scheduled capture / auto-charge | S6 packet | Flags + assert deny | S6 PASS (doc); **not re-queried this session** | Hard | **Yes** | Enabling = Major Decision |
+| PD-S6-03 | No saved cards / vault / stored PaymentMethod IDs | S6 packet | Absent features | Source search clean | Hard | **Yes** | Major Decision to add |
+| PD-S6-06 | Customer pay link + office offline; techs cannot enter cards; no Terminal | S6 packet | public-pay; no Terminal code | Doc + source | Hard | **Yes** | Major Decision to add |
+| PD-S6-05 | Paid path uses refund; unpaid void per S5; recon for disputes | S6 packet | refund + recon queue | S6 PASS (doc) | Medium | **Yes** | No |
+| PD-S6-07 | Reconciliation canonical; no new QuickBooks ownership in S6 | S6 packet | recon queue | Doc | Soft | Yes | QB expansion = Major |
+| PD-S6-PARTIAL | Partial payment / status handling via settlement writers | S6 closeout | payment writers | Doc | Medium | **Yes** | No |
+| PD-S8-INSPECT | Mobile inspection checklist + evidence gates | S8 packets | S8 RPCs + hotfix | S8 remediation PASS | Medium | **Yes** | Photo Bundles separate |
+| PD-S8-CACHE | Offline cache baseline ~250MB budget | R-S8-02 | Client cache | Mitigated (doc) | Soft | Yes | Revisit for full offline |
+| PHOTO-RETAIN | Photo retention / voided photo rules from inspection hardening | Phase migrations | Storage + guards | Doc | Medium | Yes | Bundles deferred |
+| ANALYTICS-BOUND | Analytics thin; not full finance OS | R-S8-ANALYTICS-01 | Reporting pages | Partial | Soft | Yes | Expand = V2 scope |
+| HALT-S7 | Slice 7 deferred — do not start | State ledgers | N/A | Policy | Soft | Carry as deferred | Founder to open |
+| HALT-AUTOCHARGE | Auto-charge OFF; setter refuses ON | S6 migration + auth interrupt | `ml_p1_s6_assert_auto_charge_off` | Doc | Hard | **Yes** | Major Decision |
+| HALT-AUTOSEND | Invoice auto-send OFF by default | S6 flags | `invoice_auto_send_enabled=false` | Doc | Hard | **Yes** | Major Decision |
+| HALT-PWA | Full PWA not authorized in polish slices | UX-POLISH / UXV2 | N/A | Policy | Soft | Deferred | Founder to open |
+| BRAND-TVG | Product name **TVG CRM** (Founder-locked for polish) | UX-POLISH / UXV2 | `productBrand.js` on main | **Not on prod UI** (still BHF CRM) | Soft | **Yes** | Deploy still Matrix S |
+
+## Explicitly NOT ratified as V1 complete
+
+| Topic | Status |
+| --- | --- |
+| Photo Bundles product | Deferred |
+| Admin write-off RPC/UI | Deferred (R-S5-08) |
+| Customer change-order token UI | Open residual (R-S4-03) |
+| Multi-tenant SaaS | Out of architecture |
+| Native iOS/Android | Deferred |
+| AI/voice agent operations | Deferred |

--- a/command-center/docs/v2-handoff/V1_RESIDUAL_AND_DEFECT_REGISTER.md
+++ b/command-center/docs/v2-handoff/V1_RESIDUAL_AND_DEFECT_REGISTER.md
@@ -1,0 +1,55 @@
+# V1 Residual and Defect Register (Consolidated)
+
+Consolidated from slice residual registers, UX residuals, UAT log, and this-session drift. **Not closed merely by omission in later docs.**
+
+| Residual ID | Title | Capability | Severity | Status | Source | Prod impact | Fixed in source? | Applied? | Deployed UI? | Prod validated? | Relevant to V2? | Disposition |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| DRIFT-UI-01 | Hostinger UI behind main (UX-POLISH + UXV2) | Shell/UX | High | **Open** | build-info vs `origin/main` | Prod missing TVG brand, Hub rewrite, Invoices bottom nav, synth hygiene UI | Yes (main) | N/A | **No** | N/A | **Yes** | Deploy Matrix S or accept lag |
+| R-S5-08 | Admin write-off RPC/UI absent | Invoices | Medium | Deferred | S5 residual | Cannot write-off via canonical UI/RPC | No | No | No | No | **Yes** | V2 or authorized S5 residual |
+| R-S4-03 | Customer-token change-order approval UI absent | Change orders | Medium | Open | S4 residual | Approval may be office-only / incomplete | Partial | Partial | Unknown | Incomplete | **Yes** | V2 field UX |
+| R-COH-08 | Dual quote writers (Edge + RPC) | Quotes | Medium | Accepted residual | S1–S3 residual | Alternate paths remain | Mitigated | Yes | Yes | Partial | **Yes** | Harden in V2 |
+| R-COH-12 | Superseded quotes in main list | Quotes | Low | Open | UI defects | List noise | No | No | No | No | Yes | UX polish |
+| R-COH-09 | ProposalBuilder secondary writer reachable | Quotes | Low | Accepted | UI defects | Legacy path | No | No | Yes | Partial | Yes | Remove/gate |
+| ALT-INV-01 | `invoice-save` Edge still in source as alternate writer | Invoices | High | **Open (source)** | functions/invoice-save | Risk if routed | No deny-all | Unknown deploy | Unknown | **Unresolved** | **Yes** | Verify deny/retire |
+| R-S4-07 | tenant_id stamp residue | Architecture | Low | Accepted | S4 residual | Single-company residue | N/A | Yes | Yes | Yes | Yes | Document only |
+| R-S5-04 | Grandfathered invoices incomplete lineage | Invoices | Low | Open | S5 residual | Reporting lineage gaps | No | N/A | N/A | Partial | Yes | Analytics care |
+| R-S5-07 | Auto-draft soft-fail depends on event insert | Invoices | Medium | Open | S5 residual | Missed draft possible | Partial | Yes | Yes | Partial | Yes | Monitor |
+| R-S6-UX-01 | Billing & Payments UX rough | Settings | Low | Open | S6 residual | Founder friction | No | N/A | Yes | Partial | Yes | UXV2/Settings |
+| R-S8-BUNDLE-01 | Photo Bundles product missing | Media | Info | Deferred | S8 residual | No customer bundles | N/A | N/A | N/A | N/A | Yes (deferred) | Do not treat as V1 defect |
+| R-S8-ANALYTICS-01 | Full analytics RPC suite missing | Analytics | Low | Open | S8 residual | Thin dashboard | Partial | Partial | Yes | Partial | Yes | V2 analytics |
+| R-UX-01/06 | EnterpriseLayout double chrome | Shell | Medium | Open | UX-REFACTOR residual | Split chrome on some routes | Partial | Partial | Partial | Partial | Yes | Chrome sweep |
+| R-UXP-01 | PWA installability | Install | Info | Deferred | UX-POLISH residual | No install prompt product | N/A | N/A | N/A | N/A | Deferred | UX-PWA |
+| R-UXP-03 | QuickBooks staging invoice sync audit | QB / money | Medium | Open | UX-POLISH residual | Possible external contamination | N/A | N/A | N/A | **Unresolved** | **Yes** | Founder/ops audit |
+| R-UXP-04 | Synth data DB backfill | Hygiene | Medium | Open | UX-POLISH residual | Unflagged synth may remain | Client helper on main only | DB no | UI no | Partial | **Yes** | Pattern filter + optional backfill |
+| SEC-DEFINER-01 | Historical `current_user` bypass | Security | High | **Remediated** | S8 hotfix `20260723201000` | Was privilege skip | Yes | Applied (doc+mig tip) | N/A | PASS (doc) | Carry lesson | Keep tests |
+| GRANT-01 | Widened EXECUTE / PUBLIC grants class | Security | High | Mitigated in S8 migrations | S8 remediation | Over-exposure risk if regressed | Yes | Applied (doc) | N/A | PASS (doc) | **Yes** | Continuous audit |
+| SYNTH-KPI-01 | Prod UI lacks shared excludeSynthetic on money lists | Hygiene | High | **Open on prod** | UX-POLISH/UXV2 undeployed | Synth can pollute prod KPIs/lists | Yes on main | N/A | **No** | Observed gap | **Yes** | Deploy polish/v2 UI |
+| LEAD-DRAWER-01 | Leads drawer race / stage warnings | Leads | Medium | Fixed on main | UX-POLISH | Prod tip may still have race | Yes | N/A | **No** | Unverified on prod tip | Yes | Deploy |
+| PROC-LEDGER-LOCK | PowerShell ledger harness flake | CI | Low | Open | S4 residual | CI noise | Partial | N/A | N/A | N/A | Process | Keep watch |
+| HALT-S7 | Slice 7 not started | Scheduling product | Info | Deferred | Ledgers | N/A | N/A | N/A | N/A | N/A | Deferred | Not a V1 defect |
+| HALT-AUTOCHARGE | Auto-charge disabled | Payments | Info | Policy | S6 | Correct posture | Yes | Yes | Yes | Doc PASS | Carry | Do not enable casually |
+
+## Bug-class reconciliation
+
+| Bug class | Finding |
+| --- | --- |
+| Widened EXECUTE grants | Addressed in S8 remediation migrations (documentary + tip match); live ACL not re-queried |
+| SECURITY DEFINER auth gaps / `current_user` | Hotfixed in `20260723201000` (checksum match) |
+| Alternate writer denials | Estimates INSERT deny; work-order-update payment deny; **invoice-save still present in source** |
+| Text/UUID mismatches | R-S4-06 remediated |
+| Stale schema / missing columns | Ongoing risk — treat UNKNOWN without live schema diff |
+| Trigger bleed | S3 neutralized accepted/paid quote triggers (doc) |
+| Invoice-on-complete boundary | Auto-**draft** on complete (S5); auto-send OFF |
+| Stale route names | Work Orders vs jobs entity residual accepted |
+| Frontend secrets | No `sk_live` in source search |
+| Hostinger/repo drift | **Confirmed this session** (DRIFT-UI-01) |
+| Prod ahead of source | **Not observed** for UI; DB tip matches repo tip name |
+| tenant_id assumptions | Residue accepted |
+| Pricebook mutation risk | Requires ongoing discipline; no new finding this session |
+| Synthetic contamination | Client hygiene undeployed; QB audit open |
+| Unknown lead stages / drawer | Fixed on main; prod tip unverified |
+| Misleading UI labels | Dual vocab residual R-COH-06 |
+| Incomplete mobile acceptance | S8 mobile PASS; full offline app incomplete |
+| Offline queue eviction | R-S8-02 mitigated; full offline deferred |
+| QuickBooks contamination | R-UXP-03 open |
+| Visual/UX acceptance incomplete | UXV2 on main undeployed; Percy scaffold token-gated |

--- a/command-center/docs/v2-handoff/V1_SECURITY_AND_FINANCIAL_POSTURE.md
+++ b/command-center/docs/v2-handoff/V1_SECURITY_AND_FINANCIAL_POSTURE.md
@@ -1,0 +1,50 @@
+# V1 Security and Financial Posture
+
+| Field | Value |
+| --- | --- |
+| Project | `wwyxohjnyqnegzbxtuxs` |
+| Prod UI | `c469f7c8174642f40ca60756c124dec63a80bb10` |
+| Migration tip (build-info) | `20260723201000` |
+
+Evidence labels: **P** production this session · **R** repository · **D** documentary · **U** unresolved this session
+
+## Payment / portal controls
+
+| # | Question | Answer | Evidence |
+| --- | --- | --- | --- |
+| 1 | Invoice auto-send enabled? | **Disabled by policy/default** | D: S6 closeout; R: `invoice_auto_send_enabled` default false; **U**: live `global_config` not re-queried |
+| 2 | Auto-charge enabled? | **Disabled; setter refuses ON** | D+R: `ml_p1_s6_assert_auto_charge_off`; **U**: live flag not re-queried |
+| 3 | Saved cards enabled? | **Disabled / not implemented** | R: no saved-card feature; D: PD-S6-03 |
+| 4 | Customer payment portal? | **Disabled** (Checkout pay-link ≠ Stripe Customer Portal) | D: PD-S6-06; R: no portal product |
+| 5 | Stripe Terminal / embedded card entry? | **No** | R: no Terminal; techs cannot enter cards |
+| 6 | Raw card data in BHFOS? | **No by design** (hosted Checkout) | R+D |
+| 7 | Issued invoices immutable? | **Yes (unpaid)** | D: PD-S5-04/06; R: issue RPC |
+| 8 | Corrections after issue? | **Void + reissue** (unpaid); paid → refund path | D: PD-S5-06 / PD-S6-05 |
+| 9 | Refund authority | Office/admin with audit when flag ON | D+R |
+| 10 | Write-off authority | **Admin-only ratified; implementation deferred** | D: PD-S5-05; residual R-S5-08 |
+| 11 | Synthetic excluded from live totals? | **On main yes; on prod UI no** | R: `excludeSynthetic` undeployed; P: prod tip lacks helper |
+| 12a | Synth → customer communications? | **Risk remains if unflagged rows used in send paths** | U / inference |
+| 12b | Synth → live Stripe? | **Should be blocked by process; not cryptographically enforced for all paths** | U |
+| 12c | Synth → QuickBooks? | **Unresolved** (R-UXP-03) | U |
+| 12d | Synth → live analytics/KPIs? | **Yes risk on prod UI** | P+R drift |
+| 13 | Staging invoices synced externally? | **Unresolved Founder/ops** | U |
+
+## SECURITY DEFINER / grants
+
+| # | Question | Answer | Evidence |
+| --- | --- | --- | --- |
+| 14 | DEFINER functions granted to authenticated/anon/PUBLIC | **Many S8 helpers granted to `authenticated` (+ service_role); public approve to anon** | R: migrations `20260723200000`, `20260721170000`; **U**: live ACL |
+| 15 | Independent JWT/role/tenant checks? | **Intended yes after hotfix** | D: S8 remediation PASS; R: `auth.role()='service_role'` replace `current_user` |
+| 16 | Private helper accidentally exposed? | **`ml_p1_s8_assert_inspection_actor` still granted to authenticated in source** | R: noted in audit; confirm if intentional |
+| 17 | Alternate writers remain? | **Yes in source**: quote draft direct inserts; `quote-update-status`; **`invoice-save`**; declined public path direct update | R |
+| 18 | Financial writers idempotent + audited? | **Canonical S5/S6 RPCs claim yes**; alternate Edge paths weaker | R+D; U for all paths |
+| 19 | Auth hotfixes in source and production? | Source tip = `20260723201000`; build-info migrationVersion matches; checksum matches closeout | R+P+D |
+| 20 | Provisional RLS/GRANT/trigger posture? | **Some accepted residuals** (dual writers, tenant residue); not claimed fully frozen | D+R |
+
+## High-risk open items for V2 inheritance
+
+1. **Deploy lag**: money hygiene and brand fixes exist on `main` but not Hostinger.  
+2. **`invoice-save` Edge**: treat as active risk until production routing proves retired/denied.  
+3. **Write-off gap**: policy exists; product incomplete.  
+4. **QuickBooks contamination**: unverified.  
+5. **Live grant matrix**: not re-audited from database catalogs this session.

--- a/command-center/docs/v2-handoff/V1_UX_AND_FIELD_BASELINE.md
+++ b/command-center/docs/v2-handoff/V1_UX_AND_FIELD_BASELINE.md
@@ -1,0 +1,45 @@
+# V1 UX and Field Usability Baseline
+
+Distinguish evidence: **live-verified** (this session / production build-info or authenticated E2E in closeout docs) · **source-only** · **reviewer observation** · **unverified claim**.
+
+| Surface | Confirmed V1 state | Evidence class |
+| --- | --- | --- |
+| Desktop shell | CRM shell with sidebar primary nav (Hub → Work Orders → Quotes → Inspections → Analytics → Settings) on prod tip | live-verified (deploy closeout markers) + repository @ `c469f7c` |
+| Mobile shell | Bottom bar Hub · Work Orders · Quotes · Inspections · More | repository @ prod tip; live markers in UX-REFACTOR A3 closeout |
+| Product naming | **BHF CRM** on prod mobile header | repository @ `c469f7c` (`BHFCrmLayout.jsx`); **source-only on main is TVG CRM (undeployed)** |
+| Brand consistency | Split era: TVG in some titles, BHF CRM in shell on prod | live-verified HTML title “The Vent Guys CRM” + repo BHF CRM string |
+| Typography | Inter loaded; body wiring completed on main (UX-POLISH); prod tip may still under-use Inter | source-only for full token wire on main |
+| Color tokens | shadcn slate primary on prod tip; brand accent tokens on main | source-only drift |
+| Page headers | `CrmPageHeader` on top office screens (UX-REFACTOR); expanded on main | repository + deploy markers |
+| Navigation structure | Canonical primary nav locked in UX-REFACTOR | repository |
+| Mobile bottom navigation | Inspections in 5th money-adjacent slot on prod; Invoices promoted on main (UXV2) | repository drift |
+| Quotes mobile quality | Gold sample (Dispatch & Quotes) | reviewer observation + prior critiques |
+| Dispatch quality | Gold sample | reviewer observation + prior critiques |
+| Hub density | Equal-weight KPI strip on prod tip; Today hero + KPI toggle on main | repository drift |
+| Work Order density | Improved on main (UX-POLISH); prod tip earlier state | repository drift |
+| Leads behavior | Drawer race / stage mapping fixed on main; **prod tip unverified** | source-only fix undeployed |
+| Invoices behavior | Canonical S5/S6 flows; UI hygiene filter undeployed | mixed |
+| Calendar behavior | Booking source-of-truth messaging present | repository |
+| Call Console behavior | Specialized full-height tool; header polish on main | repository |
+| Inspections behavior | S8 remediation production-validated; search card→toolbar on main only | documentary + drift |
+| Accessibility | Shared headers help; KPI toggle a11y on main; full axe farm deferred | reviewer / source |
+| Installability | **Not a productized PWA** | deferred policy |
+| Offline behavior | Partial inspection/offline cache; not full offline field app | documentary + residual |
+
+## Field usability verdict (Product lens)
+
+V1 is **usable for core TVG office + inspection field loop** on production (quotes → job → schedule/dispatch → inspect → invoice draft/issue → Checkout/offline pay), with known friction:
+
+- Shell brand inconsistency (BHF CRM).  
+- Hub KPI noise / synth pollution risk on prod UI.  
+- Change-order customer token UI incomplete.  
+- Write-off incomplete.  
+- Photo Bundles / full offline / PWA not available (deferred, not defects).
+
+## V2 must not treat as “already done on prod”
+
+- TVG CRM brand unification  
+- Hub Today rewrite  
+- Shared synthetic exclude on money lists  
+- Mobile Invoices one-tap  
+- Percy visual baselines (scaffold only; token-gated)

--- a/command-center/docs/v2-handoff/reviews/V1_CLOSEOUT_ROUND1_ARCHITECTURE.md
+++ b/command-center/docs/v2-handoff/reviews/V1_CLOSEOUT_ROUND1_ARCHITECTURE.md
@@ -1,0 +1,27 @@
+# V1 Closeout — Round 1 (Source of Truth / Architecture)
+
+| Field | Value |
+| --- | --- |
+| Lens | Independent architecture / SoT |
+| Date | 2026-07-24 |
+| Verdict | **PASS** — closeout accurate if drift and evidence gaps remain explicit |
+
+## Checks
+
+| Focus | Result |
+| --- | --- |
+| Current main vs prod UI | **Drift confirmed** via live build-info vs `git rev-parse origin/main` |
+| Migration tip naming | build-info `20260723201000` matches latest repo migration filename |
+| Stale ledger claims | Prior ledgers listing UX-POLISH as “awaiting Hostinger” remain directionally correct |
+| Confirmed vs proposed | UXV2 Hub/brand marked SOURCE MERGED — NOT APPLIED, not production confirmed |
+| Dedicated deployment boundary | Preserved — no multi-tenant claim |
+| Slice naming | S1–S6 + S8 remediation closed; S7 deferred; Photo Bundles deferred |
+| Conflicting authorities | Open stale PRs (#94 etc.) do not override merged main / live build-info |
+
+## Blockers found
+
+None that prevent publishing the closeout. Largest SoT risk is **treating `main` as production**.
+
+## Required reader rule
+
+V2 planning must pin **two SHAs**: production UI `c469f7c…` and repository tip `2557ba2…`, and never collapse them.

--- a/command-center/docs/v2-handoff/reviews/V1_CLOSEOUT_ROUND2_SECURITY.md
+++ b/command-center/docs/v2-handoff/reviews/V1_CLOSEOUT_ROUND2_SECURITY.md
@@ -1,0 +1,32 @@
+# V1 Closeout — Round 2 (Security / Financial / Adversarial)
+
+| Field | Value |
+| --- | --- |
+| Lens | Independent security & money adversarial |
+| Date | 2026-07-24 |
+| Verdict | **PASS with open risks** — posture documented; several items remain production-unverified this session |
+
+## Checks
+
+| Focus | Result |
+| --- | --- |
+| Auto-send / auto-charge | Documented OFF; live config not re-queried |
+| Saved cards / portal / Terminal | Absent in source; policy OFF |
+| Issued immutability / void path | Ratified + S5 RPCs; write-off incomplete |
+| SECURITY DEFINER hotfix | In repo + migration tip match; live ACL not re-queried |
+| Alternate writers | **`invoice-save` still in source** — adversarial must assume reachable until proven otherwise |
+| Synthetic contamination | Client exclude on main only; prod KPIs vulnerable |
+| QuickBooks | External sync audit unresolved |
+| Historical preservation | Grandfathering ratified; no rewrite |
+
+## Adversarial top risks for V2
+
+1. Deploy UI hygiene without verifying Edge route denylist (`invoice-save`).  
+2. Enable auto-send/auto-charge without Major Decision.  
+3. Assume synth cannot reach Stripe/QB.  
+4. Treat DEFINER grants as frozen without catalog audit.  
+5. Expand QuickBooks before R-UXP-03.
+
+## Residual security items that stay open
+
+ALT-INV-01 · R-UXP-03 · SYNTH-KPI-01 · E-GAP-01/02/03/07 in evidence manifest.

--- a/command-center/docs/v2-handoff/reviews/V1_CLOSEOUT_ROUND3_PRODUCT_UX.md
+++ b/command-center/docs/v2-handoff/reviews/V1_CLOSEOUT_ROUND3_PRODUCT_UX.md
@@ -1,0 +1,30 @@
+# V1 Closeout — Round 3 (Product / UX / Founder Usability)
+
+| Field | Value |
+| --- | --- |
+| Lens | Independent product & field usability |
+| Date | 2026-07-24 |
+| Verdict | **PASS** — V1 is operationally usable; remaining polish mostly belongs to V2 deploy + residual close |
+
+## Checks
+
+| Focus | Result |
+| --- | --- |
+| Can Founder run core money loop on prod? | **Yes** (quotes → job → schedule/dispatch → invoice → pay) per closed S3–S6 |
+| Field inspection usable? | **Yes** per S8 remediation mobile PASS |
+| Visual system unified on prod? | **No** — BHF CRM shell; Hub KPI density; synth noise risk |
+| Mobile money friction? | Invoices behind More on prod tip |
+| Founder interruption burden | High if V2 re-litigates ratified money halts |
+| What belongs in V2 vs V1 closeout | Deploy UX-POLISH/UXV2; write-off; change-order customer UI; QB audit; not re-building S1–S6 |
+
+## Usability barriers still on production
+
+- Brand split (BHF CRM vs Vent Guys title).  
+- Hub density / KPI equality.  
+- Synthetic rows in live lists/KPIs (no shared exclude on prod tip).  
+- Incomplete write-off and customer change-order token UI.  
+- No Photo Bundles / full offline / PWA (deferred — do not call V1 failure).
+
+## Instruction to V2
+
+Do not reopen ratified financial halts as “UX bugs.” Treat Hostinger deploy of already-merged polish as the first V2 operational act unless Founder sequences differently.


### PR DESCRIPTION
## Summary
- Authoritative **V1 Production Closeout** package under `command-center/docs/v2-handoff/`.
- Independently verified: prod UI `c469f7c8174642f40ca60756c124dec63a80bb10` vs main `2557ba28490ae38970b3a32de95130746a5b9333` (13 commits ahead); `migrationVersion=20260723201000`.
- Includes state matrix, ratified decisions, residuals, security/financial posture, UX baseline, deferred scope, evidence manifest, and 3 critique rounds.
- **Docs-only.** No app code, migrations, or deploy.

## Test plan
- [ ] Docs-only diff (no `command-center/src` / migrations)
- [ ] CI / ledger_lock green
- [ ] Founder/reviewer scan of drift + open residuals before merge