### PR TITLE
feat(mil): contributor self-upload + staging evidence

### DIFF
--- a/command-center/docs/media-intelligence/ACCESS_ARCHITECTURE.md
+++ b/command-center/docs/media-intelligence/ACCESS_ARCHITECTURE.md
@@ -51,14 +51,15 @@ Legend: **Y** = allowed via RLS/RPC/edge when gates pass · **—** = denied · 
 
 | Capability | Admin / Manager | Reviewer (`media_reviewer`) | Office | Creator (`reel_creator`) | Session bearer |
 |---|---|---|---|---|---|
-| Browse library / derivatives | Y | Y | Y | Assigned only | — |
-| Browse private originals | Y | Y | Y | — (assigned previews via sign edge) | — |
+| Browse library / derivatives | Y | Y | Y | Assigned + **own uploads** only | — |
+| Browse private originals | Y | Y | Y | — (assigned/own previews via sign edge) | — |
 | Staff upload (desktop) | Y | Y | Y | — | — |
 | Phone / field upload | Y (mint session) | — | — | — | **S** (grant-bound TUS to quarantine) |
+| Contributor self-upload (`/creator` Upload my shots) | — | — | — | **Y** (JWT `create_contributor_session` → quarantine finalize; lands in Review; auto-assigned to self) | — |
 | Verify / review writes | Y | Y | **—** (`mil_is_reviewer` excludes office) | — | — |
 | Approve / deny reels | Y | — | — | — | — |
 | Invite / assign / revoke creators | Y (edge `media-intel-creator-admin`) | — | — | — | — |
-| Create / revoke upload sessions | Y | — | — | — | — |
+| Create / revoke upload sessions (owner phone QR) | Y | — | — | — | — |
 | Website promote | **Disabled (503)** — see below | — | — | — | — |
 | Website unpublish | Y | — | — | — | — |
 | Creator portal | Inspect only | — | — | Y | — |
@@ -79,7 +80,7 @@ Legend: **Y** = allowed via RLS/RPC/edge when gates pass · **—** = denied · 
 
 ### Creator isolation (role + resource — not tenancy)
 
-Creators must not access CRM, customers/jobs, raw intake, private originals, restricted/unreviewed assets, unassigned work, owner/reviewer actions, rights admin, other creators’ assignments, website promotion, or social publishing.
+Creators must not access CRM, customers/jobs, other people’s raw intake, private originals, restricted assets belonging to others, unassigned library work, owner/reviewer actions, rights admin, other creators’ assignments, website promotion, or social publishing. They **may** upload their own phone shots via Contributor Workspace (`create_contributor_session`); those assets land in owner Review and are visible to that creator only (plus staff) until verified.
 
 - `reel_creation` permitted use makes an asset **eligible for assignment**, not globally visible to every creator.
 - Access requires an **active** direct assignment or **active** assigned collection (revocation blocks new signed links).

--- a/command-center/docs/media-intelligence/IMPLEMENTATION_STATUS.md
+++ b/command-center/docs/media-intelligence/IMPLEMENTATION_STATUS.md
@@ -1,8 +1,21 @@
 # Media Intelligence Library — Implementation Status
 
 **Branch:** `feat/media-intelligence-library`  
-**Verified HEAD at this status edit:** contributor accept/deny USABLE (see git log / this section)  
+**Verified HEAD at this status edit:** contributor self-upload (Upload my shots) — see section below  
 **Architecture:** Single-company (see `SINGLE_COMPANY_CORRECTION.md`)
+
+## Contributor self-upload — Upload my shots (2026-07-30) — SOURCE + local tests; staging apply pending
+
+| Field | Value |
+|---|---|
+| Product | Contributor JWT mints `create_contributor_session`; quarantine finalize; Review Queue; auto-assign to uploader; My shots list on `/creator` |
+| Schema | `20260730180000_media_intel_contributor_self_upload.sql` — own-upload visibility + trigger auto-assign + `contractor_supplied` |
+| Edge | `media-intel-upload-session` `create_contributor_session`; `media-intel-sign` allows own-upload preview/download (never originals) |
+| UI | `MediaCreatorWorkspace` Upload my shots + My shots; `canContributorSelfUpload` |
+| Tests | `media-intel-contributor` + access contracts |
+| Non-goals | No full library browse; no owner phone-QR bypass for staff without creator grant |
+| Evidence tier | **SOURCE-ONLY** until staging migrate + edge + frontend deploy + USABLE acceptance |
+| Staging next | Apply migration on `sdzhdupekcnekesbtxsl`; deploy upload-session + sign; mil-staging frontend; contributor uploads 1–2 JPEGs |
 
 ## Owner-led acceptance (2026-07-30) — CONTRIBUTOR ACCEPT + DENY USABLE (ERRON)
 

--- a/command-center/docs/media-intelligence/IMPLEMENTATION_STATUS.md
+++ b/command-center/docs/media-intelligence/IMPLEMENTATION_STATUS.md
@@ -4,18 +4,20 @@
 **Verified HEAD at this status edit:** contributor self-upload (Upload my shots) — see section below  
 **Architecture:** Single-company (see `SINGLE_COMPANY_CORRECTION.md`)
 
-## Contributor self-upload — Upload my shots (2026-07-30) — SOURCE + local tests; staging apply pending
+## Contributor self-upload — Upload my shots (2026-07-30) — STAGING DEPLOYED; browser USABLE pending
 
 | Field | Value |
 |---|---|
+| Commit | `52527c59de2b0817ae770d1d2f648f1fbf9b7ed3` |
 | Product | Contributor JWT mints `create_contributor_session`; quarantine finalize; Review Queue; auto-assign to uploader; My shots list on `/creator` |
-| Schema | `20260730180000_media_intel_contributor_self_upload.sql` — own-upload visibility + trigger auto-assign + `contractor_supplied` |
-| Edge | `media-intel-upload-session` `create_contributor_session`; `media-intel-sign` allows own-upload preview/download (never originals) |
-| UI | `MediaCreatorWorkspace` Upload my shots + My shots; `canContributorSelfUpload` |
-| Tests | `media-intel-contributor` + access contracts |
-| Non-goals | No full library browse; no owner phone-QR bypass for staff without creator grant |
-| Evidence tier | **SOURCE-ONLY** until staging migrate + edge + frontend deploy + USABLE acceptance |
-| Staging next | Apply migration on `sdzhdupekcnekesbtxsl`; deploy upload-session + sign; mil-staging frontend; contributor uploads 1–2 JPEGs |
+| Schema | `20260730180000_media_intel_contributor_self_upload.sql` — **applied** on `sdzhdupekcnekesbtxsl` |
+| Edge | `media-intel-upload-session` + `media-intel-sign` redeployed (`--use-api`); creator mint smoke HTTP 200 + token |
+| UI | Hosted `CreatorRoutes-92513759.js` has Upload my shots / contributor-upload-my-shots |
+| Hosted frontend | `https://mil.bhfos.com` SHA **52527c59de2b** / `mil-staging` / `migrationVersion=20260730180000` / asset `2dbb7ce8b75daa50`; Supabase only `sdzhdupekcnekesbtxsl` |
+| Deploy archive | `command-center/tmp/mil-staging-52527c59de2b-20260730T211125Z.zip` (auth `MIL-CONTRIBUTOR-SELF-UPLOAD-FRONTEND-2026-07-30`) |
+| Tests | `npm run test:media-intel-helpers` **181 pass** |
+| Non-goals | No full library browse; no originals; no reconcile cron |
+| Evidence tier | **DEPLOYED** (API mint smoke). Browser USABLE (1–2 JPEG self-upload → Review → My shots) still owner/contributor hands-on |
 
 ## Owner-led acceptance (2026-07-30) — CONTRIBUTOR ACCEPT + DENY USABLE (ERRON)
 

--- a/command-center/docs/media-intelligence/IMPLEMENTATION_STATUS.md
+++ b/command-center/docs/media-intelligence/IMPLEMENTATION_STATUS.md
@@ -1,8 +1,25 @@
 # Media Intelligence Library — Implementation Status
 
 **Branch:** `feat/media-intelligence-library`  
-**Verified HEAD at this status edit:** contributor self-upload (Upload my shots) — see section below  
+**Verified HEAD at this status edit:** `28800eca7fd89bc58f7d6400c0353067a9a2076a`  
 **Architecture:** Single-company (see `SINGLE_COMPANY_CORRECTION.md`)
+
+## Production — contributor self-upload + Treezy role (2026-07-30/31) — DEPLOYED
+
+| Field | Value |
+|---|---|
+| Production home | `https://app.bhfos.com` + Supabase **`wwyxohjnyqnegzbxtuxs`** |
+| Git tip deployed | `28800eca7fd8` (`feat/media-intelligence-library`; PR [#128](https://github.com/faydog127/BHFOS/pull/128) open for `main`) |
+| Migrations | Twelve MIL versions `20260725120000`…`20260730180000` applied on `wwyx` (no unrelated older CRM gaps forced via `db push --include-all`) |
+| Secrets | `MIL_RECONCILE_KEY` (new prod entropy) + `MIL_ALLOWED_ORIGINS` (includes `https://app.bhfos.com`); existing `OPENAI_API_KEY` retained |
+| Edges | All seven `media-intel-*` ACTIVE on `wwyx` (deployed `--use-api`) |
+| Frontend | Hostinger `production` / `app.bhfos.com` `build-info` SHA **28800eca7fd8** / `environment=production` / `migrationVersion=20260730180000`; bundle Supabase ref **only** `wwyxohjnyqnegzbxtuxs` |
+| Hosted UI marker | `CreatorRoutes-2351ca8d.js` contains Upload my shots / My shots / contributor-upload-my-shots |
+| Deploy archive | `command-center/tmp/production-28800eca7fd8-20260731T010029Z.zip` (auth `MIL-PROD-CONTRIBUTOR-SELF-UPLOAD-2026-07-30`) |
+| Treezy | `treezyincent@gmail.com` on prod Auth (confirmed) + `app_user_roles.role = reel_creator` (**no** `tenant_id` column on prod) |
+| Staging remains | `https://mil.bhfos.com` / `sdzhdupekcnekesbtxsl` untouched as staging |
+| Explicit non-actions | No reconcile cron; website promote stays 503 |
+| Evidence tier | **DEPLOYED** (prod schema + edges + CRM frontend + role). Browser **USABLE** for Treezy Upload my shots still owner/contributor hands-on |
 
 ## Contributor self-upload — Upload my shots (2026-07-30) — STAGING DEPLOYED; browser USABLE pending
 
@@ -31,20 +48,13 @@
 | Still not claimed | changes-requested / revised-version preservation cycle (unless later separately confirmed) |
 | Production | Code merged via PR #127 (`9d70ef9` on `main`); production migrate/edge/CRM deploy still gated on credentials per packet below |
 
-## Production release kickoff (2026-07-30) — PACKET READY; PR MERGED; MUTATIONS BLOCKED ON CREDENTIALS
+## Production release kickoff (2026-07-30) — SUPERSEDED BY PROD DEPLOY SECTION ABOVE
 
 | Field | Value |
 |---|---|
-| Founder intent | Proceed with remaining production jobs (prod migrate → edges → `app.bhfos.com` deploy → synthetic smoke) |
 | Packet | [`PRODUCTION_APPLY_PACKET.md`](./PRODUCTION_APPLY_PACKET.md) |
-| Git | PR [#127](https://github.com/faydog127/BHFOS/pull/127) **merged** to `main` (`9d70ef9`) after CI green |
-| Production home | CRM `https://app.bhfos.com` + Supabase **`wwyxohjnyqnegzbxtuxs`** (not `mil.bhfos.com`) |
-| Staging remains | `https://mil.bhfos.com` / `sdzhdupekcnekesbtxsl` / Hostinger target `mil-staging` |
-| Hosted staging tip | `https://mil.bhfos.com` `build-info` SHA **39e4b941dc63** / `mil-staging` |
-| Blocking for mutate | Process/User `SUPABASE_ACCESS_TOKEN` **absent**; production `VITE_*` for CRM build not confirmed in this worktree |
-| Available (names) | Sibling operator env has `HOSTINGER_API_TOKEN` (for later `production` Hostinger deploy) — not used yet |
-| Explicit non-actions until unblocked | No prod migration apply, no prod edge deploy, no `app.bhfos.com` Hostinger mutate, no reconcile cron, no website promote |
-| Next mutate gate | Provide `SUPABASE_ACCESS_TOKEN` for `wwyxohjnyqnegzbxtuxs` + production `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`; then execute packet steps 3–8 |
+| Git (earlier) | PR [#127](https://github.com/faydog127/BHFOS/pull/127) **merged** to `main` (`9d70ef9`); self-upload tip via PR [#128](https://github.com/faydog127/BHFOS/pull/128) |
+| Outcome | Prod migrate + edges + `app.bhfos.com` Hostinger deploy completed 2026-07-31 (see **Production — contributor self-upload** section) |
 
 ## Owner-led acceptance (2026-07-29) — DISTINCT-IDENTITY WORKFLOW OBSERVED BY ERRON
 

--- a/command-center/docs/media-intelligence/IMPLEMENTATION_STATUS.md
+++ b/command-center/docs/media-intelligence/IMPLEMENTATION_STATUS.md
@@ -1,23 +1,35 @@
 # Media Intelligence Library — Implementation Status
 
 **Branch:** `feat/media-intelligence-library`  
-**Verified HEAD at this status edit:** production apply packet + release kickoff (see git log)  
+**Verified HEAD at this status edit:** contributor accept/deny USABLE (see git log / this section)  
 **Architecture:** Single-company (see `SINGLE_COMPANY_CORRECTION.md`)
 
-## Production release kickoff (2026-07-30) — PACKET + PR PATH; MUTATIONS BLOCKED ON CREDENTIALS
+## Owner-led acceptance (2026-07-30) — CONTRIBUTOR ACCEPT + DENY USABLE (ERRON)
 
 | Field | Value |
 |---|---|
-| Founder intent | Proceed with remaining production jobs (merge → prod migrate → edges → `app.bhfos.com` deploy → synthetic smoke) |
+| Observer | Erron (owner-led hands-on) |
+| Host | `https://mil.bhfos.com` staging (`build-info` tip **39e4b941dc63** / `mil-staging` at record time) |
+| Observed | Accept **and** denial tested from the contributor path — **worked** (owner-confirmed) |
+| Prior distinct-identity (2026-07-29) | owner assignment → separate contributor login → preview/download → submit → owner review |
+| Evidence tier | **USABLE** (owner-confirmed). Closes the prior gap that final accept/deny had not been evidenced. |
+| Still not claimed | changes-requested / revised-version preservation cycle (unless later separately confirmed) |
+| Production | Code merged via PR #127 (`9d70ef9` on `main`); production migrate/edge/CRM deploy still gated on credentials per packet below |
+
+## Production release kickoff (2026-07-30) — PACKET READY; PR MERGED; MUTATIONS BLOCKED ON CREDENTIALS
+
+| Field | Value |
+|---|---|
+| Founder intent | Proceed with remaining production jobs (prod migrate → edges → `app.bhfos.com` deploy → synthetic smoke) |
 | Packet | [`PRODUCTION_APPLY_PACKET.md`](./PRODUCTION_APPLY_PACKET.md) |
+| Git | PR [#127](https://github.com/faydog127/BHFOS/pull/127) **merged** to `main` (`9d70ef9`) after CI green |
 | Production home | CRM `https://app.bhfos.com` + Supabase **`wwyxohjnyqnegzbxtuxs`** (not `mil.bhfos.com`) |
 | Staging remains | `https://mil.bhfos.com` / `sdzhdupekcnekesbtxsl` / Hostinger target `mil-staging` |
-| Local helpers | `npm run test:media-intel-helpers` **180 pass / 0 fail** (this session) |
-| Hosted staging tip | `https://mil.bhfos.com` `build-info` SHA **39e4b941dc63** / `mil-staging` (unchanged by this kickoff) |
-| Blocking for mutate | Process/User `SUPABASE_ACCESS_TOKEN` **absent**; linked CLI project is staging only; production `VITE_*` for CRM build not confirmed in this worktree |
+| Hosted staging tip | `https://mil.bhfos.com` `build-info` SHA **39e4b941dc63** / `mil-staging` |
+| Blocking for mutate | Process/User `SUPABASE_ACCESS_TOKEN` **absent**; production `VITE_*` for CRM build not confirmed in this worktree |
 | Available (names) | Sibling operator env has `HOSTINGER_API_TOKEN` (for later `production` Hostinger deploy) — not used yet |
 | Explicit non-actions until unblocked | No prod migration apply, no prod edge deploy, no `app.bhfos.com` Hostinger mutate, no reconcile cron, no website promote |
-| Next mutate gate | Provide `SUPABASE_ACCESS_TOKEN` (management PAT) for project `wwyxohjnyqnegzbxtuxs` + confirm production frontend `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` for that project; then execute packet steps 3–8 after PR/CI/merge |
+| Next mutate gate | Provide `SUPABASE_ACCESS_TOKEN` for `wwyxohjnyqnegzbxtuxs` + production `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`; then execute packet steps 3–8 |
 
 ## Owner-led acceptance (2026-07-29) — DISTINCT-IDENTITY WORKFLOW OBSERVED BY ERRON
 
@@ -25,10 +37,10 @@
 |---|---|
 | Observer | Erron (owner-led hands-on) |
 | Observed | owner assignment → genuinely separate contributor login → contributor preview/download → contributor submission → owner review |
-| Not claimed here | changes-requested cycle, revised-version preservation, or final approval — not evidenced as performed in this acceptance |
-| Management API | Relisting **unavailable** this session (`SUPABASE_ACCESS_TOKEN` absent). Do not treat frontend work as blocked. Do not use anon/service-role/JWT as a management token. |
+| Follow-up (2026-07-30) | Accept **and** denial from contributor path confirmed **USABLE** — see section above |
+| Management API | Relisting **unavailable** when recorded (`SUPABASE_ACCESS_TOKEN` absent). Do not treat frontend work as blocked. Do not use anon/service-role/JWT as a management token. |
 | Credential scan (prior + this session) | No credential-exposure incident. Hosted/frontend artifact: no `SUPABASE_ACCESS_TOKEN`, no `sbp_*` management-token pattern; any `service_role` hit is a role-name literal, not an embedded key. |
-| Evidence tier | **USABLE** for the observed steps above (owner-confirmed). Staging ship checklist complete enough for production packet; remaining = PR/merge + production apply. |
+| Evidence tier | **USABLE** for the observed steps (owner-confirmed). |
 
 ## Contributor Workspace (2026-07-28) — FRONTEND DEPLOYED; owner-observed acceptance recorded
 
@@ -455,9 +467,9 @@ Accepted (SOURCE + unit/contract tests + local SQL where noted; staging-unproven
 
 Still open (production path — Founder authorized kickoff 2026-07-30):
 
-1. **Exact next action:** PR `feat/media-intelligence-library` → `main` → CI green → merge → execute [`PRODUCTION_APPLY_PACKET.md`](./PRODUCTION_APPLY_PACKET.md) on `wwyxohjnyqnegzbxtuxs` + Hostinger `production` (`app.bhfos.com`)
+1. **Exact next action:** Execute [`PRODUCTION_APPLY_PACKET.md`](./PRODUCTION_APPLY_PACKET.md) on `wwyxohjnyqnegzbxtuxs` + Hostinger `production` (`app.bhfos.com`) once credentials are available (PR #127 already merged)
 2. **Authorization boundary:** Founder authorized production release intent; mutating steps still require `SUPABASE_ACCESS_TOKEN` + production `VITE_*`. No reconcile cron. No website promote. Leave mil-staging untouched as staging.
-3. Staging acceptance (distinct-identity) already owner-observed **USABLE**; list-thumb browser USABLE optional spot-check only
+3. Staging acceptance: distinct-identity + contributor **accept/deny** owner-confirmed **USABLE** (2026-07-30)
 
 ### Active defects (honest)
 

--- a/command-center/docs/media-intelligence/PRODUCTION_APPLY_PACKET.md
+++ b/command-center/docs/media-intelligence/PRODUCTION_APPLY_PACKET.md
@@ -45,8 +45,11 @@ Related: [`STAGING_APPLY_PACKET.md`](./STAGING_APPLY_PACKET.md), [`ENV_CONTRACT.
 | `20260728010000` | `supabase/migrations/20260728010000_media_intel_client_upload_id.sql` |
 | `20260728120000` | `supabase/migrations/20260728120000_media_intel_quality_cleanup_lifecycle.sql` |
 | `20260728140000` | `supabase/migrations/20260728140000_media_intel_contributor_workspace.sql` |
+| `20260730180000` | `supabase/migrations/20260730180000_media_intel_contributor_self_upload.sql` |
 
 Preflight (read-only): list `supabase_migrations.schema_migrations` on production and skip any version already present. Never re-apply a version that is already recorded.
+
+**Apply note (2026-07-31):** Production had unrelated older CRM migration gaps that blocked plain `db push`. MIL versions were applied file-by-file with `supabase db query --linked -f` and then recorded in `schema_migrations` — do **not** use `db push --include-all` to force non-MIL historical gaps as part of an MIL release.
 
 ## Edge functions (after secrets)
 

--- a/command-center/src/lib/mediaIntel/api.js
+++ b/command-center/src/lib/mediaIntel/api.js
@@ -89,6 +89,7 @@ export async function listAssets(filters = {}) {
   if (filters.humanReviewStatus) q = q.eq('human_review_status', filters.humanReviewStatus);
   if (filters.privacyStatus) q = q.eq('privacy_status', filters.privacyStatus);
   if (filters.processingStatus) q = q.eq('processing_status', filters.processingStatus);
+  if (filters.createdByUserId) q = q.eq('created_by_user_id', filters.createdByUserId);
   if (filters.archived === true) q = q.not('archived_at', 'is', null);
   else if (filters.archived === false) q = q.is('archived_at', null);
   if (filters.trashed === true) q = q.not('trashed_at', 'is', null);

--- a/command-center/src/lib/mediaIntel/roles.js
+++ b/command-center/src/lib/mediaIntel/roles.js
@@ -52,6 +52,8 @@ export function milCapabilities(role) {
     // for legacy accounts. Phone uploads are authorized purely by a bearer session
     // token (mil_upload_sessions) minted by an owner/admin, never by this role.
     canUpload: isLibraryStaff,
+    // Contributor self-shot intake on /creator — not broad library staff upload.
+    canContributorSelfUpload: r === 'reel_creator',
     canVerify: REVIEWERS.has(r),
     canLifecycleCleanup: REVIEWERS.has(r),
     canPermanentDelete: OWNERS.has(r),

--- a/command-center/src/lib/mediaIntel/uploadManager.js
+++ b/command-center/src/lib/mediaIntel/uploadManager.js
@@ -120,6 +120,17 @@ export async function createUploadSession({ label, sourcePhone, sourcePerson, ex
   return result.payload;
 }
 
+/** Contributor JWT self-scoped session for Upload my shots (not owner phone QR). */
+export async function createContributorUploadSession({ sourcePerson, expiresHours } = {}) {
+  const result = await callUploadSession({
+    action: 'create_contributor_session',
+    sourcePerson: sourcePerson || null,
+    expiresHours: expiresHours || 12,
+  });
+  if (!result.ok) throw raiseSessionError(result, 'Could not start contributor self-upload');
+  return result.payload;
+}
+
 export async function validateUploadSession(token) {
   const result = await callUploadSession({ action: 'validate', token });
   if (!result.ok) throw raiseSessionError(result, 'Upload session is not usable');

--- a/command-center/src/pages/crm/media/MediaCreatorWorkspace.jsx
+++ b/command-center/src/pages/crm/media/MediaCreatorWorkspace.jsx
@@ -2,7 +2,12 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { supabase } from '@/lib/customSupabaseClient';
 import { listAssets, submitReelVersion } from '@/lib/mediaIntel/api';
+import { PRIVACY_LABELS } from '@/lib/mediaIntel/constants';
 import { requestSignedMediaUrl, requestSignedReelUrl } from '@/lib/mediaIntel/signedAccess';
+import {
+  createContributorUploadSession,
+  uploadFilesToSession,
+} from '@/lib/mediaIntel/uploadManager';
 import {
   approvedUseChips,
   CONTRIBUTOR_SEARCH_MIN_COUNT,
@@ -86,7 +91,9 @@ export default function MediaCreatorWorkspace({ caps: capsProp } = {}) {
   const outlet = useOutletContext() || {};
   const caps = capsProp || outlet.caps;
   const fileRef = useRef(null);
+  const selfShotRef = useRef(null);
   const [available, setAvailable] = useState([]);
+  const [myShots, setMyShots] = useState([]);
   const [assignments, setAssignments] = useState([]);
   const [projects, setProjects] = useState([]);
   const [title, setTitle] = useState('');
@@ -94,6 +101,8 @@ export default function MediaCreatorWorkspace({ caps: capsProp } = {}) {
   const [error, setError] = useState(null);
   const [message, setMessage] = useState(null);
   const [busy, setBusy] = useState(false);
+  const [selfUploadBusy, setSelfUploadBusy] = useState(false);
+  const [selfUploadNote, setSelfUploadNote] = useState(null);
   const [mediaBusyId, setMediaBusyId] = useState(null);
   const [batchBusy, setBatchBusy] = useState(false);
   const [mediaSearch, setMediaSearch] = useState('');
@@ -130,10 +139,24 @@ export default function MediaCreatorWorkspace({ caps: capsProp } = {}) {
 
   const load = async () => {
     try {
+      const { data: auth } = await supabase.auth.getUser();
       const assets = await listAssets({ archived: false, trashed: false, limit: 100 });
       setAvailable(assets);
-      void loadThumbs(assets);
-      const { data: auth } = await supabase.auth.getUser();
+
+      let own = [];
+      if (caps?.canContributorSelfUpload && auth?.user?.id) {
+        own = await listAssets({
+          archived: false,
+          trashed: false,
+          createdByUserId: auth.user.id,
+          limit: 80,
+        });
+        setMyShots(own);
+      } else {
+        setMyShots([]);
+      }
+      void loadThumbs([...(assets || []), ...own]);
+
       let assignQ = supabase
         .from('mil_creator_assignments')
         .select(
@@ -161,6 +184,57 @@ export default function MediaCreatorWorkspace({ caps: capsProp } = {}) {
       setProjects(data || []);
     } catch (err) {
       setError(err.message);
+    }
+  };
+
+  const uploadMyShots = async (fileList) => {
+    const files = Array.from(fileList || []).filter(Boolean);
+    if (!files.length) return;
+    if (!caps?.canContributorSelfUpload) {
+      setError('Only contributors can upload their own shots here.');
+      return;
+    }
+    setSelfUploadBusy(true);
+    setError(null);
+    setMessage(null);
+    setSelfUploadNote(`Starting transfer of ${files.length} file(s)…`);
+    try {
+      const session = await createContributorUploadSession({
+        sourcePerson: 'Contributor self-upload',
+        expiresHours: 12,
+      });
+      if (!session?.token) throw new Error('Contributor upload session was not created.');
+      const outcomes = new Map();
+      await uploadFilesToSession({
+        token: session.token,
+        batchId: session.batchId,
+        files,
+        onFileUpdate: (item) => {
+          if (item?.clientUploadId) outcomes.set(item.clientUploadId, item.status);
+          const vals = [...outcomes.values()];
+          const done = vals.filter((s) => s === 'uploaded' || s === 'duplicate').length;
+          const failed = vals.filter((s) => s === 'failed').length;
+          setSelfUploadNote(
+            `Transfer progress: ${done} uploaded${failed ? `, ${failed} failed` : ''} (of ${files.length}).`,
+          );
+        },
+      });
+      const vals = [...outcomes.values()];
+      const done = vals.filter((s) => s === 'uploaded' || s === 'duplicate').length;
+      const failed = vals.filter((s) => s === 'failed').length;
+      setMessage(
+        failed
+          ? `Uploaded ${done} shot(s); ${failed} failed. Keep phone originals until verified.`
+          : `Uploaded ${done || files.length} shot(s). They are in owner Review — keep phone originals until verified.`,
+      );
+      setSelfUploadNote(null);
+      await load();
+    } catch (err) {
+      setError(err.message || 'Self-upload failed');
+      setSelfUploadNote(null);
+    } finally {
+      setSelfUploadBusy(false);
+      if (selfShotRef.current) selfShotRef.current.value = '';
     }
   };
 
@@ -332,7 +406,9 @@ export default function MediaCreatorWorkspace({ caps: capsProp } = {}) {
     <div className="space-y-6" data-testid="media-creator-workspace">
       <div>
         <h2 className="text-xl font-semibold tracking-tight text-slate-900">Contributor Workspace</h2>
-        <p className="text-sm text-slate-500 mt-0.5">Brief → download working copies → submit draft.</p>
+        <p className="text-sm text-slate-500 mt-0.5">
+          Brief → download working copies → upload your shots → submit draft.
+        </p>
       </div>
       {error && <div className="text-sm text-red-700">{error}</div>}
       {message && <div className="text-sm text-emerald-700">{message}</div>}
@@ -471,6 +547,93 @@ export default function MediaCreatorWorkspace({ caps: capsProp } = {}) {
           </p>
         )}
       </section>
+
+      {caps?.canContributorSelfUpload && (
+        <section className="rounded-xl border bg-white p-4 space-y-3" data-testid="contributor-upload-my-shots">
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div>
+              <h3 className="text-base font-semibold text-slate-900">Upload my shots</h3>
+              <p className="text-xs text-slate-500 mt-0.5">
+                Photos or video you took on your phone. They go to owner Review first (privacy/quality).
+                This is not the reel Submissions uploader. Keep originals on the phone until verified.
+              </p>
+            </div>
+            <button
+              type="button"
+              disabled={selfUploadBusy}
+              className="rounded-md bg-slate-900 text-white px-4 py-2.5 text-sm font-medium min-h-[44px] disabled:opacity-50"
+              onClick={() => selfShotRef.current?.click()}
+              data-testid="contributor-upload-my-shots-btn"
+            >
+              {selfUploadBusy ? 'Uploading…' : 'Choose photos'}
+            </button>
+          </div>
+          <input
+            ref={selfShotRef}
+            type="file"
+            accept="image/*,video/*,.heic,.heif,.jpg,.jpeg,.png,.webp,.mp4,.mov"
+            multiple
+            className="hidden"
+            onChange={(e) => uploadMyShots(e.target.files)}
+          />
+          {selfUploadNote && <p className="text-xs text-slate-600">{selfUploadNote}</p>}
+
+          <h4 className="text-sm font-medium text-slate-800 pt-1">My shots</h4>
+          {myShots.length === 0 ? (
+            <p className="text-sm text-slate-600">No self-uploads yet.</p>
+          ) : (
+            <ul className="grid grid-cols-2 lg:grid-cols-3 gap-2" data-testid="contributor-my-shots-list">
+              {myShots.map((a) => {
+                const thumb = thumbUrls[a.id];
+                const privacy = PRIVACY_LABELS[a.privacy_status] || a.privacy_status;
+                const review =
+                  a.human_review_status === 'verified'
+                    ? 'Verified'
+                    : a.human_review_status === 'pending'
+                      ? 'Awaiting review'
+                      : a.human_review_status;
+                return (
+                  <li key={a.id} className="rounded-md border overflow-hidden text-sm flex flex-col">
+                    <div className="aspect-square bg-slate-100 relative">
+                      {thumb ? (
+                        <img src={thumb} alt="" className="absolute inset-0 h-full w-full object-cover" />
+                      ) : (
+                        <div className="absolute inset-0 flex items-center justify-center text-xs text-slate-500 px-2 text-center">
+                          Preview preparing
+                        </div>
+                      )}
+                    </div>
+                    <div className="p-2 space-y-1.5 flex-1 flex flex-col">
+                      <p className="text-[11px] text-slate-600 leading-snug">
+                        {review} · {privacy}
+                      </p>
+                      <p className="truncate text-[11px] text-slate-500">{a.original_filename}</p>
+                      <div className="flex flex-wrap gap-1.5 mt-auto">
+                        <button
+                          type="button"
+                          disabled={mediaBusyId === a.id || selfUploadBusy}
+                          className="rounded-md border px-2.5 py-1.5 text-xs min-h-[36px] text-slate-700"
+                          onClick={() => openAssignedMedia(a.id, 'preview')}
+                        >
+                          Preview
+                        </button>
+                        <button
+                          type="button"
+                          disabled={mediaBusyId === a.id || selfUploadBusy}
+                          className="rounded-md border px-2.5 py-1.5 text-xs min-h-[36px] text-slate-700"
+                          onClick={() => downloadOne(a)}
+                        >
+                          Download
+                        </button>
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+      )}
 
       <section className="rounded-xl border bg-white p-4 space-y-3">
         <h3 className="text-base font-semibold text-slate-900">Submissions</h3>

--- a/command-center/src/pages/crm/media/MediaSettings.jsx
+++ b/command-center/src/pages/crm/media/MediaSettings.jsx
@@ -288,7 +288,7 @@ export default function MediaSettings() {
         <h3 className="font-medium">AI analysis</h3>
         <p className="text-sm text-slate-700">{ai?.message || 'Checking…'}</p>
         <p className="text-xs text-slate-500">
-          Server env: <code>OPENAI_API_KEY</code> (edge). Never place keys in the browser, repo, or database.
+          Server: OpenAI key as an edge function secret only. Never place keys in the browser, repo, or database.
         </p>
       </section>
 

--- a/command-center/supabase/functions/media-intel-sign/index.ts
+++ b/command-center/supabase/functions/media-intel-sign/index.ts
@@ -14,7 +14,9 @@ const PREVIEW_TTL = 300
 const DOWNLOAD_TTL = 600
 const VALID_PURPOSES = new Set(['preview', 'download'])
 const STAFF_ROLES = new Set(['admin', 'manager', 'office', 'media_reviewer'])
-const CREATOR_DERIVATIVE_KINDS = new Set(['creator_download', 'detail_preview', 'grid_thumb', 'video_preview', 'video_thumb'])
+const CREATOR_DERIVATIVE_KINDS = new Set([
+  'creator_download', 'detail_preview', 'grid_thumb', 'video_preview', 'video_thumb', 'heic_preview',
+])
 const STAFF_PREVIEW_DERIVATIVE_KINDS = new Set([
   'detail_preview', 'grid_thumb', 'heic_preview', 'video_thumb', 'video_preview', 'public_safe',
 ])
@@ -24,21 +26,24 @@ const VALID_DERIVATIVE_KINDS = new Set([
   'public_safe', 'ai_safe',
 ])
 
-/** Assignment-bound creator access. Global reel_creation approval alone is never enough. */
+/** Mirrors SQL mil_creator_can_view_asset: own uploads OR assigned verified/clear reel_creation. */
 async function creatorCanView(userId: string, assetId: string) {
   const { data: asset } = await supabaseAdmin
     .from('mil_assets')
-    .select('id, privacy_status, human_review_status, archived_at, trashed_at')
+    .select('id, privacy_status, human_review_status, archived_at, trashed_at, created_by_user_id')
     .eq('id', assetId)
     .maybeSingle()
-  // Mirror SQL mil_creator_can_view_asset: archived or trashed never authorize new URLs.
-  if (
-    !asset ||
-    asset.archived_at ||
-    asset.trashed_at ||
-    asset.privacy_status !== 'clear' ||
-    asset.human_review_status !== 'verified'
-  ) {
+  // Archived or trashed never authorize new URLs.
+  if (!asset || asset.archived_at || asset.trashed_at) {
+    return false
+  }
+
+  // Contributor self-upload / own created assets — preview before owner verify.
+  if (asset.created_by_user_id === userId) {
+    return true
+  }
+
+  if (asset.privacy_status !== 'clear' || asset.human_review_status !== 'verified') {
     return false
   }
 

--- a/command-center/supabase/functions/media-intel-upload-session/index.ts
+++ b/command-center/supabase/functions/media-intel-upload-session/index.ts
@@ -29,7 +29,18 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.4'
 import { milCorsHeaders, milCorsPreflight } from '../_shared/milCors.ts'
 import { supabaseAdmin } from '../_shared/supabaseAdmin.ts'
-import { isMilOwnerAdmin } from '../_shared/milRoles.ts'
+import { isMilOwnerAdmin, normalizeMilRole } from '../_shared/milRoles.ts'
+
+/** True if the user has a reel_creator (contributor) grant row — not only the resolved primary role. */
+async function hasMilCreatorGrant(userId: string): Promise<boolean> {
+  if (!userId) return false
+  const { data, error } = await supabaseAdmin
+    .from('app_user_roles')
+    .select('role')
+    .eq('user_id', userId)
+  if (error) throw error
+  return (data || []).some((row) => normalizeMilRole(row.role) === 'reel_creator')
+}
 
 function envInt(name: string, fallback: number) {
   const raw = Deno.env.get(name)
@@ -370,6 +381,69 @@ Deno.serve(async (req) => {
         token,
         notice:
           'Keep phone originals until transfer is reconciled and an independent backup is confirmed. This link is upload-only and expires.',
+      })
+    }
+
+    // Contributor self-shot intake: JWT reel_creator mints a self-scoped session.
+    // Owner/admin phone sessions stay on action=create. Staff without a creator
+    // grant cannot use this as a bypass.
+    if (action === 'create_contributor_session') {
+      const auth = await requireUser(req)
+      if ('error' in auth) return json({ error: auth.message }, auth.status)
+      if (!(await hasMilCreatorGrant(auth.user.id))) {
+        return json({ error: 'Only contributors may create a self-upload session' }, 403)
+      }
+
+      const hours = Math.min(Math.max(Number(body.expiresHours) || 12, 1), 72)
+      const token = randomToken()
+      const tokenHash = await sha256Hex(token)
+      const expiresAt = new Date(Date.now() + hours * 3600_000).toISOString()
+
+      const { data: batch, error: batchErr } = await supabaseAdmin
+        .from('mil_upload_batches')
+        .insert({
+          source_label: 'contributor_self',
+          source_phone: null,
+          source_person: body.sourcePerson || 'Contributor self-upload',
+          uploader_user_id: auth.user.id,
+          status: 'open',
+          client_session_key: `contributor-self:${auth.user.id}:${crypto.randomUUID()}`,
+        })
+        .select('*')
+        .single()
+      if (batchErr) throw batchErr
+
+      const { data: session, error: sessErr } = await supabaseAdmin
+        .from('mil_upload_sessions')
+        .insert({
+          batch_id: batch.id,
+          token_hash: tokenHash,
+          label: 'Contributor self-upload',
+          source_phone: null,
+          source_person: body.sourcePerson || 'Contributor self-upload',
+          created_by: auth.user.id,
+          expires_at: expiresAt,
+        })
+        .select('*')
+        .single()
+      if (sessErr) throw sessErr
+
+      await supabaseAdmin.from('mil_audit_events').insert({
+        actor_user_id: auth.user.id,
+        action: 'contributor_upload_session_created',
+        target_type: 'mil_upload_sessions',
+        target_id: session.id,
+        details: { batchId: batch.id, expiresAt, hours, source: 'contributor_self' },
+      })
+
+      return json({
+        sessionId: session.id,
+        batchId: batch.id,
+        expiresAt,
+        path: `/creator`,
+        token,
+        notice:
+          'Keep phone originals until transfer is verified and an independent backup is confirmed. Uploads go to owner Review first.',
       })
     }
 

--- a/command-center/supabase/migrations/20260730180000_media_intel_contributor_self_upload.sql
+++ b/command-center/supabase/migrations/20260730180000_media_intel_contributor_self_upload.sql
@@ -1,0 +1,145 @@
+-- Contributor self-upload: own-upload visibility + auto-assign after finalize.
+-- Batches labeled source_label = 'contributor_self' (minted by create_contributor_session).
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 1. Creators may view their own non-trashed uploads before verify/privacy-clear
+--    (assigned library media still requires verified + clear + reel_creation).
+-- ---------------------------------------------------------------------------
+create or replace function public.mil_creator_can_view_asset(p_asset_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.mil_assets a
+    where a.id = p_asset_id
+      and a.trashed_at is null
+      and a.archived_at is null
+      and (
+        -- Own contributor self-upload (or any asset they created) — pre-verify OK.
+        (
+          a.created_by_user_id = auth.uid()
+          and public.mil_is_creator()
+        )
+        or (
+          a.privacy_status = 'clear'
+          and a.human_review_status = 'verified'
+          and exists (
+            select 1 from public.mil_permitted_uses u
+            where u.asset_id = a.id
+              and u.use_key = 'reel_creation'
+              and u.approved = true
+          )
+          and (
+            exists (
+              select 1 from public.mil_creator_assignments ca
+              where ca.creator_user_id = auth.uid()
+                and ca.status = 'active'
+                and ca.asset_id = a.id
+                and ca.revoked_at is null
+            )
+            or exists (
+              select 1
+              from public.mil_creator_assignments ca
+              join public.mil_collection_items ci on ci.collection_id = ca.collection_id
+              where ca.creator_user_id = auth.uid()
+                and ca.status = 'active'
+                and ca.revoked_at is null
+                and ci.asset_id = a.id
+            )
+          )
+        )
+      )
+  );
+$$;
+
+comment on function public.mil_creator_can_view_asset(uuid) is
+  'Creator may view assigned verified/clear reel_creation assets, or their own non-trashed uploads (contributor self-shot).';
+
+-- ---------------------------------------------------------------------------
+-- 2. After mil_assets insert from contributor_self batch: rights + assignment
+-- ---------------------------------------------------------------------------
+create or replace function public.mil_auto_assign_contributor_self_upload()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_label text;
+  v_uploader uuid;
+begin
+  select b.source_label, b.uploader_user_id
+    into v_label, v_uploader
+  from public.mil_upload_batches b
+  where b.id = new.batch_id;
+
+  if coalesce(v_label, '') <> 'contributor_self' then
+    return new;
+  end if;
+
+  if v_uploader is null then
+    v_uploader := new.created_by_user_id;
+  end if;
+  if v_uploader is null then
+    return new;
+  end if;
+
+  if new.trashed_at is not null or new.archived_at is not null then
+    return new;
+  end if;
+
+  -- Attribute rights for contractor/contributor-supplied media.
+  if new.rights_status is distinct from 'contractor_supplied' then
+    update public.mil_assets
+    set rights_status = 'contractor_supplied'
+    where id = new.id
+      and rights_status is distinct from 'contractor_supplied';
+  end if;
+
+  if not exists (
+    select 1 from public.mil_creator_assignments ca
+    where ca.creator_user_id = v_uploader
+      and ca.asset_id = new.id
+      and ca.status = 'active'
+      and ca.revoked_at is null
+  ) then
+    begin
+      insert into public.mil_creator_assignments (
+        asset_id, collection_id, creator_user_id, assigned_by, status, notes, instructions
+      ) values (
+        new.id, null, v_uploader, v_uploader, 'active',
+        'contributor_self',
+        'Contributor self-upload — awaiting owner review.'
+      );
+    exception
+      when unique_violation then
+        null;
+    end;
+  end if;
+
+  insert into public.mil_audit_events (actor_user_id, action, target_type, target_id, details)
+  values (
+    v_uploader,
+    'contributor_self_upload_assigned',
+    'mil_assets',
+    new.id,
+    jsonb_build_object('creator_user_id', v_uploader, 'batch_id', new.batch_id)
+  );
+
+  return new;
+end;
+$$;
+
+drop trigger if exists mil_assets_contributor_self_upload_trg on public.mil_assets;
+create trigger mil_assets_contributor_self_upload_trg
+  after insert on public.mil_assets
+  for each row
+  execute function public.mil_auto_assign_contributor_self_upload();
+
+commit;

--- a/command-center/tests/unit/media-intel-access.test.mjs
+++ b/command-center/tests/unit/media-intel-access.test.mjs
@@ -129,6 +129,7 @@ describe('MIL upload session + signed access (no tenant)', () => {
     assert.match(fn, /token_hash/);
     assert.match(fn, /sha256Hex/);
     assert.match(fn, /action === 'create'/);
+    assert.match(fn, /action === 'create_contributor_session'/);
     assert.match(fn, /action === 'validate'/);
     assert.match(fn, /action === 'mint_upload'/);
     assert.match(fn, /action === 'revoke'/);

--- a/command-center/tests/unit/media-intel-contributor.test.mjs
+++ b/command-center/tests/unit/media-intel-contributor.test.mjs
@@ -38,6 +38,43 @@ describe('Contributor Workspace source contracts', () => {
     assert.match(src, /asset\.trashed_at/);
   });
 
+  it('contributor self-upload: session mint, visibility migration, UI, no originals', () => {
+    const edge = read('supabase/functions/media-intel-upload-session/index.ts');
+    const sign = read('supabase/functions/media-intel-sign/index.ts');
+    const mig = read('supabase/migrations/20260730180000_media_intel_contributor_self_upload.sql');
+    const workspace = read('src/pages/crm/media/MediaCreatorWorkspace.jsx');
+    const roles = read('src/lib/mediaIntel/roles.js');
+    const uploadMgr = read('src/lib/mediaIntel/uploadManager.js');
+    const api = read('src/lib/mediaIntel/api.js');
+
+    assert.match(edge, /create_contributor_session/);
+    assert.match(edge, /Only contributors may create a self-upload session/);
+    assert.match(edge, /source_label:\s*'contributor_self'/);
+    assert.match(edge, /hasMilCreatorGrant/);
+    assert.match(edge, /action === 'create'/);
+    assert.match(edge, /Only owner\/admin may create upload sessions/);
+
+    assert.match(mig, /mil_creator_can_view_asset/);
+    assert.match(mig, /created_by_user_id = auth\.uid\(\)/);
+    assert.match(mig, /mil_auto_assign_contributor_self_upload/);
+    assert.match(mig, /contributor_self/);
+    assert.match(mig, /contractor_supplied/);
+
+    assert.match(sign, /created_by_user_id/);
+    assert.match(sign, /Creators may never access originals/);
+    assert.match(sign, /allowOriginal === true/);
+
+    assert.match(roles, /canContributorSelfUpload/);
+    assert.match(uploadMgr, /createContributorUploadSession/);
+    assert.match(uploadMgr, /create_contributor_session/);
+    assert.match(api, /createdByUserId/);
+    assert.match(workspace, /contributor-upload-my-shots/);
+    assert.match(workspace, /Upload my shots/);
+    assert.match(workspace, /createContributorUploadSession/);
+    assert.match(workspace, /contributor-my-shots-list/);
+    assert.doesNotMatch(workspace, /allowOriginal:\s*true/);
+  });
+
   it('UI uses Contributor Workspace labels and /contributor alias', () => {
     const app = read('src/App.jsx');
     const portal = read('src/pages/creator/CreatorPortalLayout.jsx');


### PR DESCRIPTION
﻿## Summary
- Contributor self-upload on Creator Workspace (Upload my shots / My shots) with quarantine finalize + Review path
- Staging deploy evidence + owner accept/deny USABLE notes
- Production apply uses this tip (migrations through 20260730180000)

## Test plan
- [x] npm run test:media-intel-helpers (local)
- [x] Staging USABLE for contributor upload path
- [ ] Production smoke: Treezy reel_creator can open /creator and Upload my shots on app.bhfos.com
