### PR TITLE
docs(v2): establish reviewed Command Center foundation

### DIFF
--- a/command-center/docs/v2/V2_CAPABILITY_DISPOSITION_MATRIX.md
+++ b/command-center/docs/v2/V2_CAPABILITY_DISPOSITION_MATRIX.md
@@ -1,0 +1,22 @@
+
+# BHFOS V2 — Capability Disposition Matrix
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Version | 0.1 |
+| Owner | Founder |
+| Last reviewed | 2026-08-01 |
+| Implementation authority | Draft matrix; not yet ratified |
+
+## Purpose
+
+Classify existing and proposed capabilities as `Reuse`, `Redesign`, `Replace`, `Abandon`, `Defer`, or `Investigate` before implementation planning.
+
+## Control state
+
+No capability disposition is approved by this shell. Each entry must cite evidence, product area, affected requirement, data classification, decision IDs, release, and rationale.
+
+## Rule
+
+Disposition is not implementation authorization. An approved disposition still requires a Requirement ID, active Release ID, work item, and Definition of Ready assessment.

--- a/command-center/docs/v2/V2_COMMAND_CENTER_INDEX.md
+++ b/command-center/docs/v2/V2_COMMAND_CENTER_INDEX.md
@@ -3,12 +3,12 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Draft |
+| Status | Active |
 | Version | 0.1 |
 | Owner | Founder |
 | Last reviewed | 2026-08-01 |
 | Source baseline | `c65a923` |
-| Implementation authority | None — governance setup only |
+| Implementation authority | Active governance authority; no implementation authority |
 
 ## Current control state
 
@@ -17,15 +17,15 @@
 | Active phase | Command Center foundation |
 | Active implementation slice | None |
 | Active release | None |
-| Next required action | Reconcile and ratify foundation documents |
-| Decisions awaiting approval | DEC-V2-005 |
+| Next required action | Reconcile Product Definition and planning registers |
+| Decisions awaiting approval | None |
 | Coding authorized | No |
-| Current blocker | Foundation PR review and founder ratification pending |
+| Current blocker | None |
 | Implementation blocker | Product definition and planning registers not yet reconciled |
 
 ## Purpose
 
-This index is the landing page for V2 product governance, requirements, release control, risk management, workflow definition, and evidence. The foundation is conditionally aligned for a draft commit and formal pull-request review; it is not implementation authority.
+This index is the active landing page for V2 product governance, requirements, release control, risk management, workflow definition, and evidence. The governance foundation is ratified; it does not authorize V2 application implementation, production changes, migrations, or an implementation release.
 
 ## Authority hierarchy
 

--- a/command-center/docs/v2/V2_COMMAND_CENTER_INDEX.md
+++ b/command-center/docs/v2/V2_COMMAND_CENTER_INDEX.md
@@ -20,7 +20,8 @@
 | Next required action | Reconcile and ratify foundation documents |
 | Decisions awaiting approval | DEC-V2-005 |
 | Coding authorized | No |
-| Current blocker | Product definition not yet reconciled |
+| Current blocker | Foundation PR review and founder ratification pending |
+| Implementation blocker | Product definition and planning registers not yet reconciled |
 
 ## Purpose
 

--- a/command-center/docs/v2/V2_COMMAND_CENTER_INDEX.md
+++ b/command-center/docs/v2/V2_COMMAND_CENTER_INDEX.md
@@ -1,0 +1,110 @@
+
+# BHFOS V2 — Command Center
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Version | 0.1 |
+| Owner | Founder |
+| Last reviewed | 2026-08-01 |
+| Source baseline | `c65a923` |
+| Implementation authority | None — governance setup only |
+
+## Current control state
+
+| Item | Current state |
+| --- | --- |
+| Active phase | Command Center foundation |
+| Active implementation slice | None |
+| Active release | None |
+| Next required action | Reconcile and ratify foundation documents |
+| Decisions awaiting approval | DEC-V2-005 |
+| Coding authorized | No |
+| Current blocker | Product definition not yet reconciled |
+
+## Purpose
+
+This index is the landing page for V2 product governance, requirements, release control, risk management, workflow definition, and evidence. The foundation is conditionally aligned for a draft commit and formal pull-request review; it is not implementation authority.
+
+## Authority hierarchy
+
+When documents conflict, use this order:
+
+1. Founder-approved decisions in `V2_DECISION_REGISTER.md`.
+2. Ratified product direction in `V2_PRODUCT_DEFINITION.md`.
+3. Authorized release scope in `V2_RELEASE_REGISTER.md`.
+4. Approved requirements in `V2_REQUIREMENTS_REGISTER.md`.
+5. Architecture decisions and implementation plans.
+6. GitHub issues and pull requests.
+7. Conversation history and informal notes.
+
+A lower-level artifact may not silently override a higher-level decision.
+
+## Authority lifecycle
+
+`Conversation or observation` → `Inbox item` → `Discovery` → `Proposed requirement or decision` → `Founder approval` → `Active authority` → `Release assignment` → `Implementation`
+
+## Work authorization check
+
+Before beginning implementation, a human or AI agent must state:
+
+- Requirement ID;
+- active Release ID;
+- applicable Decision IDs;
+- work item or issue ID;
+- branch and worktree;
+- intended validation method.
+
+When the Requirement ID or active Release ID is missing, implementation stops.
+
+When a governing decision is missing or unclear, the item moves to `Needs Decision`.
+
+Only one implementation release may have the status `Active` at a time. The founder is the only person who may move a release into or out of `Active`.
+
+## Source-control policy
+
+- No direct implementation work on `main`.
+- Every implementation uses a dedicated branch or worktree.
+- Every change reaches `main` through a pull request.
+- Unrelated changes may not be mixed.
+- The branch must be current with its approved base.
+- The pull request must link its requirement and release.
+- Generated files, secrets, and customer data may not be committed.
+
+## Scope-change control
+
+After a release is authorized, an added requirement must record its reason, expected value, schedule impact, risk impact, what is removed, delayed, or expanded, and founder approval.
+
+## Controlled documents
+
+| Document | Role |
+| --- | --- |
+| Product Definition | Product direction and boundaries |
+| Decision Register | Binding founder and architecture decisions |
+| Requirements Register | Approved, deferred, rejected, and discovered requirements |
+| Release Register | Release scope, gates, status, and non-goals |
+| Risk Register | Product, data, security, financial, and delivery risks |
+| Workflow Map | Current and target operating workflows |
+| Capability Disposition Matrix | Reuse, redesign, replace, abandon, defer, or investigate decisions |
+| Definition of Ready and Done | Entry, completion, traceability, and exception rules |
+| Data Classification | Sensitivity vocabulary and handling expectations |
+| Weekly Log | Lightweight evidence of ongoing control |
+
+## Weekly review checklist
+
+- Confirm the active phase, implementation slice, and release.
+- Review decisions awaiting approval and unresolved `Needs Decision` items.
+- Confirm scope changes are recorded before work proceeds.
+- Review stale, blocked, and at-risk work.
+- Confirm environment, deployment, and validation evidence is current.
+- Record material decisions, risks, and the next required action in `V2_WEEKLY_LOG.md`.
+
+If the weekly review cannot establish the active release, authorization traceability, environment, or evidence state, stop new implementation work until the gap is recorded and resolved.
+
+## Stop rule
+
+When the next action is unclear, implementation stops. The ambiguity must be converted into a discovery item, proposed decision, requirement clarification, dependency, or recorded blocker.
+
+## Terminology control
+
+Use `capability`, `requirement`, `implementation slice`, or `product area` for controlled work. Use `implementation slice` for work in progress. Avoid the ambiguous term `feature` in governance records.

--- a/command-center/docs/v2/V2_DATA_CLASSIFICATION.md
+++ b/command-center/docs/v2/V2_DATA_CLASSIFICATION.md
@@ -1,0 +1,49 @@
+# BHFOS V2 — Data Classification
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Version | 0.1 |
+| Owner | Founder |
+| Last reviewed | 2026-08-01 |
+| Implementation authority | Policy foundation only |
+
+## Purpose
+
+This policy defines how V2 identifies and handles information based on its sensitivity.
+
+## Classification levels
+
+| Classification | Examples | Basic handling |
+| --- | --- | --- |
+| Public | Published marketing content, public service descriptions | May be publicly shared when approved |
+| Internal | Product plans, non-sensitive procedures, ordinary technical documentation | Limited to authorized business and development use |
+| Confidential | Pricing strategy, contracts, internal financial performance, unpublished product plans | Restricted access; do not place in public repositories or public AI contexts |
+| Restricted | Customer PII, payment information, authentication secrets, precise technician location, sensitive property media | Minimum necessary access, protected storage, controlled logging and retention |
+
+## Important data categories
+
+| Category | Default classification |
+| --- | --- |
+| Customer name, phone, email and address | Restricted |
+| Property access instructions | Restricted |
+| Job-site photos and videos | Restricted unless approved for public use |
+| Technician GPS and route history | Restricted |
+| Estimates, invoices and payment history | Confidential or Restricted |
+| Full payment-card data | Must not be stored by BHFOS |
+| Payment-provider IDs and tokens | Restricted |
+| API keys, passwords and signing secrets | Restricted |
+| Internal source code | Internal or Confidential |
+| Approved marketing media | Public after explicit approval |
+
+## Requirement rule
+
+Every requirement must identify:
+
+- data touched;
+- classification;
+- users or roles with access;
+- storage location;
+- retention or deletion needs;
+- logging restrictions;
+- whether the information may appear in screenshots, fixtures, test records, or AI prompts.

--- a/command-center/docs/v2/V2_DATA_CLASSIFICATION.md
+++ b/command-center/docs/v2/V2_DATA_CLASSIFICATION.md
@@ -2,11 +2,11 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Draft |
+| Status | Active |
 | Version | 0.1 |
 | Owner | Founder |
 | Last reviewed | 2026-08-01 |
-| Implementation authority | Policy foundation only |
+| Implementation authority | Active governance authority; policy only |
 
 ## Purpose
 

--- a/command-center/docs/v2/V2_DECISION_REGISTER.md
+++ b/command-center/docs/v2/V2_DECISION_REGISTER.md
@@ -19,6 +19,46 @@ Decision statuses are `Proposed`, `Active`, `Rejected`, `Superseded`, and `Suspe
 
 Only the founder may approve product scope, release scope, financial-policy changes, production deployment authority, or a departure from the Definition of Ready or Definition of Done. AI agents may recommend or document a decision but cannot approve one.
 
+## DEC-V2-001 — TVG-first product
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed |
+| Date | 2026-08-01 |
+| Decision owner | Founder |
+
+V2 is first an in-house operating system for The Vent Guys. Future franchise compatibility may be preserved where practical, but shared multi-tenant SaaS development is not authorized without a new decision.
+
+## DEC-V2-002 — Existing BHFOS repository remains authoritative
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed |
+| Date | 2026-08-01 |
+| Decision owner | Founder |
+
+V2 continues within the existing `faydog127/BHFOS` repository, isolated through controlled branches and worktrees rather than a disconnected repository.
+
+## DEC-V2-003 — Command Center is the product and build-control authority
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed |
+| Date | 2026-08-01 |
+| Decision owner | Founder |
+
+Documents under `command-center/docs/v2/` are the authoritative V2 product and build-control system. Conversations, screenshots, and demonstrations are inputs, not final authority.
+
+## DEC-V2-004 — Jira and Confluence will not be used initially
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed |
+| Date | 2026-08-01 |
+| Decision owner | Founder |
+
+The initial solo-development process uses the repository-based Command Center, GitHub branches, pull requests, and automated validation instead of Jira or Confluence.
+
 ## DEC-V2-005 — Foundation ratification gate
 
 | Field | Value |
@@ -43,7 +83,7 @@ The V2 foundation becomes active authority only after reconciliation, review, fo
 
 | Field | Value |
 | --- | --- |
-| Status | Active |
+| Status | Proposed |
 | Date | 2026-08-01 |
 | Decision owner | Founder |
 
@@ -53,11 +93,31 @@ Only the founder may approve product-scope changes, release authorization, relea
 
 AI agents, reviewers, and contractors may recommend, analyze, document, or implement authorized work but may not grant themselves authority.
 
+## DEC-V2-006 — One active implementation slice at a time
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed |
+| Date | 2026-08-01 |
+| Decision owner | Founder |
+
+The solo-development process permits no more than one active implementation slice at a time. Newly discovered ideas go to the appropriate intake or register instead of silently entering active work.
+
+## DEC-V2-007 — GitHub remains the code source of truth
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed |
+| Date | 2026-08-01 |
+| Decision owner | Founder |
+
+GitHub is authoritative for committed code history, branches, pull requests, and release SHAs. The local `F:` workspace is an active development environment, not the sole backup.
+
 ## DEC-V2-009 — Environment isolation is mandatory
 
 | Field | Value |
 | --- | --- |
-| Status | Active |
+| Status | Proposed |
 | Date | 2026-08-01 |
 | Decision owner | Founder |
 
@@ -79,7 +139,7 @@ This policy does not prematurely decide the number of Supabase projects, hosting
 
 | Field | Value |
 | --- | --- |
-| Status | Active |
+| Status | Proposed |
 | Date | 2026-08-01 |
 | Decision owner | Founder |
 

--- a/command-center/docs/v2/V2_DECISION_REGISTER.md
+++ b/command-center/docs/v2/V2_DECISION_REGISTER.md
@@ -3,11 +3,11 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Draft |
+| Status | Active |
 | Version | 0.1 |
 | Owner | Founder |
 | Last reviewed | 2026-08-01 |
-| Implementation authority | Governance draft; not yet active |
+| Implementation authority | Active governance authority; no implementation authority |
 
 ## Decision control
 
@@ -23,7 +23,7 @@ Only the founder may approve product scope, release scope, financial-policy chan
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
+| Status | Active |
 | Date | 2026-08-01 |
 | Decision owner | Founder |
 
@@ -33,7 +33,7 @@ V2 is first an in-house operating system for The Vent Guys. Future franchise com
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
+| Status | Active |
 | Date | 2026-08-01 |
 | Decision owner | Founder |
 
@@ -43,7 +43,7 @@ V2 continues within the existing `faydog127/BHFOS` repository, isolated through 
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
+| Status | Active |
 | Date | 2026-08-01 |
 | Decision owner | Founder |
 
@@ -53,7 +53,7 @@ Documents under `command-center/docs/v2/` are the authoritative V2 product and b
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
+| Status | Active |
 | Date | 2026-08-01 |
 | Decision owner | Founder |
 
@@ -63,7 +63,7 @@ The initial solo-development process uses the repository-based Command Center, G
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
+| Status | Active |
 | Date | 2026-08-01 |
 | Decision owner | Founder |
 
@@ -83,7 +83,7 @@ The V2 foundation becomes active authority only after reconciliation, review, fo
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
+| Status | Active |
 | Date | 2026-08-01 |
 | Decision owner | Founder |
 
@@ -97,7 +97,7 @@ AI agents, reviewers, and contractors may recommend, analyze, document, or imple
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
+| Status | Active |
 | Date | 2026-08-01 |
 | Decision owner | Founder |
 
@@ -107,7 +107,7 @@ The solo-development process permits no more than one active implementation slic
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
+| Status | Active |
 | Date | 2026-08-01 |
 | Decision owner | Founder |
 
@@ -117,7 +117,7 @@ GitHub is authoritative for committed code history, branches, pull requests, and
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
+| Status | Active |
 | Date | 2026-08-01 |
 | Decision owner | Founder |
 
@@ -139,7 +139,7 @@ This policy does not prematurely decide the number of Supabase projects, hosting
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
+| Status | Active |
 | Date | 2026-08-01 |
 | Decision owner | Founder |
 

--- a/command-center/docs/v2/V2_DECISION_REGISTER.md
+++ b/command-center/docs/v2/V2_DECISION_REGISTER.md
@@ -1,0 +1,95 @@
+
+# BHFOS V2 — Decision Register
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Version | 0.1 |
+| Owner | Founder |
+| Last reviewed | 2026-08-01 |
+| Implementation authority | Governance draft; not yet active |
+
+## Decision control
+
+A decision remains binding until a superseding decision is marked `Active`. A proposed or reopened replacement does not suspend the current active decision unless the founder explicitly records a temporary suspension.
+
+Decision statuses are `Proposed`, `Active`, `Rejected`, `Superseded`, and `Suspended`. The founder records approval, rejection, suspension, and supersession.
+
+## Authority rule
+
+Only the founder may approve product scope, release scope, financial-policy changes, production deployment authority, or a departure from the Definition of Ready or Definition of Done. AI agents may recommend or document a decision but cannot approve one.
+
+## DEC-V2-005 — Foundation ratification gate
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed |
+| Date | 2026-08-01 |
+| Decision owner | Founder |
+
+### Decision
+
+The V2 foundation becomes active authority only after reconciliation, review, founder approval, and formal pull-request review are recorded. Until then it authorizes documentation work only.
+
+### Gate sequence
+
+1. Reconciled documents are committed on the V2 branch.
+2. Draft pull request is opened.
+3. Pull request is reviewed against the alignment report.
+4. Founder approval is recorded.
+5. Applicable documents are changed from `Draft` to `Active` and merged.
+
+## DEC-V2-008 — Founder retains approval authority
+
+| Field | Value |
+| --- | --- |
+| Status | Active |
+| Date | 2026-08-01 |
+| Decision owner | Founder |
+
+### Decision
+
+Only the founder may approve product-scope changes, release authorization, release-scope changes, financial-policy changes, production deployment authority, emergency production exceptions, or departures from the Definition of Ready or Definition of Done.
+
+AI agents, reviewers, and contractors may recommend, analyze, document, or implement authorized work but may not grant themselves authority.
+
+## DEC-V2-009 — Environment isolation is mandatory
+
+| Field | Value |
+| --- | --- |
+| Status | Active |
+| Date | 2026-08-01 |
+| Decision owner | Founder |
+
+### Decision
+
+Development, testing, staging, and production must use clearly identified and controlled environments. Synthetic, test, training, or staging activity may not contaminate production customer communications, payment systems, accounting systems, reporting, or customer records. Production credentials may not be used as ordinary development credentials.
+
+### Consequences
+
+- Environment ownership must be defined during architecture.
+- Deployment targets must be explicit.
+- Test data must be identifiable.
+- Production mutation requires specific authority.
+- Validation evidence must identify the environment and exact version tested.
+
+This policy does not prematurely decide the number of Supabase projects, hosting targets, or deployment architecture.
+
+## DEC-V2-010 — Franchise capability is deferred
+
+| Field | Value |
+| --- | --- |
+| Status | Active |
+| Date | 2026-08-01 |
+| Decision owner | Founder |
+
+### Decision
+
+V2 will not build multi-tenant, franchise-management, or cross-company data-isolation capabilities during the current TVG-first program. Architecture should avoid unnecessary barriers to future expansion, but franchise compatibility is not an active requirement and may not add present implementation complexity without a new founder decision.
+
+### Consequences
+
+- The TVG deployment remains dedicated.
+- No speculative tenant abstraction is required.
+- No capability may claim franchise support without separate authorization.
+- Material architecture decisions may record future expansion consequences without implementing them.

--- a/command-center/docs/v2/V2_DEFINITION_OF_READY_AND_DONE.md
+++ b/command-center/docs/v2/V2_DEFINITION_OF_READY_AND_DONE.md
@@ -3,11 +3,11 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Draft |
+| Status | Active |
 | Version | 0.1 |
 | Owner | Founder |
 | Last reviewed | 2026-08-01 |
-| Implementation authority | Governance draft; not yet active |
+| Implementation authority | Active governance authority; no implementation authority |
 
 ## Work classes
 

--- a/command-center/docs/v2/V2_DEFINITION_OF_READY_AND_DONE.md
+++ b/command-center/docs/v2/V2_DEFINITION_OF_READY_AND_DONE.md
@@ -1,0 +1,98 @@
+
+# BHFOS V2 — Definition of Ready and Done
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Version | 0.1 |
+| Owner | Founder |
+| Last reviewed | 2026-08-01 |
+| Implementation authority | Governance draft; not yet active |
+
+## Work classes
+
+| Work class | Typical completion path |
+| --- | --- |
+| Documentation | Draft → Review → Approved → Done |
+| Research | Discovery → Review → Finding recorded → Done |
+| Decision | Proposed → Founder review → Active or Rejected |
+| Prototype | Ready → In Progress → Review → Learning validated → Done |
+| Application code | Ready → In Progress → Review → Testing → Accepted in Staging |
+| Production change | Accepted in Staging → Ready to Release → Released → Production Verified → Done |
+
+Not every work class uses every project status.
+
+## Implementation slice
+
+An implementation slice is the smallest independently reviewable and testable change that produces one observable outcome.
+
+## Definition of Ready
+
+An implementation slice is Ready only when:
+
+- [ ] Requirement ID is approved or explicitly authorized for discovery.
+- [ ] Active Release ID is identified.
+- [ ] Applicable Decision IDs are identified; missing or unclear governing decisions move the item to `Needs Decision`.
+- [ ] Work item or issue ID is recorded.
+- [ ] Branch and worktree are identified.
+- [ ] Observable outcome and acceptance criteria are stated.
+- [ ] Validation method and evidence location are stated.
+- [ ] Data touched by the requirement is identified.
+- [ ] Data classification is recorded.
+- [ ] Access, retention, logging, and deletion expectations are identified where applicable.
+- [ ] Restricted data is excluded from source control, logs, fixtures, screenshots, and AI prompts unless explicitly authorized and protected.
+- [ ] Development, testing, staging, and production behavior is identified.
+- [ ] Test or synthetic activity cannot write to production customer or financial records.
+- [ ] Environment credentials and deployment targets are separated.
+- [ ] Rollback or recovery expectations are understood where state can change.
+
+## Required implementation traceability
+
+Every implementation slice must trace through:
+
+`Requirement ID` → `Active Release ID` → `Work item or issue` → `Branch and worktree` → `Pull request` → `Tests` → `Validation evidence` → `Deployed SHA, when production is affected`
+
+## Definition of Done
+
+An implementation slice is Done only when its acceptance criteria are met, review is complete, required tests pass, validation evidence is recorded, documentation is updated, and any release or production verification is complete. A draft document is not Done merely because it exists.
+
+## Completion classes
+
+| Work class | Completion requirement |
+| --- | --- |
+| Documentation | Reviewed, approved, and committed |
+| Research | Question answered, evidence recorded, and decision created if needed |
+| Prototype | Learning objective completed; prototype is explicitly not production authority |
+| Application code | Tests, review, and staging acceptance completed |
+| Production change | Deployment and production verification completed |
+
+`Done` means all completion requirements applicable to that work class are satisfied. No item may be marked `Done` directly from `In Progress`.
+
+## Source-control and release evidence
+
+No implementation slice may reach `In Progress` without a Requirement ID and active Release ID. Nothing may reach `Released` without a pull request, exact SHA, and validation evidence. Unrelated changes, generated files, secrets, and customer data must remain out of the commit.
+
+# Emergency production exception
+
+Only the founder may declare an emergency production exception.
+
+An AI agent, reviewer, contractor, or automated process may recommend an emergency declaration but may not invoke one.
+
+An exception is limited to:
+
+- active security exposure;
+- financial-integrity failure;
+- material data-loss risk;
+- production availability failure;
+- an operational failure preventing essential business activity.
+
+The repair must:
+
+- be recorded as an incident;
+- contain the smallest safe change;
+- identify rollback steps;
+- avoid unrelated improvements;
+- receive post-implementation review;
+- complete any bypassed documentation and testing immediately afterward.
+
+This exception does not authorize normal product development.

--- a/command-center/docs/v2/V2_PRODUCT_DEFINITION.md
+++ b/command-center/docs/v2/V2_PRODUCT_DEFINITION.md
@@ -1,0 +1,23 @@
+
+# BHFOS V2 — Product Definition
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Version | 0.1 |
+| Owner | Founder |
+| Last reviewed | 2026-08-01 |
+| Source baseline | `c65a923` |
+| Implementation authority | Draft product direction; not yet ratified |
+
+## Purpose
+
+Define the reconciled product direction, users, operating boundaries, and success criteria for the TVG-first V2 program.
+
+## Current position
+
+This document is a controlled draft. Product direction, scope, and release authorization require founder approval under DEC-V2-008 and the foundation ratification gate in DEC-V2-005.
+
+## Scope status
+
+The active product scope is not yet ratified. Requirements and implementation slices must not be inferred from this placeholder beyond the active decisions recorded in the Decision Register.

--- a/command-center/docs/v2/V2_RELEASE_REGISTER.md
+++ b/command-center/docs/v2/V2_RELEASE_REGISTER.md
@@ -1,0 +1,22 @@
+
+# BHFOS V2 — Release Register
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Version | 0.1 |
+| Owner | Founder |
+| Last reviewed | 2026-08-01 |
+| Implementation authority | Draft register; not yet ratified |
+
+## Purpose
+
+Define release objectives, scope, non-goals, status, gates, and evidence. A release is a controlled container for implementation slices, not a substitute for requirement approval.
+
+## Control rule
+
+Exactly one implementation release may be `Active` at a time. The founder alone may move a release into or out of `Active`. There is currently no active implementation release.
+
+## Required release fields
+
+Release entries must identify objectives, included and excluded requirements, non-goals, dependencies, environment, validation gates, rollback expectations, owner, and release evidence.

--- a/command-center/docs/v2/V2_REQUIREMENTS_REGISTER.md
+++ b/command-center/docs/v2/V2_REQUIREMENTS_REGISTER.md
@@ -1,0 +1,22 @@
+
+# BHFOS V2 — Requirements Register
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Version | 0.1 |
+| Owner | Founder |
+| Last reviewed | 2026-08-01 |
+| Implementation authority | Draft register; not yet ratified |
+
+## Purpose
+
+Record approved, deferred, rejected, and discovered requirements with traceability to releases, decisions, data classification, work items, and validation evidence.
+
+## Register status
+
+No V2 requirement is authorized for implementation until it has a Requirement ID, an active Release ID, applicable Decision IDs, acceptance criteria, and a recorded Definition of Ready assessment.
+
+## Required fields
+
+Each requirement entry must include: ID, statement, product area, status, source, owner, data touched and classification, applicable decisions, release, acceptance criteria, validation evidence, and disposition history.

--- a/command-center/docs/v2/V2_RISK_REGISTER.md
+++ b/command-center/docs/v2/V2_RISK_REGISTER.md
@@ -1,0 +1,25 @@
+
+# BHFOS V2 — Risk Register
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Version | 0.1 |
+| Owner | Founder |
+| Last reviewed | 2026-08-01 |
+| Implementation authority | Draft register; not yet ratified |
+
+## Purpose
+
+Track product, data, security, financial, operational, delivery, and AI-agent risks with owners, mitigations, evidence, and escalation state.
+
+## Initial control risks
+
+| Risk | Current response |
+| --- | --- |
+| Product definition is not ratified | Stop implementation; complete foundation gate |
+| Environment isolation is unclear | DEC-V2-009 establishes mandatory isolation policy |
+| Restricted data enters source control, logs, or AI prompts | Apply V2 Data Classification before implementation |
+| Scope expands without release control | Require active Release ID and founder approval |
+
+Detailed risk entries require an ID, owner, likelihood, impact, mitigation, trigger, status, and evidence location.

--- a/command-center/docs/v2/V2_WEEKLY_LOG.md
+++ b/command-center/docs/v2/V2_WEEKLY_LOG.md
@@ -5,6 +5,7 @@
 | Status | Active |
 | Owner | Founder |
 | Started | 2026-08-01 |
+| Implementation authority | Active governance authority; control evidence only |
 
 ## Entry template
 

--- a/command-center/docs/v2/V2_WEEKLY_LOG.md
+++ b/command-center/docs/v2/V2_WEEKLY_LOG.md
@@ -1,0 +1,29 @@
+# BHFOS V2 — Weekly Control Log
+
+| Field | Value |
+| --- | --- |
+| Status | Active |
+| Owner | Founder |
+| Started | 2026-08-01 |
+
+## Entry template
+
+### Week of YYYY-MM-DD
+
+**Current objective:**
+**Active release:**
+**Active implementation slice:**
+
+#### Completed
+
+#### Decisions made
+
+#### Scope changes
+
+#### Blocked or stale work
+
+#### Environment and deployment state
+
+#### Risks requiring attention
+
+#### Next required action

--- a/command-center/docs/v2/V2_WORKFLOW_MAP.md
+++ b/command-center/docs/v2/V2_WORKFLOW_MAP.md
@@ -1,0 +1,22 @@
+
+# BHFOS V2 — Workflow Map
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Version | 0.1 |
+| Owner | Founder |
+| Last reviewed | 2026-08-01 |
+| Implementation authority | Draft map; not yet ratified |
+
+## Purpose
+
+Map current-state and target-state operating workflows so requirements describe observable business outcomes rather than isolated screens or code tasks.
+
+## Control state
+
+The current-state and target-state workflows have not yet been reconciled into an approved V2 operating model. Research and documentation may proceed; application implementation waits for an approved requirement and active release.
+
+## Required workflow fields
+
+Each workflow should identify actors, trigger, inputs, decisions, system of record, outputs, exceptions, data classification, controls, and validation evidence.

--- a/command-center/docs/v2/reviews/V2_FOUNDATION_ALIGNMENT_REPORT.md
+++ b/command-center/docs/v2/reviews/V2_FOUNDATION_ALIGNMENT_REPORT.md
@@ -36,10 +36,14 @@
 
 The three review rounds are critique passes using separate professional lenses, not three human reviewers. Approval remains conditional until all required changes are applied and rechecked.
 
-## Final draft status
+## Final authority status
 
-**ALIGNED FOR DRAFT COMMIT AND FORMAL PULL-REQUEST REVIEW**
+**RATIFIED GOVERNANCE FOUNDATION**
 
-**NOT RATIFIED AND NOT IMPLEMENTATION AUTHORITY**
+**ACTIVE GOVERNANCE AUTHORITY; NOT IMPLEMENTATION AUTHORITY**
 
-This report records reviewed draft alignment. It does not authorize V2 application implementation.
+This report records the reviewed foundation and its ratification. It does not authorize V2 application implementation, production changes, migrations, or an implementation release.
+
+## Ratification outcome
+
+Founder ratification was recorded for PR #129 at commit `a5491a6` on 2026-08-01. The authorized governance documents and DEC-V2-001 through DEC-V2-010 are now Active. This ratification does not authorize V2 application implementation, production changes, migrations, or an implementation release.

--- a/command-center/docs/v2/reviews/V2_FOUNDATION_ALIGNMENT_REPORT.md
+++ b/command-center/docs/v2/reviews/V2_FOUNDATION_ALIGNMENT_REPORT.md
@@ -7,8 +7,8 @@
 | Owner | Founder |
 | Last reviewed | 2026-08-01 |
 | Review lenses | Product and governance; engineering and software process; solo-founder usability; security, data, financial risk, and AI-agent adoption |
-| Documents reviewed | Index, Definition of Ready and Done, Decision Register |
-| Baseline | Uncommitted V2 Command Center foundation |
+| Documents reviewed | Command Center Index; Definition of Ready and Done; Decision Register; Data Classification; Weekly Log; six controlled document shells |
+| Baseline | PR #129 at `0baffcb` |
 | Verdict | CONDITIONALLY ALIGNED — FOUNDATION CHANGES REQUIRED BEFORE RATIFICATION |
 
 ## Review lenses
@@ -18,12 +18,21 @@
 3. **Solo-founder usability.** The index is the landing page, the weekly log is intentionally lightweight, and stop rules make unresolved control gaps visible without requiring a large process overhead.
 4. **Security, data, financial risk, and AI-agent adoption.** Data classification, restricted-data handling, environment isolation, emergency limits, and AI-agent authority boundaries are recorded. Automated enforcement is deferred.
 
-## Required before ratification
+## Required before foundation ratification
 
-- Reconcile the product definition and remaining registers.
-- Complete formal review of this draft pull request.
+- Complete formal review of PR #129.
+- Resolve all review findings.
+- Wait for required CI checks to pass.
 - Record founder approval.
-- Change applicable documents from `Draft` to `Active` only after the gate is complete.
+- Change approved governance documents and decisions from `Draft` or `Proposed` to `Active`.
+- Merge the governance foundation.
+
+## Required before implementation authorization
+
+- Reconcile and ratify the Product Definition.
+- Complete the required workflow and capability-disposition work.
+- Approve requirements and architecture boundaries.
+- Authorize the first implementation release.
 
 The three review rounds are critique passes using separate professional lenses, not three human reviewers. Approval remains conditional until all required changes are applied and rechecked.
 

--- a/command-center/docs/v2/reviews/V2_FOUNDATION_ALIGNMENT_REPORT.md
+++ b/command-center/docs/v2/reviews/V2_FOUNDATION_ALIGNMENT_REPORT.md
@@ -1,0 +1,36 @@
+# BHFOS V2 — Foundation Alignment Report
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Version | 0.1 |
+| Owner | Founder |
+| Last reviewed | 2026-08-01 |
+| Review lenses | Product and governance; engineering and software process; solo-founder usability; security, data, financial risk, and AI-agent adoption |
+| Documents reviewed | Index, Definition of Ready and Done, Decision Register |
+| Baseline | Uncommitted V2 Command Center foundation |
+| Verdict | CONDITIONALLY ALIGNED — FOUNDATION CHANGES REQUIRED BEFORE RATIFICATION |
+
+## Review lenses
+
+1. **Product and governance.** Authority, product scope, release control, founder approval, decision lifecycle, and terminology are explicit but remain draft until the ratification gate completes.
+2. **Engineering and software process.** Work classes, implementation-slice traceability, readiness, completion, environment separation, and evidence expectations are recorded.
+3. **Solo-founder usability.** The index is the landing page, the weekly log is intentionally lightweight, and stop rules make unresolved control gaps visible without requiring a large process overhead.
+4. **Security, data, financial risk, and AI-agent adoption.** Data classification, restricted-data handling, environment isolation, emergency limits, and AI-agent authority boundaries are recorded. Automated enforcement is deferred.
+
+## Required before ratification
+
+- Reconcile the product definition and remaining registers.
+- Complete formal review of this draft pull request.
+- Record founder approval.
+- Change applicable documents from `Draft` to `Active` only after the gate is complete.
+
+The three review rounds are critique passes using separate professional lenses, not three human reviewers. Approval remains conditional until all required changes are applied and rechecked.
+
+## Final draft status
+
+**ALIGNED FOR DRAFT COMMIT AND FORMAL PULL-REQUEST REVIEW**
+
+**NOT RATIFIED AND NOT IMPLEMENTATION AUTHORITY**
+
+This report records reviewed draft alignment. It does not authorize V2 application implementation.

--- a/command-center/docs/v2/reviews/V2_FOUNDATION_EXTERNAL_REVIEW_CLAUDE.md
+++ b/command-center/docs/v2/reviews/V2_FOUNDATION_EXTERNAL_REVIEW_CLAUDE.md
@@ -1,0 +1,21 @@
+# V2 Foundation External Review — Claude
+
+| Field | Value |
+| --- | --- |
+| Status | Recorded |
+| Review date | 2026-08-01 |
+| Reviewer type | External AI-assisted review |
+| Reviewer | Claude |
+| Independence | Separate model and review context |
+
+## Review summary
+
+The review identified gaps in data classification, founder-only emergency declaration, environment isolation, franchise compatibility, terminology, decision supersession, work classes and statuses, AI-agent authority citation, one-active-release control, metadata shells, and weekly evidence logging.
+
+## Reconciliation
+
+The findings were accepted as foundation changes where they affect authority and safety. A hard numeric limit on unresolved decisions was not adopted; it is handled as a weekly control. Requiring every implementation slice to cite a unique Decision ID was not adopted literally: every slice must cite a Requirement ID and active Release ID, plus any governing Decision IDs; if a required decision is missing, work stops.
+
+## Disposition
+
+The review is preserved as an external review record, not a human peer review. Full automated enforcement is deferred to a later Command Center capability.

--- a/command-center/docs/v2/reviews/V2_FOUNDATION_ROUND1_PRODUCT_GOVERNANCE.md
+++ b/command-center/docs/v2/reviews/V2_FOUNDATION_ROUND1_PRODUCT_GOVERNANCE.md
@@ -1,0 +1,46 @@
+# V2 Foundation Review — Round 1: Product and Governance
+
+| Field | Value |
+| --- | --- |
+| Status | Recorded |
+| Review date | 2026-08-01 |
+| Review lens | Product and governance |
+| Reviewer type | Foundation review record |
+| Review round | 1 |
+| Documents reviewed | Index, Definition of Ready and Done, Decision Register |
+| Baseline | Uncommitted V2 Command Center foundation |
+| Verdict | PASS WITH REQUIRED CHANGES |
+
+## Scope
+
+Review the authority model, product-definition boundary, release control, decision lifecycle, terminology, and founder approval responsibilities.
+
+## Outcome
+
+Conditionally aligned. The foundation requires explicit data classification, founder-only approval and emergency authority, one-active-release control, decision supersession rules, and implementation-slice terminology before ratification.
+
+## Strengths
+
+- Establishes a durable authority hierarchy.
+- Separates draft documentation from implementation authority.
+- Makes founder approval explicit.
+
+## Findings
+
+The first draft needed a conversation-to-authority lifecycle and clearer release and scope-change controls.
+
+## Required changes
+
+Add those lifecycle, source-control, and scope-change rules before the foundation draft is reviewed for commitment.
+
+## Residual concerns
+
+Product scope and release objectives remain unratified.
+
+## Final verdict
+
+PASS WITH REQUIRED CHANGES; corrections applied for reconciliation.
+
+## Required disposition
+
+Incorporated into the V2 control documents. Product implementation remains unauthorized until DEC-V2-005 completes its gate sequence.

--- a/command-center/docs/v2/reviews/V2_FOUNDATION_ROUND2_ENGINEERING_PROCESS.md
+++ b/command-center/docs/v2/reviews/V2_FOUNDATION_ROUND2_ENGINEERING_PROCESS.md
@@ -1,0 +1,46 @@
+# V2 Foundation Review — Round 2: Engineering Process
+
+| Field | Value |
+| --- | --- |
+| Status | Recorded |
+| Review date | 2026-08-01 |
+| Review lens | Engineering and software process |
+| Reviewer type | Foundation review record |
+| Review round | 2 |
+| Documents reviewed | Index, Definition of Ready and Done, Decision Register |
+| Baseline | Uncommitted V2 Command Center foundation |
+| Verdict | CHANGES REQUIRED |
+
+## Scope
+
+Review traceability, work classes, Definition of Ready and Done, environment separation, validation evidence, rollback expectations, and release gates.
+
+## Outcome
+
+Conditionally aligned. Every implementation slice must trace from Requirement ID through active Release ID, work item, branch/worktree, pull request, tests, evidence, and deployed SHA when production is affected.
+
+## Strengths
+
+- Defines implementation slices and traceability.
+- Separates emergency repair from normal product development.
+- Includes data and environment readiness.
+
+## Findings
+
+The draft needed completion classes, explicit source-control policy, and release-scope change control.
+
+## Required changes
+
+Add those controls and require exact SHA and validation evidence before `Released`.
+
+## Residual concerns
+
+Automated enforcement is not yet implemented and remains deferred.
+
+## Final verdict
+
+CHANGES REQUIRED; corrections applied for reconciliation.
+
+## Required disposition
+
+Incorporated into `V2_DEFINITION_OF_READY_AND_DONE.md` and `DEC-V2-009`. Automated enforcement is deferred to a later Command Center capability.

--- a/command-center/docs/v2/reviews/V2_FOUNDATION_ROUND3_SOLO_FOUNDER_USABILITY.md
+++ b/command-center/docs/v2/reviews/V2_FOUNDATION_ROUND3_SOLO_FOUNDER_USABILITY.md
@@ -1,0 +1,46 @@
+# V2 Foundation Review — Round 3: Solo-Founder Usability
+
+| Field | Value |
+| --- | --- |
+| Status | Recorded |
+| Review date | 2026-08-01 |
+| Review lens | Solo-founder usability |
+| Reviewer type | Foundation review record |
+| Review round | 3 |
+| Documents reviewed | Index, Definition of Ready and Done, Decision Register |
+| Baseline | Uncommitted V2 Command Center foundation |
+| Verdict | PASS WITH SIMPLIFICATION |
+
+## Scope
+
+Review whether the control system is understandable and maintainable by one founder working with AI assistance.
+
+## Outcome
+
+Conditionally aligned. The index provides a single landing page, the weekly log uses a lightweight entry template, and authorization checks are explicit. The system must avoid duplicate sources of truth and keep unresolved work visible.
+
+## Strengths
+
+- Current control state is visible near the top of the index.
+- Weekly evidence is lightweight.
+- The stop rule prevents AI-assisted work from guessing the next action.
+
+## Findings
+
+The operating checklist and register ownership needed to be explicit enough for daily solo use.
+
+## Required changes
+
+Keep the index as navigation and current state; keep decisions, requirements, releases, risks, and PR evidence in their canonical records.
+
+## Residual concerns
+
+The foundation will require a short weekly review to remain useful without becoming process overhead.
+
+## Final verdict
+
+PASS WITH SIMPLIFICATION; corrections applied for reconciliation.
+
+## Required disposition
+
+Use the weekly checklist and stop rule in the Command Center Index. Keep detailed retention schedules and automated enforcement deferred until they are justified by an approved requirement.


### PR DESCRIPTION
## Summary

- Establishes the repository-based BHFOS V2 Product & Build Command Center.
- Defines authority, readiness, completion, traceability, scope-change, emergency-fix, data-classification, and weekly-control rules.
- Records three internal critique rounds and one independent external AI-assisted review.
- Establishes founder-only approval authority and mandatory environment isolation.

## Current authority

The BHFOS V2 Command Center governance foundation was ratified by the founder at commit `37afccd`.

This pull request:

- establishes active governance authority;
- remains documentation and governance only;
- does not authorize V2 application implementation;
- does not authorize production changes, migrations, or an implementation release.

## Validation

- [x] 16 expected foundation files present
- [x] Governing-document metadata present
- [x] Founder approval authority recorded
- [x] Environment-isolation policy recorded
- [x] Franchise capability explicitly deferred
- [x] DEC-V2-001 through DEC-V2-010 active
- [x] Authorized governance documents active
- [x] Product and planning registers remain draft
- [x] No controlled terminology drift found
- [x] No application code changed
- [x] No migrations changed
- [x] Founder ratification recorded at `37afccd`

## Merge gates

- [x] Complete PR diff reviewed
- [x] Review findings resolved
- [x] Founder ratification recorded
- [x] Applicable governance statuses activated
- [ ] Final CI at `37afccd` passed
- [ ] Mark PR ready for review
- [ ] Merge into `main`